### PR TITLE
Dev

### DIFF
--- a/FortBackend/Resources/Config.json
+++ b/FortBackend/Resources/Config.json
@@ -26,5 +26,5 @@
   "HTTPS": false,
   "AdminEmail": "Admin@gmail.com",
   "AdminPassword": "AdminPassword123",
-  "EnableLogs": false
+  "LogLevel": 0
 }

--- a/FortBackend/Resources/GameConfig.json
+++ b/FortBackend/Resources/GameConfig.json
@@ -5,5 +5,6 @@
   "Season": 0,
   "WeeklyQuest": 1,
   "MfaClaim": true,
-  "ShopRotation": true
+  "ShopRotation": true,
+  "SeasonalShopRotation": true
 }

--- a/FortBackend/Resources/Json/Season/Season12/SeasonSpecial.json
+++ b/FortBackend/Resources/Json/Season/Season12/SeasonSpecial.json
@@ -1,0 +1,4 @@
+﻿[
+  "PlayerTech:PTID_SpyTeam_01",
+  "PlayerTech:PTID_SpyTeam_02"
+]

--- a/FortBackend/Resources/Json/Season/Season19/BP_Items.json
+++ b/FortBackend/Resources/Json/Season/Season19/BP_Items.json
@@ -1,0 +1,1788 @@
+[
+  {
+    "bRequireBp": false,
+    "OfferId": "9CC86E4644EC0926E8671889EB4A1B61",
+    "templateId": "AthenaSkyDiveContrail:trails_id_130_exosuit",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "2E4B9D3E411F2CA6F7F7E8BAAD9348FF",
+    "templateId": "AthenaBackpack:BID_915_ExoSuitFemale",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "0A1304E4407F355DD8E4859563AB92B4",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "C8661B5147016C2D9905D9911589975C",
+    "templateId": "CosmeticVariantToken:vtid_a_364_buffllama_colorb",
+    "Price": 25,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_288_Athena_Commando_M_BuffLlama",
+        "channel": "Material",
+        "added": [
+          "Mat2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_665_BuffLlamaMale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_848_BuffLlama",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "EAA7870D4ECD8DEB6DDB92A9E5472A7D",
+    "templateId": "HomebaseBannerIcon:brs19_parallel",
+    "Price": 10,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "8EF0946F4194DBB34DAA10A8BB482B61",
+    "templateId": "CosmeticVariantToken:vtid_a_362_lonewolf_colorc",
+    "Price": 30,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Material",
+        "added": [
+          "Mat3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_911_LoneWolfMale",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_715_LoneWolfMale",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_330_LoneWolfMale",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "08EA19EF4E2DEEA5C81765A4BC1817D3",
+    "templateId": "AthenaItemWrap:wrap_423_motorcyclist",
+    "Price": 15,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "B803AF59482FBEDA39EF1B99369BC814",
+    "templateId": "CosmeticVariantToken:vtid_a_368_motorcyclist_colorb",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "ClothingColor",
+        "added": [
+          "Mat4"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_913_MotorcyclistFemale",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_913_MotorcyclistFemale",
+        "channel": "Emissive",
+        "added": [
+          "Emissive3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_716_MotorcyclistFemale",
+        "channel": "Material",
+        "added": [
+          "Mat2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_716_MotorcyclistFemale",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_331_MotorcyclistFemale",
+        "channel": "Material",
+        "added": [
+          "Mat2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_331_MotorcyclistFemale",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "4D6851DE4CA806629378D19DB2AE436F",
+    "templateId": "CosmeticVariantToken:vtid_a_378_exosuit_styleb",
+    "Price": 15,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_292_Athena_Commando_F_ExoSuit",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "8DBA118B43BB459870B6B79EB8FDA110",
+    "templateId": "CosmeticVariantToken:vtid_a_367_gumball_colorc",
+    "Price": 25,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_289_Athena_Commando_M_Gumball",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_912_GumballMale",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_713_GumballMale",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_329_GumballMale",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "E1E695AD45EF4763E1AF23A7558B3883",
+    "templateId": "CosmeticVariantToken:vtid_a_385_parallelcomic_stylec",
+    "Price": 30,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_293_Athena_Commando_M_ParallelComic",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_916_ParallelComicMale",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "0197AF634360EE4CCF7DFAB6B491DFDB",
+    "templateId": "CosmeticVariantToken:vtid_a_376_islandnomad_colorb",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_291_Athena_Commando_F_IslandNomad",
+        "channel": "Material",
+        "added": [
+          "Mat2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_714_IslandNomadFemale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_914_IslandNomadFemale",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "864A43D94612F2E8A8C55CA420235E9A",
+    "templateId": "CosmeticVariantToken:vtid_a_369_motorcyclist_styleb",
+    "Price": 10,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Particle",
+        "added": [
+          "Particle4"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_913_MotorcyclistFemale",
+        "channel": "Emissive",
+        "added": [
+          "Emissive4"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_716_MotorcyclistFemale",
+        "channel": "Particle",
+        "added": [
+          "Particle4"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_331_MotorcyclistFemale",
+        "channel": "Particle",
+        "added": [
+          "Particle4"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "6F1D037A4C27BA30FEF184848F19B590",
+    "templateId": "AthenaPickaxe:Pickaxe_ID_715_LoneWolfMale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F6FC91854069B4C346AAB0977DE9EB28",
+    "templateId": "CosmeticVariantToken:vtid_a_438_lonewolf_superlevelt1",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Material",
+        "added": [
+          "Mat4"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "3F66C13A4CED5F6956A39A89C04DDA85",
+    "templateId": "CosmeticVariantToken:vtid_a_432_parallelcomic_superlevelt1",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_293_Athena_Commando_M_ParallelComic",
+        "channel": "Progressive",
+        "added": [
+          "Stage4"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "6D72B9DD4673AFD1438F27AB731481F0",
+    "templateId": "CosmeticVariantToken:vtid_a_426_buffllama_superlevelt1",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_288_Athena_Commando_M_BuffLlama",
+        "channel": "Material",
+        "added": [
+          "Mat4"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "0D96CB8A4A0374063D1BFF8F47718256",
+    "templateId": "CosmeticVariantToken:vtid_a_435_motorcyclist_superlevelt1",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "ClothingColor",
+        "added": [
+          "Mat5"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "623289C14BF47F81DCDF00B2EC6E179B",
+    "templateId": "CosmeticVariantToken:vtid_a_429_exosuit_superlevelt1",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_292_Athena_Commando_F_ExoSuit",
+        "channel": "ClothingColor",
+        "added": [
+          "Color.001"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "237C2D8A43BB74D00C0D5AA9011ADE5D",
+    "templateId": "CosmeticVariantToken:vtid_a_433_parallelcomic_superlevelt2",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_293_Athena_Commando_M_ParallelComic",
+        "channel": "Progressive",
+        "added": [
+          "Stage5"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "B2DCC1D34EDCC42B1D2D13869CE5F687",
+    "templateId": "CosmeticVariantToken:vtid_a_436_motorcyclist_superlevelt2",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "ClothingColor",
+        "added": [
+          "Mat6"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "D3B596ED459EAA81B71EB2959F950E4B",
+    "templateId": "CosmeticVariantToken:vtid_a_430_exosuit_superlevelt2",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_292_Athena_Commando_F_ExoSuit",
+        "channel": "ClothingColor",
+        "added": [
+          "Color.002"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "57C1C46047BD2B9D81DE8E8A29FDF0C8",
+    "templateId": "CosmeticVariantToken:vtid_a_427_buffllama_superlevelt2",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_288_Athena_Commando_M_BuffLlama",
+        "channel": "Material",
+        "added": [
+          "Mat5"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "13C2FE524CD9C59EEFD845910135567A",
+    "templateId": "CosmeticVariantToken:vtid_a_439_lonewolf_superlevelt2",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Material",
+        "added": [
+          "Mat5"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "7914F7C14D69F18142D78B93847DD8BB",
+    "templateId": "AthenaLoadingScreen:lsid_395_exosuitalt",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "65233FD3452CD5984AFCED83539F2860",
+    "templateId": "CosmeticVariantToken:vtid_a_440_lonewolf_superlevelt3",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Material",
+        "added": [
+          "Mat6"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "FE2E755449F1D4A497C3088A93D0D8AF",
+    "templateId": "CosmeticVariantToken:vtid_a_428_buffllama_superlevelt3",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_288_Athena_Commando_M_BuffLlama",
+        "channel": "Material",
+        "added": [
+          "Mat6"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "48C4A38B4FEA269C2FCF7AAE679D4622",
+    "templateId": "CosmeticVariantToken:vtid_a_437_motorcyclist_superlevelt3",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "ClothingColor",
+        "added": [
+          "Mat7"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "98AC795D4F7EF3CE0A6991AF5CCADCFA",
+    "templateId": "CosmeticVariantToken:vtid_a_431_exosuit_superlevelt3",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_292_Athena_Commando_F_ExoSuit",
+        "channel": "ClothingColor",
+        "added": [
+          "Color.003"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "E1A6CB5741D41E9CDD2ADCBA52DFFB09",
+    "templateId": "CosmeticVariantToken:vtid_a_434_parallelcomic_superlevelt3",
+    "Price": 20,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_293_Athena_Commando_M_ParallelComic",
+        "channel": "Progressive",
+        "added": [
+          "Stage6"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "207BC6AB4A8722EAFA07CFB0C1D00104",
+    "templateId": "AthenaDance:eid_lonewolf",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F5D4D5F9444A6A13A0EB6C9D38741A6E",
+    "templateId": "AthenaItemWrap:wrap_425_exosuit",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "E7CD6E6041B64E5594F01A82F7791F9C",
+    "templateId": "AthenaGlider:Glider_ID_330_LoneWolfMale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 6,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "870EEBFD4D067D8337979B94B7FE6E96",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "E6C86D3E465820600CF4F99D089E85AB",
+    "templateId": "AthenaDance:spid_342_lonewolfhero",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "83BEC81846AA1F6456B76A821E891E58",
+    "templateId": "CosmeticVariantToken:vtid_a_361_lonewolf_colorb",
+    "Price": 8,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Material",
+        "added": [
+          "Mat2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_911_LoneWolfMale",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_715_LoneWolfMale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_330_LoneWolfMale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "7981F39E493BDD05D0E53D904C05BC87",
+    "templateId": "AthenaBackpack:BID_911_LoneWolfMale",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "8566D265454FFB78F09DA4BEA72898AF",
+    "templateId": "AthenaDance:spid_336_exosuit",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "F7BBEDB644E157FC303A778E66ACEDBE",
+    "templateId": "AthenaItemWrap:wrap_420_lonewolf",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "3F2FCBBF4B693141C79C00AE3100F5F5",
+    "templateId": "CosmeticVariantToken:vtid_a_402_exosuit_backbling_styleb",
+    "Price": 4,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaBackpack:BID_915_ExoSuitFemale",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_915_ExoSuitFemale",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "2FC9E0184C541CDBE21947806CE9617D",
+    "templateId": "AthenaDance:emoji_s19_lonewolf",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "112EA58C415D5D8F64B658B14663B5DB",
+    "templateId": "AthenaDance:eid_lifted",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "4AF68E2A48949BFED69195BF6D4A98D7",
+    "templateId": "AthenaSkyDiveContrail:trails_id_133_lonewolfmale",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "4C46F35C41C713C95F00AF8214513056",
+    "templateId": "AthenaBackpack:BID_848_BuffLlama",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "943BA1894DB4BA8F0A85EB9EEA58D241",
+    "templateId": "AthenaCharacter:CID_A_288_Athena_Commando_M_BuffLlama",
+    "variants": [
+      {
+        "channel": "Material",
+        "active": "Mat1",
+        "owned": [
+          "Mat1"
+        ]
+      }
+    ],
+    "Price": 9,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "FA94555648326BFC23FF8D91A66EB420",
+    "templateId": "AthenaLoadingScreen:lsid_381_buffllama",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "257483914A4857BA03CC728C0E0095B4",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "2EB6F58041F2F98EB181F492B8CDFC2B",
+    "templateId": "HomebaseBannerIcon:brs19_buffllama",
+    "Price": 2,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "D998ABBC499B6A297B42859565134FF7",
+    "templateId": "AthenaCharacter:CID_A_292_Athena_Commando_F_ExoSuit",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      },
+      {
+        "channel": "Material",
+        "active": "Mat1",
+        "owned": [
+          "Mat1"
+        ]
+      },
+      {
+        "channel": "Mesh",
+        "active": "Mat3",
+        "owned": [
+          "Mat3"
+        ]
+      },
+      {
+        "channel": "Emissive",
+        "active": "Emissive1",
+        "owned": [
+          "Emissive1"
+        ]
+      },
+      {
+        "channel": "ClothingColor",
+        "active": "Color.000",
+        "owned": [
+          "Color.000"
+        ]
+      },
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": -1,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "28726E814E6CD3ACB9904FA436E3708C",
+    "templateId": "AthenaDance:emoji_s19_buffllama",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "045F2D144F78FE4597ADEE95831362A6",
+    "templateId": "AthenaDance:eid_doodling",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "E67CE0544376384C6BEE9292B90E1C1F",
+    "templateId": "AthenaDance:spid_335_buffllama",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "548109944808033E2ECCB590B4B1C0C6",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "E69CBF7E459A47E16612EF9266927717",
+    "templateId": "AthenaGlider:glider_id_310_buffllamamale",
+    "Price": 6,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "4652125E4D5F0BC1C15267BF061E9D40",
+    "templateId": "AthenaLoadingScreen:lsid_389_collage",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "2C3EEFEE46054D1339BAE2887D6074F2",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "4CF915F74258575FA434DABBBBD0B5B8",
+    "templateId": "AthenaPickaxe:Pickaxe_ID_665_BuffLlamaMale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "637BC2EF4A9BC64DB9E620AABD3643C9",
+    "templateId": "CosmeticVariantToken:vtid_a_365_buffllama_colorc",
+    "Price": 8,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_288_Athena_Commando_M_BuffLlama",
+        "channel": "Material",
+        "added": [
+          "Mat3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_848_BuffLlama",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_665_BuffLlamaMale",
+        "channel": "Particle",
+        "added": [
+          "Particle3"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "10B651E54CA86FB1B20757AE5315FB46",
+    "templateId": "AthenaItemWrap:wrap_421_buffllama",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "1882CE704594B349EEB2B28433548CE6",
+    "templateId": "AthenaGlider:glider_id_328_exosuitfemale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 6,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "FE141A8A4A77AB6C8175F4814AE88FDD",
+    "templateId": "AthenaMusicPack:musicpack_114_islandnomad",
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F992FD4546ED5ABA2D8E898E4C80C50A",
+    "templateId": "AthenaPickaxe:Pickaxe_ID_714_IslandNomadFemale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "FF0083734612D2F9049F0D85EA5DA52C",
+    "templateId": "AthenaCharacter:CID_A_291_Athena_Commando_F_IslandNomad",
+    "variants": [
+      {
+        "channel": "Parts",
+        "active": "Stage1",
+        "owned": [
+          "Stage1",
+          "Stage3"
+        ]
+      },
+      {
+        "channel": "Material",
+        "active": "Mat1",
+        "owned": [
+          "Mat1"
+        ]
+      }
+    ],
+    "Price": 9,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "4DB64617486D4506C7934D9591EFCE22",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "42B2FD134AC584553D7EE78C6EEDFE73",
+    "templateId": "AthenaLoadingScreen:lsid_383_islandnomad",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "B9027AF446324C58982CEF820E03BCCC",
+    "templateId": "AthenaItemWrap:wrap_424_islandnomad",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "729F3B93433F92E2F56555A2B1761FD7",
+    "templateId": "AthenaDance:spid_338_islandnomad",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "5523CB104A1400D1AFE841AECF09F532",
+    "templateId": "CosmeticVariantToken:vtid_a_359_lonewolf_styleb",
+    "Price": 8,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "15805A7841705341DCDBF5822B8AFAC4",
+    "templateId": "HomebaseBannerIcon:brs19_islandnomad",
+    "Price": 2,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "65AAE67D49738B6A35074794219D5BE8",
+    "templateId": "AthenaBackpack:BID_914_IslandNomadFemale",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "68DFF99B43FAF85BEF46C59A36A01F66",
+    "templateId": "AthenaPickaxe:pickaxe_id_712_exosuitfemale1h",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "02DFA4B2465BB21F49A996A44838D9E4",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "40FB45804C52DA3B55C807B3003CC838",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "66846AB842510F91328DEFA125DBAB8E",
+    "templateId": "AthenaSkyDiveContrail:trails_id_131_gumball",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "CDE35D824959E744326DF08C24333F0B",
+    "templateId": "AthenaDance:eid_chuckle",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "A6C966A04833C8A8208AE1A651A606F4",
+    "templateId": "AthenaDance:spid_337_gumball",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F144441E459E4A49F02DB1A29270430F",
+    "templateId": "AthenaBackpack:BID_912_GumballMale",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "C431B5BF418AE90D18C091B646F57B01",
+    "templateId": "AthenaCharacter:CID_A_289_Athena_Commando_M_Gumball",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 9,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "5BD80C3641AB3E766181A59253BB00AE",
+    "templateId": "CosmeticVariantToken:vtid_a_377_islandnomad_styleb",
+    "Price": 4,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_291_Athena_Commando_F_IslandNomad",
+        "channel": "Parts",
+        "added": [
+          "Stage2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "B7A440CF4C5D219204015DAB088090E7",
+    "templateId": "AthenaLoadingScreen:lsid_392_icelegends",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "1230AA744A4E49655CA022AC827A38B1",
+    "templateId": "AthenaPickaxe:Pickaxe_ID_713_GumballMale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "D554258C41E2FEA456840BB0AD433FF8",
+    "templateId": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      },
+      {
+        "channel": "Parts",
+        "active": "Stage4",
+        "owned": [
+          "Stage4"
+        ]
+      },
+      {
+        "channel": "Material",
+        "active": "Mat11",
+        "owned": [
+          "Mat11"
+        ]
+      }
+    ],
+    "Price": 9,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "9367F1E44A21D4762E5B20B71125AA10",
+    "templateId": "HomebaseBannerIcon:brs19_gumball",
+    "Price": 2,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "80F957CF47D54198BE5DA1A1E7DE453C",
+    "templateId": "AthenaMusicPack:musicpack_116_gumball",
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "769CFCE54E11EF60163F67AED3F2EFF7",
+    "templateId": "CosmeticVariantToken:vtid_a_366_gumball_colorb",
+    "Price": 8,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_289_Athena_Commando_M_Gumball",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_912_GumballMale",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_713_GumballMale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_329_GumballMale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "572518784C2384114452319C1FFCFD47",
+    "templateId": "AthenaDance:emoji_s19_gumball",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "401E03904C0E52552C82B5B9B003F8D8",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "593EE46D4ABAD09E2BC453856B5460A6",
+    "templateId": "AthenaItemWrap:wrap_422_gumball",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "631F83424B737BEF3E6FBD943BC288FE",
+    "templateId": "AthenaLoadingScreen:lsid_382_gumball",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "E80E39C1477CCEC9D01EB491C49D876D",
+    "templateId": "AthenaDance:EID_Gumball",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "7D4286354E58AA589C70A3AE3D83501B",
+    "templateId": "AthenaDance:spid_340_motorcyclist",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "0FF97127417CE4B32F3B6596BA6BAB4C",
+    "templateId": "AthenaGlider:Glider_ID_329_GumballMale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 6,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "C060D0C946D827401F97CD99F6E8E305",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "7F2D6276447A7B009C7D88A688D9338A",
+    "templateId": "AthenaDance:emoji_s19_motorcyclist",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "C2F784054C575B82CCB458BF6C276CC4",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F4363D5341645A18539D48AEDEDF0EF9",
+    "templateId": "CosmeticVariantToken:vtid_a_360_lonewolf_stylec",
+    "Price": 8,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Progressive",
+        "added": [
+          "Stage3"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_287_Athena_Commando_M_LoneWolf",
+        "channel": "Parts",
+        "added": [
+          "Stage5"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "6B3D785B4C782A24BA4FF2B7F72FBAF5",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "0F449EE0499652B3A6B2DFB86CED618C",
+    "templateId": "AthenaBackpack:BID_913_MotorcyclistFemale",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      },
+      {
+        "channel": "Emissive",
+        "active": "Emissive1",
+        "owned": [
+          "Emissive1"
+        ]
+      }
+    ],
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "701E619A40B6A10B130C5A9B274DDDF3",
+    "templateId": "AthenaPickaxe:Pickaxe_ID_716_MotorcyclistFemale",
+    "variants": [
+      {
+        "channel": "Material",
+        "active": "Mat1",
+        "owned": [
+          "Mat1"
+        ]
+      },
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F10B23E8461C8B0F657CFFB0E4DABA3C",
+    "templateId": "AthenaGlider:Glider_ID_331_MotorcyclistFemale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      },
+      {
+        "channel": "Material",
+        "active": "Mat1",
+        "owned": [
+          "Mat1"
+        ]
+      }
+    ],
+    "Price": 6,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "58512666416FE30709D78096BA1D743C",
+    "templateId": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      },
+      {
+        "channel": "Parts",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      },
+      {
+        "channel": "Mat1",
+        "active": "Mat1",
+        "owned": [
+          "Mat1"
+        ]
+      },
+      {
+        "channel": "Emissive",
+        "active": "Emissive1",
+        "owned": [
+          "Emissive1"
+        ]
+      },
+      {
+        "channel": "ClothingColor",
+        "active": "Mat3",
+        "owned": [
+          "Mat3"
+        ]
+      },
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 9,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "6D860AB64A03DF71C5249AAA3FAF8812",
+    "templateId": "AthenaLoadingScreen:lsid_385_motorcyclist",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "C4F313444C04F0C47F9FA08176E57998",
+    "templateId": "AthenaSkyDiveContrail:trails_id_134_motorcyclistfemale",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F31428EB45229CB488D247AB24F5886A",
+    "templateId": "HomebaseBannerIcon:brs19_lonewolf",
+    "Price": 2,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "028CD65848E068A96207A9AC937162D6",
+    "templateId": "HomebaseBannerIcon:brs19_parallelsymbol",
+    "Price": 2,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "0E089CE246353E666499209D75284167",
+    "templateId": "CosmeticVariantToken:vtid_a_370_motorcyclist_stylec",
+    "Price": 8,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Parts",
+        "added": [
+          "Stage2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Material",
+        "added": [
+          "Mat2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Emissive",
+        "added": [
+          "Emissive2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaCharacter:CID_A_290_Athena_Commando_F_Motorcyclist",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_913_MotorcyclistFemale",
+        "channel": "Emissive",
+        "added": [
+          "Emissive2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaPickaxe:Pickaxe_ID_716_MotorcyclistFemale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaGlider:Glider_ID_331_MotorcyclistFemale",
+        "channel": "Particle",
+        "added": [
+          "Particle2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "0C362396435CF988FD1FBE98B0D6FBA5",
+    "templateId": "AthenaMusicPack:musicpack_115_motorcyclist",
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "833BBC5849F742838A848DBBD5AACFE3",
+    "templateId": "AthenaSkyDiveContrail:trails_id_135_parallelcomic",
+    "Price": 4,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "647229A941580CF26C9617B74C4D385C",
+    "templateId": "AthenaCharacter:CID_A_293_Athena_Commando_M_ParallelComic",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 9,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "AB20EBB14288B5D698C1B3B98AAE5C29",
+    "templateId": "AthenaBackpack:BID_916_ParallelComicMale",
+    "variants": [
+      {
+        "channel": "Progressive",
+        "active": "Stage1",
+        "owned": [
+          "Stage1"
+        ]
+      }
+    ],
+    "Price": 5,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "F65D3C044E7487AD4A12D481A3BC1792",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "DB72AADE421385606A8C0AA12AD250E9",
+    "templateId": "AthenaDance:emoji_s19_parallelsling",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "B837DA8B4263BE49924B29A9B1D83B91",
+    "templateId": "AthenaDance:eid_youthere",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "48FF873642F1379749B59BA10001A05F",
+    "templateId": "AthenaLoadingScreen:lsid_387_island",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "BC5FF1BB4183D236EB7725A5E35C67D9",
+    "templateId": "AthenaLoadingScreen:lsid_384_lonewolf",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "822AEB7F442C8550C3AF259E749DF0C7",
+    "templateId": "AthenaDance:emoji_s19_parallelsenses",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "64F9DE4B4510BDDD664099A14DB5E65B",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "3F5FFD0348E0076EF9B41FB3155B97BE",
+    "templateId": "AthenaLoadingScreen:lsid_386_parallel",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "74BEBC604629EBA7F86A38842B549295",
+    "templateId": "CosmeticVariantToken:vtid_a_384_parallelcomic_styleb",
+    "Price": 8,
+    "Quantity": 1,
+    "new_variants": [
+      {
+        "connectedItem": "AthenaCharacter:CID_A_293_Athena_Commando_M_ParallelComic",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      },
+      {
+        "connectedItem": "AthenaBackpack:BID_916_ParallelComicMale",
+        "channel": "Progressive",
+        "added": [
+          "Stage2"
+        ]
+      }
+    ]
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "57FF9FD446B8B23667DC9D9B04A5DA03",
+    "templateId": "Currency:mtxgiveaway",
+    "Price": 5,
+    "Quantity": 100
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "6D9C1EBE46704F3CCF79AFB5928906FC",
+    "templateId": "AthenaDance:spid_341_parallel",
+    "Price": 3,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "A027912E446D790B4439C797EFA90F3F",
+    "templateId": "AthenaPickaxe:pickaxe_id_718_parallelcomicmale",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "55948AF6469BB0833B3F7CB9F20E7E5E",
+    "templateId": "AthenaGlider:glider_id_332_parallelcomicmale",
+    "variants": [
+      {
+        "channel": "Particle",
+        "active": "Particle1",
+        "owned": [
+          "Particle1"
+        ]
+      }
+    ],
+    "Price": 6,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": true,
+    "OfferId": "0B16464F4137F7D41006BA9DE59B28CD",
+    "templateId": "AthenaDance:EID_ParallelComic",
+    "Price": 7,
+    "Quantity": 1
+  },
+  {
+    "bRequireBp": false,
+    "OfferId": "8D3640624141C86E4BA80C915FC02436",
+    "templateId": "AthenaItemWrap:wrap_426_parallel",
+    "Price": 4,
+    "Quantity": 1
+  }
+]

--- a/FortBackend/Resources/Json/Season/Season19/BattlePass.json
+++ b/FortBackend/Resources/Json/Season/Season19/BattlePass.json
@@ -1,0 +1,244 @@
+{
+  "name": "BRSeason19",
+  "catalogEntries": [
+    {
+      "offerId": "B1E16EBD418B6892081A9C990F431AD4",
+      "devName": "BR.Season19.BattlePass.01",
+      "offerType": "StaticPrice",
+      "prices": [
+        {
+          "currencyType": "MtxCurrency",
+          "currencySubType": "",
+          "regularPrice": 950,
+          "finalPrice": 950,
+          "saleExpiration": "9999-12-31T23:59:59.999Z",
+          "basePrice": 950
+        }
+      ],
+      "categories": [],
+      "dailyLimit": -1,
+      "weeklyLimit": -1,
+      "monthlyLimit": -1,
+      "refundable": false,
+      "appStoreId": [ "", "", "", "", "", "", "", "", "", "", "", "" ],
+      "requirements": [
+        {
+          "requirementType": "DenyOnFulfillment",
+          "requiredId": "B1E16EBD418B6892081A9C990F431AD4",
+          "minQuantity": 1
+        }
+      ],
+      "metaInfo": [
+        {
+          "key": "Preroll",
+          "value": "False"
+        }
+      ],
+      "catalogGroup": "",
+      "catalogGroupPriority": 0,
+      "sortPriority": 1,
+      "title": {
+        "en": "Battle Pass",
+        "es": "Pase de batalla",
+        "es-419": "Pase de batalla",
+        "fr": "Passe de combat",
+        "it": "Pass battaglia",
+        "ja": "バトルパス",
+        "ko": "배틀 패스",
+        "pl": "Pakiet bojowy",
+        "pt-BR": "Passe de Batalha",
+        "ru": "Боевой пропуск",
+        "tr": "Savaş Bileti",
+        "de": "Kampfpass"
+      },
+      "shortDescription": {
+        "en": "Chapter 3 - Season 1",
+        "es": "",
+        "es-419": "",
+        "fr": "",
+        "it": "",
+        "ja": "",
+        "ko": "",
+        "pl": "",
+        "pt-BR": "",
+        "ru": "",
+        "tr": "",
+        "de": ""
+      },
+      "description": {
+        "en": "Chapter 3 - Season 1 through April 16.",
+        "es": "pp",
+        "es-419": "",
+        "fr": "",
+        "it": "",
+        "ja": "",
+        "ko": "",
+        "pl": "",
+        "pt-BR": "",
+        "ru": "",
+        "tr": "",
+        "de": ""
+      },
+      "displayAssetPath": "/Game/Catalog/DisplayAssets/DA_BR_Season19_BattlePass.DA_BR_Season19_BattlePass",
+      "itemGrants": []
+    },
+    {
+      "offerId": "C6CAE9BA435CF1B0BE4BE7865B9F4E0F",
+      "devName": "BR.Season19.SingleTier.01",
+      "offerType": "StaticPrice",
+      "prices": [
+        {
+          "currencyType": "MtxCurrency",
+          "currencySubType": "",
+          "regularPrice": 150,
+          "dynamicRegularPrice": -1,
+          "finalPrice": 150,
+          "saleExpiration": "9999-12-31T23:59:59.999Z",
+          "basePrice": 150
+        }
+      ],
+      "categories": [],
+      "dailyLimit": -1,
+      "weeklyLimit": -1,
+      "monthlyLimit": -1,
+      "refundable": false,
+      "appStoreId": [ "", "", "", "", "", "", "", "", "", "", "", "" ],
+      "requirements": [],
+      "metaInfo": [
+        {
+          "key": "Preroll",
+          "value": "False"
+        }
+      ],
+      "catalogGroup": "",
+      "catalogGroupPriority": 0,
+      "sortPriority": 0,
+      "title": {
+        "eu": "Battle Pass Tier",
+        "es": "",
+        "es-419": "",
+        "fr": "",
+        "it": "",
+        "ja": "",
+        "ko": "",
+        "pl": "",
+        "pt-BR": "",
+        "ru": "",
+        "tr": "",
+        "de": ""
+      },
+      "shortDescription": {
+        "en": "",
+        "es": "",
+        "es-419": "",
+        "fr": "",
+        "it": "",
+        "ja": "",
+        "ko": "",
+        "pl": "",
+        "pt-BR": "",
+        "ru": "",
+        "tr": "",
+        "de": ""
+      },
+      "description": {
+        "en": "Get great rewards now!",
+        "es": "",
+        "es-419": "",
+        "fr": "",
+        "it": "",
+        "ja": "",
+        "ko": "",
+        "pl": "",
+        "pt-BR": "",
+        "ru": "",
+        "tr": "",
+        "de": ""
+      },
+      "displayAssetPath": "",
+      "itemGrants": []
+    },
+    {
+      "offerId": "2719FD6E4F264293B3B8B4842F272FCB",
+      "devName": "BR.Season19.BattleBundle.01",
+      "offerType": "StaticPrice",
+      "prices": [
+        {
+          "currencyType": "MtxCurrency",
+          "currencySubType": "",
+          "regularPrice": 4700,
+          "finalPrice": 2800,
+          "saleType": "PercentOff",
+          "saleExpiration": "9999-12-31T23:59:59.999Z",
+          "basePrice": 2800
+        }
+      ],
+      "categories": [],
+      "dailyLimit": -1,
+      "weeklyLimit": -1,
+      "monthlyLimit": -1,
+      "refundable": false,
+      "appStoreId": [ "", "", "", "", "", "", "", "", "", "", "", "" ],
+      "requirements": [
+        {
+          "requirementType": "DenyOnFulfillment",
+          "requiredId": "2719FD6E4F264293B3B8B4842F272FCB",
+          "minQuantity": 1
+        }
+      ],
+      "metaInfo": [
+        {
+          "key": "Preroll",
+          "value": "False"
+        }
+      ],
+      "catalogGroup": "",
+      "catalogGroupPriority": 0,
+      "sortPriority": 0,
+      "title": {
+        "en": "Battle Bundle",
+        "es": "Lote de Batalla",
+        "es-419": "Lote de Batalla",
+        "fr": "Lot de Combat",
+        "it": "Pacchetto Battaglia",
+        "ja": "バトルバンドル",
+        "ko": "배틀 번들",
+        "pl": "Pakiet Bitwy",
+        "pt-BR": "Pacote de Batalha",
+        "ru": "Боевой Набор",
+        "tr": "Savaş Paketi",
+        "de": "Kampfpaket"
+      },
+      "shortDescription": {
+        "en": "Battle Pass + 25 tiers!",
+        "es": "",
+        "es-419": "",
+        "fr": "",
+        "it": "",
+        "ja": "",
+        "ko": "",
+        "pl": "",
+        "pt-BR": "",
+        "ru": "",
+        "tr": "",
+        "de": ""
+      },
+      "description": {
+        "en": "Chapter 3 - Season 1 through April 16.",
+        "es": "pp",
+        "es-419": "",
+        "fr": "",
+        "it": "",
+        "ja": "",
+        "ko": "",
+        "pl": "",
+        "pt-BR": "",
+        "ru": "",
+        "tr": "",
+        "de": ""
+      },
+      "displayAssetPath": "/Game/Catalog/DisplayAssets/DA_BR_Season19_BattlePassWithLevels.DA_BR_Season19_BattlePassWithLevels",
+      "itemGrants": []
+    }
+  ]
+}

--- a/FortBackend/Resources/Json/Season/Season19/SeasonFreeBattlepass.json
+++ b/FortBackend/Resources/Json/Season/Season19/SeasonFreeBattlepass.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Rewards": [],
+    "Level": 0
+  },
+  {
+    "Rewards": [],
+    "Level": 1
+  }
+]

--- a/FortBackend/Resources/Json/Season/Season19/SeasonPaidBattlepass.json
+++ b/FortBackend/Resources/Json/Season/Season19/SeasonPaidBattlepass.json
@@ -1,0 +1,26 @@
+[
+  {
+    "Rewards": [],
+    "Level": 0
+  },
+  {
+    "Rewards": [
+      {
+        "templateId": "AthenaCharacter:CID_A_292_Athena_Commando_F_ExoSuit",
+        "connectedTemplate": "",
+        "quantity": 1
+      },
+      {
+        "templateId": "ChallengeBundleSchedule:Season19_Exosuit_Schedule",
+        "connectedTemplate": "",
+        "quantity": 1
+      },
+      {
+        "templateId": "AccountResource:AthenaBattleStar",
+        "connectedTemplate": "",
+        "quantity": 5
+      }
+    ],
+    "Level": 1
+  }
+]

--- a/FortBackend/Resources/Json/Season/Season19/SeasonXP.json
+++ b/FortBackend/Resources/Json/Season/Season19/SeasonXP.json
@@ -1,0 +1,4997 @@
+[
+  {
+    "Level": 1,
+    "XpToNextLevel": 40000,
+    "XpTotal": 0
+  },
+  {
+    "Level": 2,
+    "XpToNextLevel": 50000,
+    "XpTotal": 40000
+  },
+  {
+    "Level": 3,
+    "XpToNextLevel": 50000,
+    "XpTotal": 90000
+  },
+  {
+    "Level": 4,
+    "XpToNextLevel": 60000,
+    "XpTotal": 140000
+  },
+  {
+    "Level": 5,
+    "XpToNextLevel": 60000,
+    "XpTotal": 200000
+  },
+  {
+    "Level": 6,
+    "XpToNextLevel": 75000,
+    "XpTotal": 260000
+  },
+  {
+    "Level": 7,
+    "XpToNextLevel": 75000,
+    "XpTotal": 335000
+  },
+  {
+    "Level": 8,
+    "XpToNextLevel": 75000,
+    "XpTotal": 410000
+  },
+  {
+    "Level": 9,
+    "XpToNextLevel": 75000,
+    "XpTotal": 485000
+  },
+  {
+    "Level": 10,
+    "XpToNextLevel": 75000,
+    "XpTotal": 560000
+  },
+  {
+    "Level": 11,
+    "XpToNextLevel": 75000,
+    "XpTotal": 635000
+  },
+  {
+    "Level": 12,
+    "XpToNextLevel": 75000,
+    "XpTotal": 710000
+  },
+  {
+    "Level": 13,
+    "XpToNextLevel": 75000,
+    "XpTotal": 785000
+  },
+  {
+    "Level": 14,
+    "XpToNextLevel": 75000,
+    "XpTotal": 860000
+  },
+  {
+    "Level": 15,
+    "XpToNextLevel": 75000,
+    "XpTotal": 935000
+  },
+  {
+    "Level": 16,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1010000
+  },
+  {
+    "Level": 17,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1085000
+  },
+  {
+    "Level": 18,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1160000
+  },
+  {
+    "Level": 19,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1235000
+  },
+  {
+    "Level": 20,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1310000
+  },
+  {
+    "Level": 21,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1385000
+  },
+  {
+    "Level": 22,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1460000
+  },
+  {
+    "Level": 23,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1535000
+  },
+  {
+    "Level": 24,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1610000
+  },
+  {
+    "Level": 25,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1685000
+  },
+  {
+    "Level": 26,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1760000
+  },
+  {
+    "Level": 27,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1835000
+  },
+  {
+    "Level": 28,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1910000
+  },
+  {
+    "Level": 29,
+    "XpToNextLevel": 75000,
+    "XpTotal": 1985000
+  },
+  {
+    "Level": 30,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2060000
+  },
+  {
+    "Level": 31,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2135000
+  },
+  {
+    "Level": 32,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2210000
+  },
+  {
+    "Level": 33,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2285000
+  },
+  {
+    "Level": 34,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2360000
+  },
+  {
+    "Level": 35,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2435000
+  },
+  {
+    "Level": 36,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2510000
+  },
+  {
+    "Level": 37,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2585000
+  },
+  {
+    "Level": 38,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2660000
+  },
+  {
+    "Level": 39,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2735000
+  },
+  {
+    "Level": 40,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2810000
+  },
+  {
+    "Level": 41,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2885000
+  },
+  {
+    "Level": 42,
+    "XpToNextLevel": 75000,
+    "XpTotal": 2960000
+  },
+  {
+    "Level": 43,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3035000
+  },
+  {
+    "Level": 44,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3110000
+  },
+  {
+    "Level": 45,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3185000
+  },
+  {
+    "Level": 46,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3260000
+  },
+  {
+    "Level": 47,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3335000
+  },
+  {
+    "Level": 48,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3410000
+  },
+  {
+    "Level": 49,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3485000
+  },
+  {
+    "Level": 50,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3560000
+  },
+  {
+    "Level": 51,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3635000
+  },
+  {
+    "Level": 52,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3710000
+  },
+  {
+    "Level": 53,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3785000
+  },
+  {
+    "Level": 54,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3860000
+  },
+  {
+    "Level": 55,
+    "XpToNextLevel": 75000,
+    "XpTotal": 3935000
+  },
+  {
+    "Level": 56,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4010000
+  },
+  {
+    "Level": 57,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4085000
+  },
+  {
+    "Level": 58,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4160000
+  },
+  {
+    "Level": 59,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4235000
+  },
+  {
+    "Level": 60,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4310000
+  },
+  {
+    "Level": 61,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4385000
+  },
+  {
+    "Level": 62,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4460000
+  },
+  {
+    "Level": 63,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4535000
+  },
+  {
+    "Level": 64,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4610000
+  },
+  {
+    "Level": 65,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4685000
+  },
+  {
+    "Level": 66,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4760000
+  },
+  {
+    "Level": 67,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4835000
+  },
+  {
+    "Level": 68,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4910000
+  },
+  {
+    "Level": 69,
+    "XpToNextLevel": 75000,
+    "XpTotal": 4985000
+  },
+  {
+    "Level": 70,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5060000
+  },
+  {
+    "Level": 71,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5135000
+  },
+  {
+    "Level": 72,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5210000
+  },
+  {
+    "Level": 73,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5285000
+  },
+  {
+    "Level": 74,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5360000
+  },
+  {
+    "Level": 75,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5435000
+  },
+  {
+    "Level": 76,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5510000
+  },
+  {
+    "Level": 77,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5585000
+  },
+  {
+    "Level": 78,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5660000
+  },
+  {
+    "Level": 79,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5735000
+  },
+  {
+    "Level": 80,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5810000
+  },
+  {
+    "Level": 81,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5885000
+  },
+  {
+    "Level": 82,
+    "XpToNextLevel": 75000,
+    "XpTotal": 5960000
+  },
+  {
+    "Level": 83,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6035000
+  },
+  {
+    "Level": 84,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6110000
+  },
+  {
+    "Level": 85,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6185000
+  },
+  {
+    "Level": 86,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6260000
+  },
+  {
+    "Level": 87,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6335000
+  },
+  {
+    "Level": 88,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6410000
+  },
+  {
+    "Level": 89,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6485000
+  },
+  {
+    "Level": 90,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6560000
+  },
+  {
+    "Level": 91,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6635000
+  },
+  {
+    "Level": 92,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6710000
+  },
+  {
+    "Level": 93,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6785000
+  },
+  {
+    "Level": 94,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6860000
+  },
+  {
+    "Level": 95,
+    "XpToNextLevel": 75000,
+    "XpTotal": 6935000
+  },
+  {
+    "Level": 96,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7010000
+  },
+  {
+    "Level": 97,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7085000
+  },
+  {
+    "Level": 98,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7160000
+  },
+  {
+    "Level": 99,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7235000
+  },
+  {
+    "Level": 100,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7565000
+  },
+  {
+    "Level": 101,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7640000
+  },
+  {
+    "Level": 102,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7715000
+  },
+  {
+    "Level": 103,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7790000
+  },
+  {
+    "Level": 104,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7865000
+  },
+  {
+    "Level": 105,
+    "XpToNextLevel": 75000,
+    "XpTotal": 7940000
+  },
+  {
+    "Level": 106,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8015000
+  },
+  {
+    "Level": 107,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8090000
+  },
+  {
+    "Level": 108,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8165000
+  },
+  {
+    "Level": 109,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8240000
+  },
+  {
+    "Level": 110,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8315000
+  },
+  {
+    "Level": 111,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8390000
+  },
+  {
+    "Level": 112,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8465000
+  },
+  {
+    "Level": 113,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8540000
+  },
+  {
+    "Level": 114,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8615000
+  },
+  {
+    "Level": 115,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8690000
+  },
+  {
+    "Level": 116,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8765000
+  },
+  {
+    "Level": 117,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8840000
+  },
+  {
+    "Level": 118,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8915000
+  },
+  {
+    "Level": 119,
+    "XpToNextLevel": 75000,
+    "XpTotal": 8990000
+  },
+  {
+    "Level": 120,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9065000
+  },
+  {
+    "Level": 121,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9140000
+  },
+  {
+    "Level": 122,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9215000
+  },
+  {
+    "Level": 123,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9290000
+  },
+  {
+    "Level": 124,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9365000
+  },
+  {
+    "Level": 125,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9440000
+  },
+  {
+    "Level": 126,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9515000
+  },
+  {
+    "Level": 127,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9590000
+  },
+  {
+    "Level": 128,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9665000
+  },
+  {
+    "Level": 129,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9740000
+  },
+  {
+    "Level": 130,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9815000
+  },
+  {
+    "Level": 131,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9890000
+  },
+  {
+    "Level": 132,
+    "XpToNextLevel": 75000,
+    "XpTotal": 9965000
+  },
+  {
+    "Level": 133,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10040000
+  },
+  {
+    "Level": 134,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10115000
+  },
+  {
+    "Level": 135,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10190000
+  },
+  {
+    "Level": 136,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10265000
+  },
+  {
+    "Level": 137,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10340000
+  },
+  {
+    "Level": 138,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10415000
+  },
+  {
+    "Level": 139,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10490000
+  },
+  {
+    "Level": 140,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10565000
+  },
+  {
+    "Level": 141,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10640000
+  },
+  {
+    "Level": 142,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10715000
+  },
+  {
+    "Level": 143,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10790000
+  },
+  {
+    "Level": 144,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10865000
+  },
+  {
+    "Level": 145,
+    "XpToNextLevel": 75000,
+    "XpTotal": 10940000
+  },
+  {
+    "Level": 146,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11015000
+  },
+  {
+    "Level": 147,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11090000
+  },
+  {
+    "Level": 148,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11165000
+  },
+  {
+    "Level": 149,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11240000
+  },
+  {
+    "Level": 150,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11315000
+  },
+  {
+    "Level": 151,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11390000
+  },
+  {
+    "Level": 152,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11465000
+  },
+  {
+    "Level": 153,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11540000
+  },
+  {
+    "Level": 154,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11615000
+  },
+  {
+    "Level": 155,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11690000
+  },
+  {
+    "Level": 156,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11765000
+  },
+  {
+    "Level": 157,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11840000
+  },
+  {
+    "Level": 158,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11915000
+  },
+  {
+    "Level": 159,
+    "XpToNextLevel": 75000,
+    "XpTotal": 11990000
+  },
+  {
+    "Level": 160,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12065000
+  },
+  {
+    "Level": 161,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12140000
+  },
+  {
+    "Level": 162,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12215000
+  },
+  {
+    "Level": 163,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12290000
+  },
+  {
+    "Level": 164,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12365000
+  },
+  {
+    "Level": 165,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12440000
+  },
+  {
+    "Level": 166,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12515000
+  },
+  {
+    "Level": 167,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12590000
+  },
+  {
+    "Level": 168,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12665000
+  },
+  {
+    "Level": 169,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12740000
+  },
+  {
+    "Level": 170,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12815000
+  },
+  {
+    "Level": 171,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12890000
+  },
+  {
+    "Level": 172,
+    "XpToNextLevel": 75000,
+    "XpTotal": 12965000
+  },
+  {
+    "Level": 173,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13040000
+  },
+  {
+    "Level": 174,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13115000
+  },
+  {
+    "Level": 175,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13190000
+  },
+  {
+    "Level": 176,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13265000
+  },
+  {
+    "Level": 177,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13340000
+  },
+  {
+    "Level": 178,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13415000
+  },
+  {
+    "Level": 179,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13490000
+  },
+  {
+    "Level": 180,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13565000
+  },
+  {
+    "Level": 181,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13640000
+  },
+  {
+    "Level": 182,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13715000
+  },
+  {
+    "Level": 183,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13790000
+  },
+  {
+    "Level": 184,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13865000
+  },
+  {
+    "Level": 185,
+    "XpToNextLevel": 75000,
+    "XpTotal": 13940000
+  },
+  {
+    "Level": 186,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14015000
+  },
+  {
+    "Level": 187,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14090000
+  },
+  {
+    "Level": 188,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14165000
+  },
+  {
+    "Level": 189,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14240000
+  },
+  {
+    "Level": 190,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14315000
+  },
+  {
+    "Level": 191,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14390000
+  },
+  {
+    "Level": 192,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14465000
+  },
+  {
+    "Level": 193,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14540000
+  },
+  {
+    "Level": 194,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14615000
+  },
+  {
+    "Level": 195,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14690000
+  },
+  {
+    "Level": 196,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14765000
+  },
+  {
+    "Level": 197,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14840000
+  },
+  {
+    "Level": 198,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14915000
+  },
+  {
+    "Level": 199,
+    "XpToNextLevel": 75000,
+    "XpTotal": 14990000
+  },
+  {
+    "Level": 200,
+    "XpToNextLevel": 75000,
+    "XpTotal": 15065000
+  },
+  {
+    "Level": 201,
+    "XpToNextLevel": 75250,
+    "XpTotal": 15140250
+  },
+  {
+    "Level": 202,
+    "XpToNextLevel": 75750,
+    "XpTotal": 15216000
+  },
+  {
+    "Level": 203,
+    "XpToNextLevel": 76000,
+    "XpTotal": 15292000
+  },
+  {
+    "Level": 204,
+    "XpToNextLevel": 76500,
+    "XpTotal": 15368500
+  },
+  {
+    "Level": 205,
+    "XpToNextLevel": 76750,
+    "XpTotal": 15445250
+  },
+  {
+    "Level": 206,
+    "XpToNextLevel": 77000,
+    "XpTotal": 15522250
+  },
+  {
+    "Level": 207,
+    "XpToNextLevel": 77500,
+    "XpTotal": 15599750
+  },
+  {
+    "Level": 208,
+    "XpToNextLevel": 77750,
+    "XpTotal": 15677500
+  },
+  {
+    "Level": 209,
+    "XpToNextLevel": 78250,
+    "XpTotal": 15755750
+  },
+  {
+    "Level": 210,
+    "XpToNextLevel": 78500,
+    "XpTotal": 15834250
+  },
+  {
+    "Level": 211,
+    "XpToNextLevel": 79000,
+    "XpTotal": 15913250
+  },
+  {
+    "Level": 212,
+    "XpToNextLevel": 79250,
+    "XpTotal": 15992500
+  },
+  {
+    "Level": 213,
+    "XpToNextLevel": 79750,
+    "XpTotal": 16072250
+  },
+  {
+    "Level": 214,
+    "XpToNextLevel": 80000,
+    "XpTotal": 16152250
+  },
+  {
+    "Level": 215,
+    "XpToNextLevel": 80500,
+    "XpTotal": 16232750
+  },
+  {
+    "Level": 216,
+    "XpToNextLevel": 80750,
+    "XpTotal": 16313500
+  },
+  {
+    "Level": 217,
+    "XpToNextLevel": 81000,
+    "XpTotal": 16394500
+  },
+  {
+    "Level": 218,
+    "XpToNextLevel": 81500,
+    "XpTotal": 16476000
+  },
+  {
+    "Level": 219,
+    "XpToNextLevel": 82000,
+    "XpTotal": 16558000
+  },
+  {
+    "Level": 220,
+    "XpToNextLevel": 82250,
+    "XpTotal": 16640250
+  },
+  {
+    "Level": 221,
+    "XpToNextLevel": 82750,
+    "XpTotal": 16723000
+  },
+  {
+    "Level": 222,
+    "XpToNextLevel": 83000,
+    "XpTotal": 16806000
+  },
+  {
+    "Level": 223,
+    "XpToNextLevel": 83500,
+    "XpTotal": 16889500
+  },
+  {
+    "Level": 224,
+    "XpToNextLevel": 83750,
+    "XpTotal": 16973250
+  },
+  {
+    "Level": 225,
+    "XpToNextLevel": 84250,
+    "XpTotal": 17057500
+  },
+  {
+    "Level": 226,
+    "XpToNextLevel": 84500,
+    "XpTotal": 17142000
+  },
+  {
+    "Level": 227,
+    "XpToNextLevel": 85000,
+    "XpTotal": 17227000
+  },
+  {
+    "Level": 228,
+    "XpToNextLevel": 85250,
+    "XpTotal": 17312250
+  },
+  {
+    "Level": 229,
+    "XpToNextLevel": 85750,
+    "XpTotal": 17398000
+  },
+  {
+    "Level": 230,
+    "XpToNextLevel": 86250,
+    "XpTotal": 17484250
+  },
+  {
+    "Level": 231,
+    "XpToNextLevel": 86500,
+    "XpTotal": 17570750
+  },
+  {
+    "Level": 232,
+    "XpToNextLevel": 87000,
+    "XpTotal": 17657750
+  },
+  {
+    "Level": 233,
+    "XpToNextLevel": 87250,
+    "XpTotal": 17745000
+  },
+  {
+    "Level": 234,
+    "XpToNextLevel": 87750,
+    "XpTotal": 17832750
+  },
+  {
+    "Level": 235,
+    "XpToNextLevel": 88250,
+    "XpTotal": 17921000
+  },
+  {
+    "Level": 236,
+    "XpToNextLevel": 88500,
+    "XpTotal": 18009500
+  },
+  {
+    "Level": 237,
+    "XpToNextLevel": 89000,
+    "XpTotal": 18098500
+  },
+  {
+    "Level": 238,
+    "XpToNextLevel": 89500,
+    "XpTotal": 18188000
+  },
+  {
+    "Level": 239,
+    "XpToNextLevel": 89750,
+    "XpTotal": 18277750
+  },
+  {
+    "Level": 240,
+    "XpToNextLevel": 90250,
+    "XpTotal": 18368000
+  },
+  {
+    "Level": 241,
+    "XpToNextLevel": 90750,
+    "XpTotal": 18458750
+  },
+  {
+    "Level": 242,
+    "XpToNextLevel": 91000,
+    "XpTotal": 18549750
+  },
+  {
+    "Level": 243,
+    "XpToNextLevel": 91500,
+    "XpTotal": 18641250
+  },
+  {
+    "Level": 244,
+    "XpToNextLevel": 92000,
+    "XpTotal": 18733250
+  },
+  {
+    "Level": 245,
+    "XpToNextLevel": 92250,
+    "XpTotal": 18825500
+  },
+  {
+    "Level": 246,
+    "XpToNextLevel": 92750,
+    "XpTotal": 18918250
+  },
+  {
+    "Level": 247,
+    "XpToNextLevel": 93250,
+    "XpTotal": 19011500
+  },
+  {
+    "Level": 248,
+    "XpToNextLevel": 93500,
+    "XpTotal": 19105000
+  },
+  {
+    "Level": 249,
+    "XpToNextLevel": 94000,
+    "XpTotal": 19199000
+  },
+  {
+    "Level": 250,
+    "XpToNextLevel": 94500,
+    "XpTotal": 19293500
+  },
+  {
+    "Level": 251,
+    "XpToNextLevel": 95000,
+    "XpTotal": 19388500
+  },
+  {
+    "Level": 252,
+    "XpToNextLevel": 95250,
+    "XpTotal": 19483750
+  },
+  {
+    "Level": 253,
+    "XpToNextLevel": 95750,
+    "XpTotal": 19579500
+  },
+  {
+    "Level": 254,
+    "XpToNextLevel": 96250,
+    "XpTotal": 19675750
+  },
+  {
+    "Level": 255,
+    "XpToNextLevel": 96750,
+    "XpTotal": 19772500
+  },
+  {
+    "Level": 256,
+    "XpToNextLevel": 97250,
+    "XpTotal": 19869750
+  },
+  {
+    "Level": 257,
+    "XpToNextLevel": 97500,
+    "XpTotal": 19967250
+  },
+  {
+    "Level": 258,
+    "XpToNextLevel": 98000,
+    "XpTotal": 20065250
+  },
+  {
+    "Level": 259,
+    "XpToNextLevel": 98500,
+    "XpTotal": 20163750
+  },
+  {
+    "Level": 260,
+    "XpToNextLevel": 99000,
+    "XpTotal": 20262750
+  },
+  {
+    "Level": 261,
+    "XpToNextLevel": 99500,
+    "XpTotal": 20362250
+  },
+  {
+    "Level": 262,
+    "XpToNextLevel": 99750,
+    "XpTotal": 20462000
+  },
+  {
+    "Level": 263,
+    "XpToNextLevel": 100250,
+    "XpTotal": 20562250
+  },
+  {
+    "Level": 264,
+    "XpToNextLevel": 100750,
+    "XpTotal": 20663000
+  },
+  {
+    "Level": 265,
+    "XpToNextLevel": 101250,
+    "XpTotal": 20764250
+  },
+  {
+    "Level": 266,
+    "XpToNextLevel": 101750,
+    "XpTotal": 20866000
+  },
+  {
+    "Level": 267,
+    "XpToNextLevel": 102250,
+    "XpTotal": 20968250
+  },
+  {
+    "Level": 268,
+    "XpToNextLevel": 102750,
+    "XpTotal": 21071000
+  },
+  {
+    "Level": 269,
+    "XpToNextLevel": 103250,
+    "XpTotal": 21174250
+  },
+  {
+    "Level": 270,
+    "XpToNextLevel": 103500,
+    "XpTotal": 21277750
+  },
+  {
+    "Level": 271,
+    "XpToNextLevel": 104000,
+    "XpTotal": 21381750
+  },
+  {
+    "Level": 272,
+    "XpToNextLevel": 104500,
+    "XpTotal": 21486250
+  },
+  {
+    "Level": 273,
+    "XpToNextLevel": 105000,
+    "XpTotal": 21591250
+  },
+  {
+    "Level": 274,
+    "XpToNextLevel": 105500,
+    "XpTotal": 21696750
+  },
+  {
+    "Level": 275,
+    "XpToNextLevel": 106000,
+    "XpTotal": 21802750
+  },
+  {
+    "Level": 276,
+    "XpToNextLevel": 106500,
+    "XpTotal": 21909250
+  },
+  {
+    "Level": 277,
+    "XpToNextLevel": 107000,
+    "XpTotal": 22016250
+  },
+  {
+    "Level": 278,
+    "XpToNextLevel": 107500,
+    "XpTotal": 22123750
+  },
+  {
+    "Level": 279,
+    "XpToNextLevel": 108000,
+    "XpTotal": 22231750
+  },
+  {
+    "Level": 280,
+    "XpToNextLevel": 108500,
+    "XpTotal": 22340250
+  },
+  {
+    "Level": 281,
+    "XpToNextLevel": 109000,
+    "XpTotal": 22449250
+  },
+  {
+    "Level": 282,
+    "XpToNextLevel": 109500,
+    "XpTotal": 22558750
+  },
+  {
+    "Level": 283,
+    "XpToNextLevel": 110000,
+    "XpTotal": 22668750
+  },
+  {
+    "Level": 284,
+    "XpToNextLevel": 110500,
+    "XpTotal": 22779250
+  },
+  {
+    "Level": 285,
+    "XpToNextLevel": 111000,
+    "XpTotal": 22890250
+  },
+  {
+    "Level": 286,
+    "XpToNextLevel": 111500,
+    "XpTotal": 23001750
+  },
+  {
+    "Level": 287,
+    "XpToNextLevel": 112000,
+    "XpTotal": 23113750
+  },
+  {
+    "Level": 288,
+    "XpToNextLevel": 112500,
+    "XpTotal": 23226250
+  },
+  {
+    "Level": 289,
+    "XpToNextLevel": 113000,
+    "XpTotal": 23339250
+  },
+  {
+    "Level": 290,
+    "XpToNextLevel": 113750,
+    "XpTotal": 23453000
+  },
+  {
+    "Level": 291,
+    "XpToNextLevel": 114250,
+    "XpTotal": 23567250
+  },
+  {
+    "Level": 292,
+    "XpToNextLevel": 114750,
+    "XpTotal": 23682000
+  },
+  {
+    "Level": 293,
+    "XpToNextLevel": 115250,
+    "XpTotal": 23797250
+  },
+  {
+    "Level": 294,
+    "XpToNextLevel": 115750,
+    "XpTotal": 23913000
+  },
+  {
+    "Level": 295,
+    "XpToNextLevel": 116250,
+    "XpTotal": 24029250
+  },
+  {
+    "Level": 296,
+    "XpToNextLevel": 116750,
+    "XpTotal": 24146000
+  },
+  {
+    "Level": 297,
+    "XpToNextLevel": 117250,
+    "XpTotal": 24263250
+  },
+  {
+    "Level": 298,
+    "XpToNextLevel": 118000,
+    "XpTotal": 24381250
+  },
+  {
+    "Level": 299,
+    "XpToNextLevel": 118500,
+    "XpTotal": 24499750
+  },
+  {
+    "Level": 300,
+    "XpToNextLevel": 119000,
+    "XpTotal": 24618750
+  },
+  {
+    "Level": 301,
+    "XpToNextLevel": 119500,
+    "XpTotal": 24738250
+  },
+  {
+    "Level": 302,
+    "XpToNextLevel": 120000,
+    "XpTotal": 24858250
+  },
+  {
+    "Level": 303,
+    "XpToNextLevel": 120750,
+    "XpTotal": 24979000
+  },
+  {
+    "Level": 304,
+    "XpToNextLevel": 121250,
+    "XpTotal": 25100250
+  },
+  {
+    "Level": 305,
+    "XpToNextLevel": 121750,
+    "XpTotal": 25222000
+  },
+  {
+    "Level": 306,
+    "XpToNextLevel": 122250,
+    "XpTotal": 25344250
+  },
+  {
+    "Level": 307,
+    "XpToNextLevel": 123000,
+    "XpTotal": 25467250
+  },
+  {
+    "Level": 308,
+    "XpToNextLevel": 123500,
+    "XpTotal": 25590750
+  },
+  {
+    "Level": 309,
+    "XpToNextLevel": 124000,
+    "XpTotal": 25714750
+  },
+  {
+    "Level": 310,
+    "XpToNextLevel": 124750,
+    "XpTotal": 25839500
+  },
+  {
+    "Level": 311,
+    "XpToNextLevel": 125250,
+    "XpTotal": 25964750
+  },
+  {
+    "Level": 312,
+    "XpToNextLevel": 125750,
+    "XpTotal": 26090500
+  },
+  {
+    "Level": 313,
+    "XpToNextLevel": 126250,
+    "XpTotal": 26216750
+  },
+  {
+    "Level": 314,
+    "XpToNextLevel": 127000,
+    "XpTotal": 26343750
+  },
+  {
+    "Level": 315,
+    "XpToNextLevel": 127500,
+    "XpTotal": 26471250
+  },
+  {
+    "Level": 316,
+    "XpToNextLevel": 128250,
+    "XpTotal": 26599500
+  },
+  {
+    "Level": 317,
+    "XpToNextLevel": 128750,
+    "XpTotal": 26728250
+  },
+  {
+    "Level": 318,
+    "XpToNextLevel": 129250,
+    "XpTotal": 26857500
+  },
+  {
+    "Level": 319,
+    "XpToNextLevel": 130000,
+    "XpTotal": 26987500
+  },
+  {
+    "Level": 320,
+    "XpToNextLevel": 130500,
+    "XpTotal": 27118000
+  },
+  {
+    "Level": 321,
+    "XpToNextLevel": 131000,
+    "XpTotal": 27249000
+  },
+  {
+    "Level": 322,
+    "XpToNextLevel": 131750,
+    "XpTotal": 27380750
+  },
+  {
+    "Level": 323,
+    "XpToNextLevel": 132250,
+    "XpTotal": 27513000
+  },
+  {
+    "Level": 324,
+    "XpToNextLevel": 133000,
+    "XpTotal": 27646000
+  },
+  {
+    "Level": 325,
+    "XpToNextLevel": 133500,
+    "XpTotal": 27779500
+  },
+  {
+    "Level": 326,
+    "XpToNextLevel": 134250,
+    "XpTotal": 27913750
+  },
+  {
+    "Level": 327,
+    "XpToNextLevel": 134750,
+    "XpTotal": 28048500
+  },
+  {
+    "Level": 328,
+    "XpToNextLevel": 135500,
+    "XpTotal": 28184000
+  },
+  {
+    "Level": 329,
+    "XpToNextLevel": 136000,
+    "XpTotal": 28320000
+  },
+  {
+    "Level": 330,
+    "XpToNextLevel": 136750,
+    "XpTotal": 28456750
+  },
+  {
+    "Level": 331,
+    "XpToNextLevel": 137250,
+    "XpTotal": 28594000
+  },
+  {
+    "Level": 332,
+    "XpToNextLevel": 138000,
+    "XpTotal": 28732000
+  },
+  {
+    "Level": 333,
+    "XpToNextLevel": 138500,
+    "XpTotal": 28870500
+  },
+  {
+    "Level": 334,
+    "XpToNextLevel": 139250,
+    "XpTotal": 29009750
+  },
+  {
+    "Level": 335,
+    "XpToNextLevel": 140000,
+    "XpTotal": 29149750
+  },
+  {
+    "Level": 336,
+    "XpToNextLevel": 140500,
+    "XpTotal": 29290250
+  },
+  {
+    "Level": 337,
+    "XpToNextLevel": 141250,
+    "XpTotal": 29431500
+  },
+  {
+    "Level": 338,
+    "XpToNextLevel": 141750,
+    "XpTotal": 29573250
+  },
+  {
+    "Level": 339,
+    "XpToNextLevel": 142500,
+    "XpTotal": 29715750
+  },
+  {
+    "Level": 340,
+    "XpToNextLevel": 143250,
+    "XpTotal": 29859000
+  },
+  {
+    "Level": 341,
+    "XpToNextLevel": 143750,
+    "XpTotal": 30002750
+  },
+  {
+    "Level": 342,
+    "XpToNextLevel": 144500,
+    "XpTotal": 30147250
+  },
+  {
+    "Level": 343,
+    "XpToNextLevel": 145250,
+    "XpTotal": 30292500
+  },
+  {
+    "Level": 344,
+    "XpToNextLevel": 145750,
+    "XpTotal": 30438250
+  },
+  {
+    "Level": 345,
+    "XpToNextLevel": 146500,
+    "XpTotal": 30584750
+  },
+  {
+    "Level": 346,
+    "XpToNextLevel": 147250,
+    "XpTotal": 30732000
+  },
+  {
+    "Level": 347,
+    "XpToNextLevel": 147750,
+    "XpTotal": 30879750
+  },
+  {
+    "Level": 348,
+    "XpToNextLevel": 148500,
+    "XpTotal": 31028250
+  },
+  {
+    "Level": 349,
+    "XpToNextLevel": 149250,
+    "XpTotal": 31177500
+  },
+  {
+    "Level": 350,
+    "XpToNextLevel": 150000,
+    "XpTotal": 31327500
+  },
+  {
+    "Level": 351,
+    "XpToNextLevel": 150500,
+    "XpTotal": 31478000
+  },
+  {
+    "Level": 352,
+    "XpToNextLevel": 151250,
+    "XpTotal": 31629250
+  },
+  {
+    "Level": 353,
+    "XpToNextLevel": 152000,
+    "XpTotal": 31781250
+  },
+  {
+    "Level": 354,
+    "XpToNextLevel": 152750,
+    "XpTotal": 31934000
+  },
+  {
+    "Level": 355,
+    "XpToNextLevel": 153500,
+    "XpTotal": 32087500
+  },
+  {
+    "Level": 356,
+    "XpToNextLevel": 154000,
+    "XpTotal": 32241500
+  },
+  {
+    "Level": 357,
+    "XpToNextLevel": 154750,
+    "XpTotal": 32396250
+  },
+  {
+    "Level": 358,
+    "XpToNextLevel": 155500,
+    "XpTotal": 32551750
+  },
+  {
+    "Level": 359,
+    "XpToNextLevel": 156250,
+    "XpTotal": 32708000
+  },
+  {
+    "Level": 360,
+    "XpToNextLevel": 157000,
+    "XpTotal": 32865000
+  },
+  {
+    "Level": 361,
+    "XpToNextLevel": 157750,
+    "XpTotal": 33022750
+  },
+  {
+    "Level": 362,
+    "XpToNextLevel": 158500,
+    "XpTotal": 33181250
+  },
+  {
+    "Level": 363,
+    "XpToNextLevel": 159250,
+    "XpTotal": 33340500
+  },
+  {
+    "Level": 364,
+    "XpToNextLevel": 160000,
+    "XpTotal": 33500500
+  },
+  {
+    "Level": 365,
+    "XpToNextLevel": 160750,
+    "XpTotal": 33661250
+  },
+  {
+    "Level": 366,
+    "XpToNextLevel": 161500,
+    "XpTotal": 33822750
+  },
+  {
+    "Level": 367,
+    "XpToNextLevel": 162250,
+    "XpTotal": 33985000
+  },
+  {
+    "Level": 368,
+    "XpToNextLevel": 163000,
+    "XpTotal": 34148000
+  },
+  {
+    "Level": 369,
+    "XpToNextLevel": 163750,
+    "XpTotal": 34311750
+  },
+  {
+    "Level": 370,
+    "XpToNextLevel": 164500,
+    "XpTotal": 34476250
+  },
+  {
+    "Level": 371,
+    "XpToNextLevel": 165250,
+    "XpTotal": 34641500
+  },
+  {
+    "Level": 372,
+    "XpToNextLevel": 166000,
+    "XpTotal": 34807500
+  },
+  {
+    "Level": 373,
+    "XpToNextLevel": 166750,
+    "XpTotal": 34974250
+  },
+  {
+    "Level": 374,
+    "XpToNextLevel": 167500,
+    "XpTotal": 35141750
+  },
+  {
+    "Level": 375,
+    "XpToNextLevel": 168250,
+    "XpTotal": 35310000
+  },
+  {
+    "Level": 376,
+    "XpToNextLevel": 169000,
+    "XpTotal": 35479000
+  },
+  {
+    "Level": 377,
+    "XpToNextLevel": 169750,
+    "XpTotal": 35648750
+  },
+  {
+    "Level": 378,
+    "XpToNextLevel": 170500,
+    "XpTotal": 35819250
+  },
+  {
+    "Level": 379,
+    "XpToNextLevel": 171500,
+    "XpTotal": 35990750
+  },
+  {
+    "Level": 380,
+    "XpToNextLevel": 172250,
+    "XpTotal": 36163000
+  },
+  {
+    "Level": 381,
+    "XpToNextLevel": 173000,
+    "XpTotal": 36336000
+  },
+  {
+    "Level": 382,
+    "XpToNextLevel": 173750,
+    "XpTotal": 36509750
+  },
+  {
+    "Level": 383,
+    "XpToNextLevel": 174500,
+    "XpTotal": 36684250
+  },
+  {
+    "Level": 384,
+    "XpToNextLevel": 175500,
+    "XpTotal": 36859750
+  },
+  {
+    "Level": 385,
+    "XpToNextLevel": 176250,
+    "XpTotal": 37036000
+  },
+  {
+    "Level": 386,
+    "XpToNextLevel": 177000,
+    "XpTotal": 37213000
+  },
+  {
+    "Level": 387,
+    "XpToNextLevel": 177750,
+    "XpTotal": 37390750
+  },
+  {
+    "Level": 388,
+    "XpToNextLevel": 178750,
+    "XpTotal": 37569500
+  },
+  {
+    "Level": 389,
+    "XpToNextLevel": 179500,
+    "XpTotal": 37749000
+  },
+  {
+    "Level": 390,
+    "XpToNextLevel": 180250,
+    "XpTotal": 37929250
+  },
+  {
+    "Level": 391,
+    "XpToNextLevel": 181250,
+    "XpTotal": 38110500
+  },
+  {
+    "Level": 392,
+    "XpToNextLevel": 182000,
+    "XpTotal": 38292500
+  },
+  {
+    "Level": 393,
+    "XpToNextLevel": 182750,
+    "XpTotal": 38475250
+  },
+  {
+    "Level": 394,
+    "XpToNextLevel": 183750,
+    "XpTotal": 38659000
+  },
+  {
+    "Level": 395,
+    "XpToNextLevel": 184500,
+    "XpTotal": 38843500
+  },
+  {
+    "Level": 396,
+    "XpToNextLevel": 185500,
+    "XpTotal": 39029000
+  },
+  {
+    "Level": 397,
+    "XpToNextLevel": 186250,
+    "XpTotal": 39215250
+  },
+  {
+    "Level": 398,
+    "XpToNextLevel": 187000,
+    "XpTotal": 39402250
+  },
+  {
+    "Level": 399,
+    "XpToNextLevel": 188000,
+    "XpTotal": 39590250
+  },
+  {
+    "Level": 400,
+    "XpToNextLevel": 188750,
+    "XpTotal": 39779000
+  },
+  {
+    "Level": 401,
+    "XpToNextLevel": 189750,
+    "XpTotal": 39968750
+  },
+  {
+    "Level": 402,
+    "XpToNextLevel": 190500,
+    "XpTotal": 40159250
+  },
+  {
+    "Level": 403,
+    "XpToNextLevel": 191500,
+    "XpTotal": 40350750
+  },
+  {
+    "Level": 404,
+    "XpToNextLevel": 192250,
+    "XpTotal": 40543000
+  },
+  {
+    "Level": 405,
+    "XpToNextLevel": 193250,
+    "XpTotal": 40736250
+  },
+  {
+    "Level": 406,
+    "XpToNextLevel": 194250,
+    "XpTotal": 40930500
+  },
+  {
+    "Level": 407,
+    "XpToNextLevel": 195000,
+    "XpTotal": 41125500
+  },
+  {
+    "Level": 408,
+    "XpToNextLevel": 196000,
+    "XpTotal": 41321500
+  },
+  {
+    "Level": 409,
+    "XpToNextLevel": 196750,
+    "XpTotal": 41518250
+  },
+  {
+    "Level": 410,
+    "XpToNextLevel": 197750,
+    "XpTotal": 41716000
+  },
+  {
+    "Level": 411,
+    "XpToNextLevel": 198750,
+    "XpTotal": 41914750
+  },
+  {
+    "Level": 412,
+    "XpToNextLevel": 199500,
+    "XpTotal": 42114250
+  },
+  {
+    "Level": 413,
+    "XpToNextLevel": 200500,
+    "XpTotal": 42314750
+  },
+  {
+    "Level": 414,
+    "XpToNextLevel": 201500,
+    "XpTotal": 42516250
+  },
+  {
+    "Level": 415,
+    "XpToNextLevel": 202250,
+    "XpTotal": 42718500
+  },
+  {
+    "Level": 416,
+    "XpToNextLevel": 203250,
+    "XpTotal": 42921750
+  },
+  {
+    "Level": 417,
+    "XpToNextLevel": 204250,
+    "XpTotal": 43126000
+  },
+  {
+    "Level": 418,
+    "XpToNextLevel": 205250,
+    "XpTotal": 43331250
+  },
+  {
+    "Level": 419,
+    "XpToNextLevel": 206250,
+    "XpTotal": 43537500
+  },
+  {
+    "Level": 420,
+    "XpToNextLevel": 207000,
+    "XpTotal": 43744500
+  },
+  {
+    "Level": 421,
+    "XpToNextLevel": 208000,
+    "XpTotal": 43952500
+  },
+  {
+    "Level": 422,
+    "XpToNextLevel": 209000,
+    "XpTotal": 44161500
+  },
+  {
+    "Level": 423,
+    "XpToNextLevel": 210000,
+    "XpTotal": 44371500
+  },
+  {
+    "Level": 424,
+    "XpToNextLevel": 211000,
+    "XpTotal": 44582500
+  },
+  {
+    "Level": 425,
+    "XpToNextLevel": 212000,
+    "XpTotal": 44794500
+  },
+  {
+    "Level": 426,
+    "XpToNextLevel": 213000,
+    "XpTotal": 45007500
+  },
+  {
+    "Level": 427,
+    "XpToNextLevel": 214000,
+    "XpTotal": 45221500
+  },
+  {
+    "Level": 428,
+    "XpToNextLevel": 215000,
+    "XpTotal": 45436500
+  },
+  {
+    "Level": 429,
+    "XpToNextLevel": 216000,
+    "XpTotal": 45652500
+  },
+  {
+    "Level": 430,
+    "XpToNextLevel": 217000,
+    "XpTotal": 45869500
+  },
+  {
+    "Level": 431,
+    "XpToNextLevel": 218000,
+    "XpTotal": 46087500
+  },
+  {
+    "Level": 432,
+    "XpToNextLevel": 219000,
+    "XpTotal": 46306500
+  },
+  {
+    "Level": 433,
+    "XpToNextLevel": 220000,
+    "XpTotal": 46526500
+  },
+  {
+    "Level": 434,
+    "XpToNextLevel": 221000,
+    "XpTotal": 46747500
+  },
+  {
+    "Level": 435,
+    "XpToNextLevel": 222000,
+    "XpTotal": 46969500
+  },
+  {
+    "Level": 436,
+    "XpToNextLevel": 223000,
+    "XpTotal": 47192500
+  },
+  {
+    "Level": 437,
+    "XpToNextLevel": 224000,
+    "XpTotal": 47416500
+  },
+  {
+    "Level": 438,
+    "XpToNextLevel": 225000,
+    "XpTotal": 47641500
+  },
+  {
+    "Level": 439,
+    "XpToNextLevel": 226000,
+    "XpTotal": 47867500
+  },
+  {
+    "Level": 440,
+    "XpToNextLevel": 227250,
+    "XpTotal": 48094750
+  },
+  {
+    "Level": 441,
+    "XpToNextLevel": 228250,
+    "XpTotal": 48323000
+  },
+  {
+    "Level": 442,
+    "XpToNextLevel": 229250,
+    "XpTotal": 48552250
+  },
+  {
+    "Level": 443,
+    "XpToNextLevel": 230250,
+    "XpTotal": 48782500
+  },
+  {
+    "Level": 444,
+    "XpToNextLevel": 231250,
+    "XpTotal": 49013750
+  },
+  {
+    "Level": 445,
+    "XpToNextLevel": 232500,
+    "XpTotal": 49246250
+  },
+  {
+    "Level": 446,
+    "XpToNextLevel": 233500,
+    "XpTotal": 49479750
+  },
+  {
+    "Level": 447,
+    "XpToNextLevel": 234500,
+    "XpTotal": 49714250
+  },
+  {
+    "Level": 448,
+    "XpToNextLevel": 235750,
+    "XpTotal": 49950000
+  },
+  {
+    "Level": 449,
+    "XpToNextLevel": 236750,
+    "XpTotal": 50186750
+  },
+  {
+    "Level": 450,
+    "XpToNextLevel": 237750,
+    "XpTotal": 50424500
+  },
+  {
+    "Level": 451,
+    "XpToNextLevel": 239000,
+    "XpTotal": 50663500
+  },
+  {
+    "Level": 452,
+    "XpToNextLevel": 240000,
+    "XpTotal": 50903500
+  },
+  {
+    "Level": 453,
+    "XpToNextLevel": 241250,
+    "XpTotal": 51144750
+  },
+  {
+    "Level": 454,
+    "XpToNextLevel": 242250,
+    "XpTotal": 51387000
+  },
+  {
+    "Level": 455,
+    "XpToNextLevel": 243500,
+    "XpTotal": 51630500
+  },
+  {
+    "Level": 456,
+    "XpToNextLevel": 244500,
+    "XpTotal": 51875000
+  },
+  {
+    "Level": 457,
+    "XpToNextLevel": 245750,
+    "XpTotal": 52120750
+  },
+  {
+    "Level": 458,
+    "XpToNextLevel": 246750,
+    "XpTotal": 52367500
+  },
+  {
+    "Level": 459,
+    "XpToNextLevel": 248000,
+    "XpTotal": 52615500
+  },
+  {
+    "Level": 460,
+    "XpToNextLevel": 249000,
+    "XpTotal": 52864500
+  },
+  {
+    "Level": 461,
+    "XpToNextLevel": 250250,
+    "XpTotal": 53114750
+  },
+  {
+    "Level": 462,
+    "XpToNextLevel": 251500,
+    "XpTotal": 53366250
+  },
+  {
+    "Level": 463,
+    "XpToNextLevel": 252500,
+    "XpTotal": 53618750
+  },
+  {
+    "Level": 464,
+    "XpToNextLevel": 253750,
+    "XpTotal": 53872500
+  },
+  {
+    "Level": 465,
+    "XpToNextLevel": 255000,
+    "XpTotal": 54127500
+  },
+  {
+    "Level": 466,
+    "XpToNextLevel": 256000,
+    "XpTotal": 54383500
+  },
+  {
+    "Level": 467,
+    "XpToNextLevel": 257250,
+    "XpTotal": 54640750
+  },
+  {
+    "Level": 468,
+    "XpToNextLevel": 258500,
+    "XpTotal": 54899250
+  },
+  {
+    "Level": 469,
+    "XpToNextLevel": 259750,
+    "XpTotal": 55159000
+  },
+  {
+    "Level": 470,
+    "XpToNextLevel": 261000,
+    "XpTotal": 55420000
+  },
+  {
+    "Level": 471,
+    "XpToNextLevel": 262000,
+    "XpTotal": 55682000
+  },
+  {
+    "Level": 472,
+    "XpToNextLevel": 263250,
+    "XpTotal": 55945250
+  },
+  {
+    "Level": 473,
+    "XpToNextLevel": 264500,
+    "XpTotal": 56209750
+  },
+  {
+    "Level": 474,
+    "XpToNextLevel": 265750,
+    "XpTotal": 56475500
+  },
+  {
+    "Level": 475,
+    "XpToNextLevel": 267000,
+    "XpTotal": 56742500
+  },
+  {
+    "Level": 476,
+    "XpToNextLevel": 268250,
+    "XpTotal": 57010750
+  },
+  {
+    "Level": 477,
+    "XpToNextLevel": 269500,
+    "XpTotal": 57280250
+  },
+  {
+    "Level": 478,
+    "XpToNextLevel": 270750,
+    "XpTotal": 57551000
+  },
+  {
+    "Level": 479,
+    "XpToNextLevel": 272000,
+    "XpTotal": 57823000
+  },
+  {
+    "Level": 480,
+    "XpToNextLevel": 273250,
+    "XpTotal": 58096250
+  },
+  {
+    "Level": 481,
+    "XpToNextLevel": 274500,
+    "XpTotal": 58370750
+  },
+  {
+    "Level": 482,
+    "XpToNextLevel": 275750,
+    "XpTotal": 58646500
+  },
+  {
+    "Level": 483,
+    "XpToNextLevel": 277000,
+    "XpTotal": 58923500
+  },
+  {
+    "Level": 484,
+    "XpToNextLevel": 278250,
+    "XpTotal": 59201750
+  },
+  {
+    "Level": 485,
+    "XpToNextLevel": 279500,
+    "XpTotal": 59481250
+  },
+  {
+    "Level": 486,
+    "XpToNextLevel": 281000,
+    "XpTotal": 59762250
+  },
+  {
+    "Level": 487,
+    "XpToNextLevel": 282250,
+    "XpTotal": 60044500
+  },
+  {
+    "Level": 488,
+    "XpToNextLevel": 283500,
+    "XpTotal": 60328000
+  },
+  {
+    "Level": 489,
+    "XpToNextLevel": 284750,
+    "XpTotal": 60612750
+  },
+  {
+    "Level": 490,
+    "XpToNextLevel": 286000,
+    "XpTotal": 60898750
+  },
+  {
+    "Level": 491,
+    "XpToNextLevel": 287500,
+    "XpTotal": 61186250
+  },
+  {
+    "Level": 492,
+    "XpToNextLevel": 288750,
+    "XpTotal": 61475000
+  },
+  {
+    "Level": 493,
+    "XpToNextLevel": 290000,
+    "XpTotal": 61765000
+  },
+  {
+    "Level": 494,
+    "XpToNextLevel": 291500,
+    "XpTotal": 62056500
+  },
+  {
+    "Level": 495,
+    "XpToNextLevel": 292750,
+    "XpTotal": 62349250
+  },
+  {
+    "Level": 496,
+    "XpToNextLevel": 294250,
+    "XpTotal": 62643500
+  },
+  {
+    "Level": 497,
+    "XpToNextLevel": 295500,
+    "XpTotal": 62939000
+  },
+  {
+    "Level": 498,
+    "XpToNextLevel": 297000,
+    "XpTotal": 63236000
+  },
+  {
+    "Level": 499,
+    "XpToNextLevel": 298250,
+    "XpTotal": 63534250
+  },
+  {
+    "Level": 500,
+    "XpToNextLevel": 299750,
+    "XpTotal": 63834000
+  },
+  {
+    "Level": 501,
+    "XpToNextLevel": 301000,
+    "XpTotal": 64135000
+  },
+  {
+    "Level": 502,
+    "XpToNextLevel": 302500,
+    "XpTotal": 64437500
+  },
+  {
+    "Level": 503,
+    "XpToNextLevel": 303750,
+    "XpTotal": 64741250
+  },
+  {
+    "Level": 504,
+    "XpToNextLevel": 305250,
+    "XpTotal": 65046500
+  },
+  {
+    "Level": 505,
+    "XpToNextLevel": 306750,
+    "XpTotal": 65353250
+  },
+  {
+    "Level": 506,
+    "XpToNextLevel": 308000,
+    "XpTotal": 65661250
+  },
+  {
+    "Level": 507,
+    "XpToNextLevel": 309500,
+    "XpTotal": 65970750
+  },
+  {
+    "Level": 508,
+    "XpToNextLevel": 311000,
+    "XpTotal": 66281750
+  },
+  {
+    "Level": 509,
+    "XpToNextLevel": 312250,
+    "XpTotal": 66594000
+  },
+  {
+    "Level": 510,
+    "XpToNextLevel": 313750,
+    "XpTotal": 66907750
+  },
+  {
+    "Level": 511,
+    "XpToNextLevel": 315250,
+    "XpTotal": 67223000
+  },
+  {
+    "Level": 512,
+    "XpToNextLevel": 316750,
+    "XpTotal": 67539750
+  },
+  {
+    "Level": 513,
+    "XpToNextLevel": 318250,
+    "XpTotal": 67858000
+  },
+  {
+    "Level": 514,
+    "XpToNextLevel": 319750,
+    "XpTotal": 68177750
+  },
+  {
+    "Level": 515,
+    "XpToNextLevel": 321000,
+    "XpTotal": 68498750
+  },
+  {
+    "Level": 516,
+    "XpToNextLevel": 322500,
+    "XpTotal": 68821250
+  },
+  {
+    "Level": 517,
+    "XpToNextLevel": 324000,
+    "XpTotal": 69145250
+  },
+  {
+    "Level": 518,
+    "XpToNextLevel": 325500,
+    "XpTotal": 69470750
+  },
+  {
+    "Level": 519,
+    "XpToNextLevel": 327000,
+    "XpTotal": 69797750
+  },
+  {
+    "Level": 520,
+    "XpToNextLevel": 328500,
+    "XpTotal": 70126250
+  },
+  {
+    "Level": 521,
+    "XpToNextLevel": 330250,
+    "XpTotal": 70456500
+  },
+  {
+    "Level": 522,
+    "XpToNextLevel": 331750,
+    "XpTotal": 70788250
+  },
+  {
+    "Level": 523,
+    "XpToNextLevel": 333250,
+    "XpTotal": 71121500
+  },
+  {
+    "Level": 524,
+    "XpToNextLevel": 334750,
+    "XpTotal": 71456250
+  },
+  {
+    "Level": 525,
+    "XpToNextLevel": 336250,
+    "XpTotal": 71792500
+  },
+  {
+    "Level": 526,
+    "XpToNextLevel": 337750,
+    "XpTotal": 72130250
+  },
+  {
+    "Level": 527,
+    "XpToNextLevel": 339500,
+    "XpTotal": 72469750
+  },
+  {
+    "Level": 528,
+    "XpToNextLevel": 341000,
+    "XpTotal": 72810750
+  },
+  {
+    "Level": 529,
+    "XpToNextLevel": 342500,
+    "XpTotal": 73153250
+  },
+  {
+    "Level": 530,
+    "XpToNextLevel": 344250,
+    "XpTotal": 73497500
+  },
+  {
+    "Level": 531,
+    "XpToNextLevel": 345750,
+    "XpTotal": 73843250
+  },
+  {
+    "Level": 532,
+    "XpToNextLevel": 347250,
+    "XpTotal": 74190500
+  },
+  {
+    "Level": 533,
+    "XpToNextLevel": 349000,
+    "XpTotal": 74539500
+  },
+  {
+    "Level": 534,
+    "XpToNextLevel": 350500,
+    "XpTotal": 74890000
+  },
+  {
+    "Level": 535,
+    "XpToNextLevel": 352250,
+    "XpTotal": 75242250
+  },
+  {
+    "Level": 536,
+    "XpToNextLevel": 353750,
+    "XpTotal": 75596000
+  },
+  {
+    "Level": 537,
+    "XpToNextLevel": 355500,
+    "XpTotal": 75951500
+  },
+  {
+    "Level": 538,
+    "XpToNextLevel": 357000,
+    "XpTotal": 76308500
+  },
+  {
+    "Level": 539,
+    "XpToNextLevel": 358750,
+    "XpTotal": 76667250
+  },
+  {
+    "Level": 540,
+    "XpToNextLevel": 360500,
+    "XpTotal": 77027750
+  },
+  {
+    "Level": 541,
+    "XpToNextLevel": 362000,
+    "XpTotal": 77389750
+  },
+  {
+    "Level": 542,
+    "XpToNextLevel": 363750,
+    "XpTotal": 77753500
+  },
+  {
+    "Level": 543,
+    "XpToNextLevel": 365500,
+    "XpTotal": 78119000
+  },
+  {
+    "Level": 544,
+    "XpToNextLevel": 367000,
+    "XpTotal": 78486000
+  },
+  {
+    "Level": 545,
+    "XpToNextLevel": 368750,
+    "XpTotal": 78854750
+  },
+  {
+    "Level": 546,
+    "XpToNextLevel": 370500,
+    "XpTotal": 79225250
+  },
+  {
+    "Level": 547,
+    "XpToNextLevel": 372250,
+    "XpTotal": 79597500
+  },
+  {
+    "Level": 548,
+    "XpToNextLevel": 374000,
+    "XpTotal": 79971500
+  },
+  {
+    "Level": 549,
+    "XpToNextLevel": 375750,
+    "XpTotal": 80347250
+  },
+  {
+    "Level": 550,
+    "XpToNextLevel": 377500,
+    "XpTotal": 80724750
+  },
+  {
+    "Level": 551,
+    "XpToNextLevel": 379250,
+    "XpTotal": 81104000
+  },
+  {
+    "Level": 552,
+    "XpToNextLevel": 381000,
+    "XpTotal": 81485000
+  },
+  {
+    "Level": 553,
+    "XpToNextLevel": 382750,
+    "XpTotal": 81867750
+  },
+  {
+    "Level": 554,
+    "XpToNextLevel": 384500,
+    "XpTotal": 82252250
+  },
+  {
+    "Level": 555,
+    "XpToNextLevel": 386250,
+    "XpTotal": 82638500
+  },
+  {
+    "Level": 556,
+    "XpToNextLevel": 388000,
+    "XpTotal": 83026500
+  },
+  {
+    "Level": 557,
+    "XpToNextLevel": 389750,
+    "XpTotal": 83416250
+  },
+  {
+    "Level": 558,
+    "XpToNextLevel": 391750,
+    "XpTotal": 83808000
+  },
+  {
+    "Level": 559,
+    "XpToNextLevel": 393500,
+    "XpTotal": 84201500
+  },
+  {
+    "Level": 560,
+    "XpToNextLevel": 395250,
+    "XpTotal": 84596750
+  },
+  {
+    "Level": 561,
+    "XpToNextLevel": 397000,
+    "XpTotal": 84993750
+  },
+  {
+    "Level": 562,
+    "XpToNextLevel": 399000,
+    "XpTotal": 85392750
+  },
+  {
+    "Level": 563,
+    "XpToNextLevel": 400750,
+    "XpTotal": 85793500
+  },
+  {
+    "Level": 564,
+    "XpToNextLevel": 402750,
+    "XpTotal": 86196250
+  },
+  {
+    "Level": 565,
+    "XpToNextLevel": 404500,
+    "XpTotal": 86600750
+  },
+  {
+    "Level": 566,
+    "XpToNextLevel": 406250,
+    "XpTotal": 87007000
+  },
+  {
+    "Level": 567,
+    "XpToNextLevel": 408250,
+    "XpTotal": 87415250
+  },
+  {
+    "Level": 568,
+    "XpToNextLevel": 410250,
+    "XpTotal": 87825500
+  },
+  {
+    "Level": 569,
+    "XpToNextLevel": 412000,
+    "XpTotal": 88237500
+  },
+  {
+    "Level": 570,
+    "XpToNextLevel": 414000,
+    "XpTotal": 88651500
+  },
+  {
+    "Level": 571,
+    "XpToNextLevel": 415750,
+    "XpTotal": 89067250
+  },
+  {
+    "Level": 572,
+    "XpToNextLevel": 417750,
+    "XpTotal": 89485000
+  },
+  {
+    "Level": 573,
+    "XpToNextLevel": 419750,
+    "XpTotal": 89904750
+  },
+  {
+    "Level": 574,
+    "XpToNextLevel": 421750,
+    "XpTotal": 90326500
+  },
+  {
+    "Level": 575,
+    "XpToNextLevel": 423500,
+    "XpTotal": 90750000
+  },
+  {
+    "Level": 576,
+    "XpToNextLevel": 425500,
+    "XpTotal": 91175500
+  },
+  {
+    "Level": 577,
+    "XpToNextLevel": 427500,
+    "XpTotal": 91603000
+  },
+  {
+    "Level": 578,
+    "XpToNextLevel": 429500,
+    "XpTotal": 92032500
+  },
+  {
+    "Level": 579,
+    "XpToNextLevel": 431500,
+    "XpTotal": 92464000
+  },
+  {
+    "Level": 580,
+    "XpToNextLevel": 433500,
+    "XpTotal": 92897500
+  },
+  {
+    "Level": 581,
+    "XpToNextLevel": 435500,
+    "XpTotal": 93333000
+  },
+  {
+    "Level": 582,
+    "XpToNextLevel": 437500,
+    "XpTotal": 93770500
+  },
+  {
+    "Level": 583,
+    "XpToNextLevel": 439500,
+    "XpTotal": 94210000
+  },
+  {
+    "Level": 584,
+    "XpToNextLevel": 441500,
+    "XpTotal": 94651500
+  },
+  {
+    "Level": 585,
+    "XpToNextLevel": 443750,
+    "XpTotal": 95095250
+  },
+  {
+    "Level": 586,
+    "XpToNextLevel": 445750,
+    "XpTotal": 95541000
+  },
+  {
+    "Level": 587,
+    "XpToNextLevel": 447750,
+    "XpTotal": 95988750
+  },
+  {
+    "Level": 588,
+    "XpToNextLevel": 449750,
+    "XpTotal": 96438500
+  },
+  {
+    "Level": 589,
+    "XpToNextLevel": 452000,
+    "XpTotal": 96890500
+  },
+  {
+    "Level": 590,
+    "XpToNextLevel": 454000,
+    "XpTotal": 97344500
+  },
+  {
+    "Level": 591,
+    "XpToNextLevel": 456000,
+    "XpTotal": 97800500
+  },
+  {
+    "Level": 592,
+    "XpToNextLevel": 458250,
+    "XpTotal": 98258750
+  },
+  {
+    "Level": 593,
+    "XpToNextLevel": 460250,
+    "XpTotal": 98719000
+  },
+  {
+    "Level": 594,
+    "XpToNextLevel": 462500,
+    "XpTotal": 99181500
+  },
+  {
+    "Level": 595,
+    "XpToNextLevel": 464500,
+    "XpTotal": 99646000
+  },
+  {
+    "Level": 596,
+    "XpToNextLevel": 466750,
+    "XpTotal": 100112750
+  },
+  {
+    "Level": 597,
+    "XpToNextLevel": 469000,
+    "XpTotal": 100581750
+  },
+  {
+    "Level": 598,
+    "XpToNextLevel": 471000,
+    "XpTotal": 101052750
+  },
+  {
+    "Level": 599,
+    "XpToNextLevel": 473250,
+    "XpTotal": 101526000
+  },
+  {
+    "Level": 600,
+    "XpToNextLevel": 475500,
+    "XpTotal": 102001500
+  },
+  {
+    "Level": 601,
+    "XpToNextLevel": 477750,
+    "XpTotal": 102479250
+  },
+  {
+    "Level": 602,
+    "XpToNextLevel": 479750,
+    "XpTotal": 102959000
+  },
+  {
+    "Level": 603,
+    "XpToNextLevel": 482000,
+    "XpTotal": 103441000
+  },
+  {
+    "Level": 604,
+    "XpToNextLevel": 484250,
+    "XpTotal": 103925250
+  },
+  {
+    "Level": 605,
+    "XpToNextLevel": 486500,
+    "XpTotal": 104411750
+  },
+  {
+    "Level": 606,
+    "XpToNextLevel": 488750,
+    "XpTotal": 104900500
+  },
+  {
+    "Level": 607,
+    "XpToNextLevel": 491000,
+    "XpTotal": 105391500
+  },
+  {
+    "Level": 608,
+    "XpToNextLevel": 493250,
+    "XpTotal": 105884750
+  },
+  {
+    "Level": 609,
+    "XpToNextLevel": 495500,
+    "XpTotal": 106380250
+  },
+  {
+    "Level": 610,
+    "XpToNextLevel": 498000,
+    "XpTotal": 106878250
+  },
+  {
+    "Level": 611,
+    "XpToNextLevel": 500250,
+    "XpTotal": 107378500
+  },
+  {
+    "Level": 612,
+    "XpToNextLevel": 502500,
+    "XpTotal": 107881000
+  },
+  {
+    "Level": 613,
+    "XpToNextLevel": 504750,
+    "XpTotal": 108385750
+  },
+  {
+    "Level": 614,
+    "XpToNextLevel": 507250,
+    "XpTotal": 108893000
+  },
+  {
+    "Level": 615,
+    "XpToNextLevel": 509500,
+    "XpTotal": 109402500
+  },
+  {
+    "Level": 616,
+    "XpToNextLevel": 512000,
+    "XpTotal": 109914500
+  },
+  {
+    "Level": 617,
+    "XpToNextLevel": 514250,
+    "XpTotal": 110428750
+  },
+  {
+    "Level": 618,
+    "XpToNextLevel": 516750,
+    "XpTotal": 110945500
+  },
+  {
+    "Level": 619,
+    "XpToNextLevel": 519000,
+    "XpTotal": 111464500
+  },
+  {
+    "Level": 620,
+    "XpToNextLevel": 521500,
+    "XpTotal": 111986000
+  },
+  {
+    "Level": 621,
+    "XpToNextLevel": 523750,
+    "XpTotal": 112509750
+  },
+  {
+    "Level": 622,
+    "XpToNextLevel": 526250,
+    "XpTotal": 113036000
+  },
+  {
+    "Level": 623,
+    "XpToNextLevel": 528750,
+    "XpTotal": 113564750
+  },
+  {
+    "Level": 624,
+    "XpToNextLevel": 531250,
+    "XpTotal": 114096000
+  },
+  {
+    "Level": 625,
+    "XpToNextLevel": 533500,
+    "XpTotal": 114629500
+  },
+  {
+    "Level": 626,
+    "XpToNextLevel": 536000,
+    "XpTotal": 115165500
+  },
+  {
+    "Level": 627,
+    "XpToNextLevel": 538500,
+    "XpTotal": 115704000
+  },
+  {
+    "Level": 628,
+    "XpToNextLevel": 541000,
+    "XpTotal": 116245000
+  },
+  {
+    "Level": 629,
+    "XpToNextLevel": 543500,
+    "XpTotal": 116788500
+  },
+  {
+    "Level": 630,
+    "XpToNextLevel": 546000,
+    "XpTotal": 117334500
+  },
+  {
+    "Level": 631,
+    "XpToNextLevel": 548500,
+    "XpTotal": 117883000
+  },
+  {
+    "Level": 632,
+    "XpToNextLevel": 551250,
+    "XpTotal": 118434250
+  },
+  {
+    "Level": 633,
+    "XpToNextLevel": 553750,
+    "XpTotal": 118988000
+  },
+  {
+    "Level": 634,
+    "XpToNextLevel": 556250,
+    "XpTotal": 119544250
+  },
+  {
+    "Level": 635,
+    "XpToNextLevel": 558750,
+    "XpTotal": 120103000
+  },
+  {
+    "Level": 636,
+    "XpToNextLevel": 561500,
+    "XpTotal": 120664500
+  },
+  {
+    "Level": 637,
+    "XpToNextLevel": 564000,
+    "XpTotal": 121228500
+  },
+  {
+    "Level": 638,
+    "XpToNextLevel": 566500,
+    "XpTotal": 121795000
+  },
+  {
+    "Level": 639,
+    "XpToNextLevel": 569250,
+    "XpTotal": 122364250
+  },
+  {
+    "Level": 640,
+    "XpToNextLevel": 571750,
+    "XpTotal": 122936000
+  },
+  {
+    "Level": 641,
+    "XpToNextLevel": 574500,
+    "XpTotal": 123510500
+  },
+  {
+    "Level": 642,
+    "XpToNextLevel": 577250,
+    "XpTotal": 124087750
+  },
+  {
+    "Level": 643,
+    "XpToNextLevel": 579750,
+    "XpTotal": 124667500
+  },
+  {
+    "Level": 644,
+    "XpToNextLevel": 582500,
+    "XpTotal": 125250000
+  },
+  {
+    "Level": 645,
+    "XpToNextLevel": 585250,
+    "XpTotal": 125835250
+  },
+  {
+    "Level": 646,
+    "XpToNextLevel": 588000,
+    "XpTotal": 126423250
+  },
+  {
+    "Level": 647,
+    "XpToNextLevel": 590750,
+    "XpTotal": 127014000
+  },
+  {
+    "Level": 648,
+    "XpToNextLevel": 593500,
+    "XpTotal": 127607500
+  },
+  {
+    "Level": 649,
+    "XpToNextLevel": 596250,
+    "XpTotal": 128203750
+  },
+  {
+    "Level": 650,
+    "XpToNextLevel": 599000,
+    "XpTotal": 128802750
+  },
+  {
+    "Level": 651,
+    "XpToNextLevel": 601750,
+    "XpTotal": 129404500
+  },
+  {
+    "Level": 652,
+    "XpToNextLevel": 604500,
+    "XpTotal": 130009000
+  },
+  {
+    "Level": 653,
+    "XpToNextLevel": 607250,
+    "XpTotal": 130616250
+  },
+  {
+    "Level": 654,
+    "XpToNextLevel": 610000,
+    "XpTotal": 131226250
+  },
+  {
+    "Level": 655,
+    "XpToNextLevel": 613000,
+    "XpTotal": 131839250
+  },
+  {
+    "Level": 656,
+    "XpToNextLevel": 615750,
+    "XpTotal": 132455000
+  },
+  {
+    "Level": 657,
+    "XpToNextLevel": 618500,
+    "XpTotal": 133073500
+  },
+  {
+    "Level": 658,
+    "XpToNextLevel": 621500,
+    "XpTotal": 133695000
+  },
+  {
+    "Level": 659,
+    "XpToNextLevel": 624250,
+    "XpTotal": 134319250
+  },
+  {
+    "Level": 660,
+    "XpToNextLevel": 627250,
+    "XpTotal": 134946500
+  },
+  {
+    "Level": 661,
+    "XpToNextLevel": 630000,
+    "XpTotal": 135576500
+  },
+  {
+    "Level": 662,
+    "XpToNextLevel": 633000,
+    "XpTotal": 136209500
+  },
+  {
+    "Level": 663,
+    "XpToNextLevel": 636000,
+    "XpTotal": 136845500
+  },
+  {
+    "Level": 664,
+    "XpToNextLevel": 639000,
+    "XpTotal": 137484500
+  },
+  {
+    "Level": 665,
+    "XpToNextLevel": 641750,
+    "XpTotal": 138126250
+  },
+  {
+    "Level": 666,
+    "XpToNextLevel": 644750,
+    "XpTotal": 138771000
+  },
+  {
+    "Level": 667,
+    "XpToNextLevel": 647750,
+    "XpTotal": 139418750
+  },
+  {
+    "Level": 668,
+    "XpToNextLevel": 650750,
+    "XpTotal": 140069500
+  },
+  {
+    "Level": 669,
+    "XpToNextLevel": 653750,
+    "XpTotal": 140723250
+  },
+  {
+    "Level": 670,
+    "XpToNextLevel": 656750,
+    "XpTotal": 141380000
+  },
+  {
+    "Level": 671,
+    "XpToNextLevel": 659750,
+    "XpTotal": 142039750
+  },
+  {
+    "Level": 672,
+    "XpToNextLevel": 663000,
+    "XpTotal": 142702750
+  },
+  {
+    "Level": 673,
+    "XpToNextLevel": 666000,
+    "XpTotal": 143368750
+  },
+  {
+    "Level": 674,
+    "XpToNextLevel": 669000,
+    "XpTotal": 144037750
+  },
+  {
+    "Level": 675,
+    "XpToNextLevel": 672250,
+    "XpTotal": 144710000
+  },
+  {
+    "Level": 676,
+    "XpToNextLevel": 675250,
+    "XpTotal": 145385250
+  },
+  {
+    "Level": 677,
+    "XpToNextLevel": 678500,
+    "XpTotal": 146063750
+  },
+  {
+    "Level": 678,
+    "XpToNextLevel": 681500,
+    "XpTotal": 146745250
+  },
+  {
+    "Level": 679,
+    "XpToNextLevel": 684750,
+    "XpTotal": 147430000
+  },
+  {
+    "Level": 680,
+    "XpToNextLevel": 687750,
+    "XpTotal": 148117750
+  },
+  {
+    "Level": 681,
+    "XpToNextLevel": 691000,
+    "XpTotal": 148808750
+  },
+  {
+    "Level": 682,
+    "XpToNextLevel": 694250,
+    "XpTotal": 149503000
+  },
+  {
+    "Level": 683,
+    "XpToNextLevel": 697500,
+    "XpTotal": 150200500
+  },
+  {
+    "Level": 684,
+    "XpToNextLevel": 700750,
+    "XpTotal": 150901250
+  },
+  {
+    "Level": 685,
+    "XpToNextLevel": 704000,
+    "XpTotal": 151605250
+  },
+  {
+    "Level": 686,
+    "XpToNextLevel": 707250,
+    "XpTotal": 152312500
+  },
+  {
+    "Level": 687,
+    "XpToNextLevel": 710500,
+    "XpTotal": 153023000
+  },
+  {
+    "Level": 688,
+    "XpToNextLevel": 713750,
+    "XpTotal": 153736750
+  },
+  {
+    "Level": 689,
+    "XpToNextLevel": 717000,
+    "XpTotal": 154453750
+  },
+  {
+    "Level": 690,
+    "XpToNextLevel": 720250,
+    "XpTotal": 155174000
+  },
+  {
+    "Level": 691,
+    "XpToNextLevel": 723750,
+    "XpTotal": 155897750
+  },
+  {
+    "Level": 692,
+    "XpToNextLevel": 727000,
+    "XpTotal": 156624750
+  },
+  {
+    "Level": 693,
+    "XpToNextLevel": 730500,
+    "XpTotal": 157355250
+  },
+  {
+    "Level": 694,
+    "XpToNextLevel": 733750,
+    "XpTotal": 158089000
+  },
+  {
+    "Level": 695,
+    "XpToNextLevel": 737250,
+    "XpTotal": 158826250
+  },
+  {
+    "Level": 696,
+    "XpToNextLevel": 740500,
+    "XpTotal": 159566750
+  },
+  {
+    "Level": 697,
+    "XpToNextLevel": 744000,
+    "XpTotal": 160310750
+  },
+  {
+    "Level": 698,
+    "XpToNextLevel": 747500,
+    "XpTotal": 161058250
+  },
+  {
+    "Level": 699,
+    "XpToNextLevel": 751000,
+    "XpTotal": 161809250
+  },
+  {
+    "Level": 700,
+    "XpToNextLevel": 754500,
+    "XpTotal": 162563750
+  },
+  {
+    "Level": 701,
+    "XpToNextLevel": 758000,
+    "XpTotal": 163321750
+  },
+  {
+    "Level": 702,
+    "XpToNextLevel": 761500,
+    "XpTotal": 164083250
+  },
+  {
+    "Level": 703,
+    "XpToNextLevel": 765000,
+    "XpTotal": 164848250
+  },
+  {
+    "Level": 704,
+    "XpToNextLevel": 768500,
+    "XpTotal": 165616750
+  },
+  {
+    "Level": 705,
+    "XpToNextLevel": 772000,
+    "XpTotal": 166388750
+  },
+  {
+    "Level": 706,
+    "XpToNextLevel": 775500,
+    "XpTotal": 167164250
+  },
+  {
+    "Level": 707,
+    "XpToNextLevel": 779250,
+    "XpTotal": 167943500
+  },
+  {
+    "Level": 708,
+    "XpToNextLevel": 782750,
+    "XpTotal": 168726250
+  },
+  {
+    "Level": 709,
+    "XpToNextLevel": 786500,
+    "XpTotal": 169512750
+  },
+  {
+    "Level": 710,
+    "XpToNextLevel": 790000,
+    "XpTotal": 170302750
+  },
+  {
+    "Level": 711,
+    "XpToNextLevel": 793750,
+    "XpTotal": 171096500
+  },
+  {
+    "Level": 712,
+    "XpToNextLevel": 797500,
+    "XpTotal": 171894000
+  },
+  {
+    "Level": 713,
+    "XpToNextLevel": 801000,
+    "XpTotal": 172695000
+  },
+  {
+    "Level": 714,
+    "XpToNextLevel": 804750,
+    "XpTotal": 173499750
+  },
+  {
+    "Level": 715,
+    "XpToNextLevel": 808500,
+    "XpTotal": 174308250
+  },
+  {
+    "Level": 716,
+    "XpToNextLevel": 812250,
+    "XpTotal": 175120500
+  },
+  {
+    "Level": 717,
+    "XpToNextLevel": 816000,
+    "XpTotal": 175936500
+  },
+  {
+    "Level": 718,
+    "XpToNextLevel": 819750,
+    "XpTotal": 176756250
+  },
+  {
+    "Level": 719,
+    "XpToNextLevel": 823500,
+    "XpTotal": 177579750
+  },
+  {
+    "Level": 720,
+    "XpToNextLevel": 827500,
+    "XpTotal": 178407250
+  },
+  {
+    "Level": 721,
+    "XpToNextLevel": 831250,
+    "XpTotal": 179238500
+  },
+  {
+    "Level": 722,
+    "XpToNextLevel": 835000,
+    "XpTotal": 180073500
+  },
+  {
+    "Level": 723,
+    "XpToNextLevel": 839000,
+    "XpTotal": 180912500
+  },
+  {
+    "Level": 724,
+    "XpToNextLevel": 842750,
+    "XpTotal": 181755250
+  },
+  {
+    "Level": 725,
+    "XpToNextLevel": 846750,
+    "XpTotal": 182602000
+  },
+  {
+    "Level": 726,
+    "XpToNextLevel": 850500,
+    "XpTotal": 183452500
+  },
+  {
+    "Level": 727,
+    "XpToNextLevel": 854500,
+    "XpTotal": 184307000
+  },
+  {
+    "Level": 728,
+    "XpToNextLevel": 858500,
+    "XpTotal": 185165500
+  },
+  {
+    "Level": 729,
+    "XpToNextLevel": 862500,
+    "XpTotal": 186028000
+  },
+  {
+    "Level": 730,
+    "XpToNextLevel": 866500,
+    "XpTotal": 186894500
+  },
+  {
+    "Level": 731,
+    "XpToNextLevel": 870500,
+    "XpTotal": 187765000
+  },
+  {
+    "Level": 732,
+    "XpToNextLevel": 874500,
+    "XpTotal": 188639500
+  },
+  {
+    "Level": 733,
+    "XpToNextLevel": 878500,
+    "XpTotal": 189518000
+  },
+  {
+    "Level": 734,
+    "XpToNextLevel": 882500,
+    "XpTotal": 190400500
+  },
+  {
+    "Level": 735,
+    "XpToNextLevel": 886750,
+    "XpTotal": 191287250
+  },
+  {
+    "Level": 736,
+    "XpToNextLevel": 890750,
+    "XpTotal": 192178000
+  },
+  {
+    "Level": 737,
+    "XpToNextLevel": 895000,
+    "XpTotal": 193073000
+  },
+  {
+    "Level": 738,
+    "XpToNextLevel": 899000,
+    "XpTotal": 193972000
+  },
+  {
+    "Level": 739,
+    "XpToNextLevel": 903250,
+    "XpTotal": 194875250
+  },
+  {
+    "Level": 740,
+    "XpToNextLevel": 907500,
+    "XpTotal": 195782750
+  },
+  {
+    "Level": 741,
+    "XpToNextLevel": 911500,
+    "XpTotal": 196694250
+  },
+  {
+    "Level": 742,
+    "XpToNextLevel": 915750,
+    "XpTotal": 197610000
+  },
+  {
+    "Level": 743,
+    "XpToNextLevel": 920000,
+    "XpTotal": 198530000
+  },
+  {
+    "Level": 744,
+    "XpToNextLevel": 924250,
+    "XpTotal": 199454250
+  },
+  {
+    "Level": 745,
+    "XpToNextLevel": 928500,
+    "XpTotal": 200382750
+  },
+  {
+    "Level": 746,
+    "XpToNextLevel": 933000,
+    "XpTotal": 201315750
+  },
+  {
+    "Level": 747,
+    "XpToNextLevel": 937250,
+    "XpTotal": 202253000
+  },
+  {
+    "Level": 748,
+    "XpToNextLevel": 941500,
+    "XpTotal": 203194500
+  },
+  {
+    "Level": 749,
+    "XpToNextLevel": 946000,
+    "XpTotal": 204140500
+  },
+  {
+    "Level": 750,
+    "XpToNextLevel": 950250,
+    "XpTotal": 205090750
+  },
+  {
+    "Level": 751,
+    "XpToNextLevel": 954750,
+    "XpTotal": 206045500
+  },
+  {
+    "Level": 752,
+    "XpToNextLevel": 959000,
+    "XpTotal": 207004500
+  },
+  {
+    "Level": 753,
+    "XpToNextLevel": 963500,
+    "XpTotal": 207968000
+  },
+  {
+    "Level": 754,
+    "XpToNextLevel": 968000,
+    "XpTotal": 208936000
+  },
+  {
+    "Level": 755,
+    "XpToNextLevel": 972500,
+    "XpTotal": 209908500
+  },
+  {
+    "Level": 756,
+    "XpToNextLevel": 977000,
+    "XpTotal": 210885500
+  },
+  {
+    "Level": 757,
+    "XpToNextLevel": 981500,
+    "XpTotal": 211867000
+  },
+  {
+    "Level": 758,
+    "XpToNextLevel": 986000,
+    "XpTotal": 212853000
+  },
+  {
+    "Level": 759,
+    "XpToNextLevel": 990500,
+    "XpTotal": 213843500
+  },
+  {
+    "Level": 760,
+    "XpToNextLevel": 995250,
+    "XpTotal": 214838750
+  },
+  {
+    "Level": 761,
+    "XpToNextLevel": 999750,
+    "XpTotal": 215838500
+  },
+  {
+    "Level": 762,
+    "XpToNextLevel": 1004500,
+    "XpTotal": 216843000
+  },
+  {
+    "Level": 763,
+    "XpToNextLevel": 1009000,
+    "XpTotal": 217852000
+  },
+  {
+    "Level": 764,
+    "XpToNextLevel": 1013750,
+    "XpTotal": 218865750
+  },
+  {
+    "Level": 765,
+    "XpToNextLevel": 1018500,
+    "XpTotal": 219884250
+  },
+  {
+    "Level": 766,
+    "XpToNextLevel": 1023250,
+    "XpTotal": 220907500
+  },
+  {
+    "Level": 767,
+    "XpToNextLevel": 1028000,
+    "XpTotal": 221935500
+  },
+  {
+    "Level": 768,
+    "XpToNextLevel": 1032750,
+    "XpTotal": 222968250
+  },
+  {
+    "Level": 769,
+    "XpToNextLevel": 1037500,
+    "XpTotal": 224005750
+  },
+  {
+    "Level": 770,
+    "XpToNextLevel": 1042250,
+    "XpTotal": 225048000
+  },
+  {
+    "Level": 771,
+    "XpToNextLevel": 1047000,
+    "XpTotal": 226095000
+  },
+  {
+    "Level": 772,
+    "XpToNextLevel": 1052000,
+    "XpTotal": 227147000
+  },
+  {
+    "Level": 773,
+    "XpToNextLevel": 1056750,
+    "XpTotal": 228203750
+  },
+  {
+    "Level": 774,
+    "XpToNextLevel": 1061750,
+    "XpTotal": 229265500
+  },
+  {
+    "Level": 775,
+    "XpToNextLevel": 1066500,
+    "XpTotal": 230332000
+  },
+  {
+    "Level": 776,
+    "XpToNextLevel": 1071500,
+    "XpTotal": 231403500
+  },
+  {
+    "Level": 777,
+    "XpToNextLevel": 1076500,
+    "XpTotal": 232480000
+  },
+  {
+    "Level": 778,
+    "XpToNextLevel": 1081500,
+    "XpTotal": 233561500
+  },
+  {
+    "Level": 779,
+    "XpToNextLevel": 1086500,
+    "XpTotal": 234648000
+  },
+  {
+    "Level": 780,
+    "XpToNextLevel": 1091500,
+    "XpTotal": 235739500
+  },
+  {
+    "Level": 781,
+    "XpToNextLevel": 1096500,
+    "XpTotal": 236836000
+  },
+  {
+    "Level": 782,
+    "XpToNextLevel": 1101500,
+    "XpTotal": 237937500
+  },
+  {
+    "Level": 783,
+    "XpToNextLevel": 1106750,
+    "XpTotal": 239044250
+  },
+  {
+    "Level": 784,
+    "XpToNextLevel": 1111750,
+    "XpTotal": 240156000
+  },
+  {
+    "Level": 785,
+    "XpToNextLevel": 1117000,
+    "XpTotal": 241273000
+  },
+  {
+    "Level": 786,
+    "XpToNextLevel": 1122000,
+    "XpTotal": 242395000
+  },
+  {
+    "Level": 787,
+    "XpToNextLevel": 1127250,
+    "XpTotal": 243522250
+  },
+  {
+    "Level": 788,
+    "XpToNextLevel": 1132500,
+    "XpTotal": 244654750
+  },
+  {
+    "Level": 789,
+    "XpToNextLevel": 1137750,
+    "XpTotal": 245792500
+  },
+  {
+    "Level": 790,
+    "XpToNextLevel": 1143000,
+    "XpTotal": 246935500
+  },
+  {
+    "Level": 791,
+    "XpToNextLevel": 1148250,
+    "XpTotal": 248083750
+  },
+  {
+    "Level": 792,
+    "XpToNextLevel": 1153750,
+    "XpTotal": 249237500
+  },
+  {
+    "Level": 793,
+    "XpToNextLevel": 1159000,
+    "XpTotal": 250396500
+  },
+  {
+    "Level": 794,
+    "XpToNextLevel": 1164250,
+    "XpTotal": 251560750
+  },
+  {
+    "Level": 795,
+    "XpToNextLevel": 1169750,
+    "XpTotal": 252730500
+  },
+  {
+    "Level": 796,
+    "XpToNextLevel": 1175250,
+    "XpTotal": 253905750
+  },
+  {
+    "Level": 797,
+    "XpToNextLevel": 1180500,
+    "XpTotal": 255086250
+  },
+  {
+    "Level": 798,
+    "XpToNextLevel": 1186000,
+    "XpTotal": 256272250
+  },
+  {
+    "Level": 799,
+    "XpToNextLevel": 1191500,
+    "XpTotal": 257463750
+  },
+  {
+    "Level": 800,
+    "XpToNextLevel": 1197000,
+    "XpTotal": 258660750
+  },
+  {
+    "Level": 801,
+    "XpToNextLevel": 1202500,
+    "XpTotal": 259863250
+  },
+  {
+    "Level": 802,
+    "XpToNextLevel": 1208250,
+    "XpTotal": 261071500
+  },
+  {
+    "Level": 803,
+    "XpToNextLevel": 1213750,
+    "XpTotal": 262285250
+  },
+  {
+    "Level": 804,
+    "XpToNextLevel": 1219250,
+    "XpTotal": 263504500
+  },
+  {
+    "Level": 805,
+    "XpToNextLevel": 1225000,
+    "XpTotal": 264729500
+  },
+  {
+    "Level": 806,
+    "XpToNextLevel": 1230750,
+    "XpTotal": 265960250
+  },
+  {
+    "Level": 807,
+    "XpToNextLevel": 1236250,
+    "XpTotal": 267196500
+  },
+  {
+    "Level": 808,
+    "XpToNextLevel": 1242000,
+    "XpTotal": 268438500
+  },
+  {
+    "Level": 809,
+    "XpToNextLevel": 1247750,
+    "XpTotal": 269686250
+  },
+  {
+    "Level": 810,
+    "XpToNextLevel": 1253500,
+    "XpTotal": 270939750
+  },
+  {
+    "Level": 811,
+    "XpToNextLevel": 1259500,
+    "XpTotal": 272199250
+  },
+  {
+    "Level": 812,
+    "XpToNextLevel": 1265250,
+    "XpTotal": 273464500
+  },
+  {
+    "Level": 813,
+    "XpToNextLevel": 1271000,
+    "XpTotal": 274735500
+  },
+  {
+    "Level": 814,
+    "XpToNextLevel": 1277000,
+    "XpTotal": 276012500
+  },
+  {
+    "Level": 815,
+    "XpToNextLevel": 1283000,
+    "XpTotal": 277295500
+  },
+  {
+    "Level": 816,
+    "XpToNextLevel": 1288750,
+    "XpTotal": 278584250
+  },
+  {
+    "Level": 817,
+    "XpToNextLevel": 1294750,
+    "XpTotal": 279879000
+  },
+  {
+    "Level": 818,
+    "XpToNextLevel": 1300750,
+    "XpTotal": 281179750
+  },
+  {
+    "Level": 819,
+    "XpToNextLevel": 1306750,
+    "XpTotal": 282486500
+  },
+  {
+    "Level": 820,
+    "XpToNextLevel": 1312750,
+    "XpTotal": 283799250
+  },
+  {
+    "Level": 821,
+    "XpToNextLevel": 1319000,
+    "XpTotal": 285118250
+  },
+  {
+    "Level": 822,
+    "XpToNextLevel": 1325000,
+    "XpTotal": 286443250
+  },
+  {
+    "Level": 823,
+    "XpToNextLevel": 1331250,
+    "XpTotal": 287774500
+  },
+  {
+    "Level": 824,
+    "XpToNextLevel": 1337250,
+    "XpTotal": 289111750
+  },
+  {
+    "Level": 825,
+    "XpToNextLevel": 1343500,
+    "XpTotal": 290455250
+  },
+  {
+    "Level": 826,
+    "XpToNextLevel": 1349750,
+    "XpTotal": 291805000
+  },
+  {
+    "Level": 827,
+    "XpToNextLevel": 1356000,
+    "XpTotal": 293161000
+  },
+  {
+    "Level": 828,
+    "XpToNextLevel": 1362250,
+    "XpTotal": 294523250
+  },
+  {
+    "Level": 829,
+    "XpToNextLevel": 1368500,
+    "XpTotal": 295891750
+  },
+  {
+    "Level": 830,
+    "XpToNextLevel": 1374750,
+    "XpTotal": 297266500
+  },
+  {
+    "Level": 831,
+    "XpToNextLevel": 1381250,
+    "XpTotal": 298647750
+  },
+  {
+    "Level": 832,
+    "XpToNextLevel": 1387750,
+    "XpTotal": 300035500
+  },
+  {
+    "Level": 833,
+    "XpToNextLevel": 1394000,
+    "XpTotal": 301429500
+  },
+  {
+    "Level": 834,
+    "XpToNextLevel": 1400500,
+    "XpTotal": 302830000
+  },
+  {
+    "Level": 835,
+    "XpToNextLevel": 1407000,
+    "XpTotal": 304237000
+  },
+  {
+    "Level": 836,
+    "XpToNextLevel": 1413500,
+    "XpTotal": 305650500
+  },
+  {
+    "Level": 837,
+    "XpToNextLevel": 1420000,
+    "XpTotal": 307070500
+  },
+  {
+    "Level": 838,
+    "XpToNextLevel": 1426500,
+    "XpTotal": 308497000
+  },
+  {
+    "Level": 839,
+    "XpToNextLevel": 1433250,
+    "XpTotal": 309930250
+  },
+  {
+    "Level": 840,
+    "XpToNextLevel": 1439750,
+    "XpTotal": 311370000
+  },
+  {
+    "Level": 841,
+    "XpToNextLevel": 1446500,
+    "XpTotal": 312816500
+  },
+  {
+    "Level": 842,
+    "XpToNextLevel": 1453250,
+    "XpTotal": 314269750
+  },
+  {
+    "Level": 843,
+    "XpToNextLevel": 1460000,
+    "XpTotal": 315729750
+  },
+  {
+    "Level": 844,
+    "XpToNextLevel": 1466750,
+    "XpTotal": 317196500
+  },
+  {
+    "Level": 845,
+    "XpToNextLevel": 1473500,
+    "XpTotal": 318670000
+  },
+  {
+    "Level": 846,
+    "XpToNextLevel": 1480250,
+    "XpTotal": 320150250
+  },
+  {
+    "Level": 847,
+    "XpToNextLevel": 1487250,
+    "XpTotal": 321637500
+  },
+  {
+    "Level": 848,
+    "XpToNextLevel": 1494000,
+    "XpTotal": 323131500
+  },
+  {
+    "Level": 849,
+    "XpToNextLevel": 1501000,
+    "XpTotal": 324632500
+  },
+  {
+    "Level": 850,
+    "XpToNextLevel": 1507750,
+    "XpTotal": 326140250
+  },
+  {
+    "Level": 851,
+    "XpToNextLevel": 1514750,
+    "XpTotal": 327655000
+  },
+  {
+    "Level": 852,
+    "XpToNextLevel": 1521750,
+    "XpTotal": 329176750
+  },
+  {
+    "Level": 853,
+    "XpToNextLevel": 1529000,
+    "XpTotal": 330705750
+  },
+  {
+    "Level": 854,
+    "XpToNextLevel": 1536000,
+    "XpTotal": 332241750
+  },
+  {
+    "Level": 855,
+    "XpToNextLevel": 1543000,
+    "XpTotal": 333784750
+  },
+  {
+    "Level": 856,
+    "XpToNextLevel": 1550250,
+    "XpTotal": 335335000
+  },
+  {
+    "Level": 857,
+    "XpToNextLevel": 1557500,
+    "XpTotal": 336892500
+  },
+  {
+    "Level": 858,
+    "XpToNextLevel": 1564500,
+    "XpTotal": 338457000
+  },
+  {
+    "Level": 859,
+    "XpToNextLevel": 1571750,
+    "XpTotal": 340028750
+  },
+  {
+    "Level": 860,
+    "XpToNextLevel": 1579000,
+    "XpTotal": 341607750
+  },
+  {
+    "Level": 861,
+    "XpToNextLevel": 1586500,
+    "XpTotal": 343194250
+  },
+  {
+    "Level": 862,
+    "XpToNextLevel": 1593750,
+    "XpTotal": 344788000
+  },
+  {
+    "Level": 863,
+    "XpToNextLevel": 1601250,
+    "XpTotal": 346389250
+  },
+  {
+    "Level": 864,
+    "XpToNextLevel": 1608500,
+    "XpTotal": 347997750
+  },
+  {
+    "Level": 865,
+    "XpToNextLevel": 1616000,
+    "XpTotal": 349613750
+  },
+  {
+    "Level": 866,
+    "XpToNextLevel": 1623500,
+    "XpTotal": 351237250
+  },
+  {
+    "Level": 867,
+    "XpToNextLevel": 1631000,
+    "XpTotal": 352868250
+  },
+  {
+    "Level": 868,
+    "XpToNextLevel": 1638500,
+    "XpTotal": 354506750
+  },
+  {
+    "Level": 869,
+    "XpToNextLevel": 1646000,
+    "XpTotal": 356152750
+  },
+  {
+    "Level": 870,
+    "XpToNextLevel": 1653750,
+    "XpTotal": 357806500
+  },
+  {
+    "Level": 871,
+    "XpToNextLevel": 1661500,
+    "XpTotal": 359468000
+  },
+  {
+    "Level": 872,
+    "XpToNextLevel": 1669000,
+    "XpTotal": 361137000
+  },
+  {
+    "Level": 873,
+    "XpToNextLevel": 1676750,
+    "XpTotal": 362813750
+  },
+  {
+    "Level": 874,
+    "XpToNextLevel": 1684500,
+    "XpTotal": 364498250
+  },
+  {
+    "Level": 875,
+    "XpToNextLevel": 1692250,
+    "XpTotal": 366190500
+  },
+  {
+    "Level": 876,
+    "XpToNextLevel": 1700250,
+    "XpTotal": 367890750
+  },
+  {
+    "Level": 877,
+    "XpToNextLevel": 1708000,
+    "XpTotal": 369598750
+  },
+  {
+    "Level": 878,
+    "XpToNextLevel": 1716000,
+    "XpTotal": 371314750
+  },
+  {
+    "Level": 879,
+    "XpToNextLevel": 1724000,
+    "XpTotal": 373038750
+  },
+  {
+    "Level": 880,
+    "XpToNextLevel": 1732000,
+    "XpTotal": 374770750
+  },
+  {
+    "Level": 881,
+    "XpToNextLevel": 1740000,
+    "XpTotal": 376510750
+  },
+  {
+    "Level": 882,
+    "XpToNextLevel": 1748000,
+    "XpTotal": 378258750
+  },
+  {
+    "Level": 883,
+    "XpToNextLevel": 1756000,
+    "XpTotal": 380014750
+  },
+  {
+    "Level": 884,
+    "XpToNextLevel": 1764250,
+    "XpTotal": 381779000
+  },
+  {
+    "Level": 885,
+    "XpToNextLevel": 1772250,
+    "XpTotal": 383551250
+  },
+  {
+    "Level": 886,
+    "XpToNextLevel": 1780500,
+    "XpTotal": 385331750
+  },
+  {
+    "Level": 887,
+    "XpToNextLevel": 1788750,
+    "XpTotal": 387120500
+  },
+  {
+    "Level": 888,
+    "XpToNextLevel": 1797000,
+    "XpTotal": 388917500
+  },
+  {
+    "Level": 889,
+    "XpToNextLevel": 1805250,
+    "XpTotal": 390722750
+  },
+  {
+    "Level": 890,
+    "XpToNextLevel": 1813750,
+    "XpTotal": 392536500
+  },
+  {
+    "Level": 891,
+    "XpToNextLevel": 1822000,
+    "XpTotal": 394358500
+  },
+  {
+    "Level": 892,
+    "XpToNextLevel": 1830500,
+    "XpTotal": 396189000
+  },
+  {
+    "Level": 893,
+    "XpToNextLevel": 1839000,
+    "XpTotal": 398028000
+  },
+  {
+    "Level": 894,
+    "XpToNextLevel": 1847500,
+    "XpTotal": 399875500
+  },
+  {
+    "Level": 895,
+    "XpToNextLevel": 1856000,
+    "XpTotal": 401731500
+  },
+  {
+    "Level": 896,
+    "XpToNextLevel": 1864750,
+    "XpTotal": 403596250
+  },
+  {
+    "Level": 897,
+    "XpToNextLevel": 1873250,
+    "XpTotal": 405469500
+  },
+  {
+    "Level": 898,
+    "XpToNextLevel": 1882000,
+    "XpTotal": 407351500
+  },
+  {
+    "Level": 899,
+    "XpToNextLevel": 1890750,
+    "XpTotal": 409242250
+  },
+  {
+    "Level": 900,
+    "XpToNextLevel": 1899500,
+    "XpTotal": 411141750
+  },
+  {
+    "Level": 901,
+    "XpToNextLevel": 1908250,
+    "XpTotal": 413050000
+  },
+  {
+    "Level": 902,
+    "XpToNextLevel": 1917000,
+    "XpTotal": 414967000
+  },
+  {
+    "Level": 903,
+    "XpToNextLevel": 1926000,
+    "XpTotal": 416893000
+  },
+  {
+    "Level": 904,
+    "XpToNextLevel": 1934750,
+    "XpTotal": 418827750
+  },
+  {
+    "Level": 905,
+    "XpToNextLevel": 1943750,
+    "XpTotal": 420771500
+  },
+  {
+    "Level": 906,
+    "XpToNextLevel": 1952750,
+    "XpTotal": 422724250
+  },
+  {
+    "Level": 907,
+    "XpToNextLevel": 1961750,
+    "XpTotal": 424686000
+  },
+  {
+    "Level": 908,
+    "XpToNextLevel": 1970750,
+    "XpTotal": 426656750
+  },
+  {
+    "Level": 909,
+    "XpToNextLevel": 1980000,
+    "XpTotal": 428636750
+  },
+  {
+    "Level": 910,
+    "XpToNextLevel": 1989250,
+    "XpTotal": 430626000
+  },
+  {
+    "Level": 911,
+    "XpToNextLevel": 1998250,
+    "XpTotal": 432624250
+  },
+  {
+    "Level": 912,
+    "XpToNextLevel": 2007500,
+    "XpTotal": 434631750
+  },
+  {
+    "Level": 913,
+    "XpToNextLevel": 2017000,
+    "XpTotal": 436648750
+  },
+  {
+    "Level": 914,
+    "XpToNextLevel": 2026250,
+    "XpTotal": 438675000
+  },
+  {
+    "Level": 915,
+    "XpToNextLevel": 2035500,
+    "XpTotal": 440710500
+  },
+  {
+    "Level": 916,
+    "XpToNextLevel": 2045000,
+    "XpTotal": 442755500
+  },
+  {
+    "Level": 917,
+    "XpToNextLevel": 2054500,
+    "XpTotal": 444810000
+  },
+  {
+    "Level": 918,
+    "XpToNextLevel": 2064000,
+    "XpTotal": 446874000
+  },
+  {
+    "Level": 919,
+    "XpToNextLevel": 2073500,
+    "XpTotal": 448947500
+  },
+  {
+    "Level": 920,
+    "XpToNextLevel": 2083250,
+    "XpTotal": 451030750
+  },
+  {
+    "Level": 921,
+    "XpToNextLevel": 2092750,
+    "XpTotal": 453123500
+  },
+  {
+    "Level": 922,
+    "XpToNextLevel": 2102500,
+    "XpTotal": 455226000
+  },
+  {
+    "Level": 923,
+    "XpToNextLevel": 2112250,
+    "XpTotal": 457338250
+  },
+  {
+    "Level": 924,
+    "XpToNextLevel": 2122000,
+    "XpTotal": 459460250
+  },
+  {
+    "Level": 925,
+    "XpToNextLevel": 2131750,
+    "XpTotal": 461592000
+  },
+  {
+    "Level": 926,
+    "XpToNextLevel": 2141750,
+    "XpTotal": 463733750
+  },
+  {
+    "Level": 927,
+    "XpToNextLevel": 2151500,
+    "XpTotal": 465885250
+  },
+  {
+    "Level": 928,
+    "XpToNextLevel": 2161500,
+    "XpTotal": 468046750
+  },
+  {
+    "Level": 929,
+    "XpToNextLevel": 2171500,
+    "XpTotal": 470218250
+  },
+  {
+    "Level": 930,
+    "XpToNextLevel": 2181500,
+    "XpTotal": 472399750
+  },
+  {
+    "Level": 931,
+    "XpToNextLevel": 2191750,
+    "XpTotal": 474591500
+  },
+  {
+    "Level": 932,
+    "XpToNextLevel": 2201750,
+    "XpTotal": 476793250
+  },
+  {
+    "Level": 933,
+    "XpToNextLevel": 2212000,
+    "XpTotal": 479005250
+  },
+  {
+    "Level": 934,
+    "XpToNextLevel": 2222250,
+    "XpTotal": 481227500
+  },
+  {
+    "Level": 935,
+    "XpToNextLevel": 2232500,
+    "XpTotal": 483460000
+  },
+  {
+    "Level": 936,
+    "XpToNextLevel": 2242750,
+    "XpTotal": 485702750
+  },
+  {
+    "Level": 937,
+    "XpToNextLevel": 2253250,
+    "XpTotal": 487956000
+  },
+  {
+    "Level": 938,
+    "XpToNextLevel": 2263750,
+    "XpTotal": 490219750
+  },
+  {
+    "Level": 939,
+    "XpToNextLevel": 2274250,
+    "XpTotal": 492494000
+  },
+  {
+    "Level": 940,
+    "XpToNextLevel": 2284750,
+    "XpTotal": 494778750
+  },
+  {
+    "Level": 941,
+    "XpToNextLevel": 2295250,
+    "XpTotal": 497074000
+  },
+  {
+    "Level": 942,
+    "XpToNextLevel": 2305750,
+    "XpTotal": 499379750
+  },
+  {
+    "Level": 943,
+    "XpToNextLevel": 2316500,
+    "XpTotal": 501696250
+  },
+  {
+    "Level": 944,
+    "XpToNextLevel": 2327250,
+    "XpTotal": 504023500
+  },
+  {
+    "Level": 945,
+    "XpToNextLevel": 2338000,
+    "XpTotal": 506361500
+  },
+  {
+    "Level": 946,
+    "XpToNextLevel": 2348750,
+    "XpTotal": 508710250
+  },
+  {
+    "Level": 947,
+    "XpToNextLevel": 2359750,
+    "XpTotal": 511070000
+  },
+  {
+    "Level": 948,
+    "XpToNextLevel": 2370500,
+    "XpTotal": 513440500
+  },
+  {
+    "Level": 949,
+    "XpToNextLevel": 2381500,
+    "XpTotal": 515822000
+  },
+  {
+    "Level": 950,
+    "XpToNextLevel": 2392500,
+    "XpTotal": 518214500
+  },
+  {
+    "Level": 951,
+    "XpToNextLevel": 2403750,
+    "XpTotal": 520618250
+  },
+  {
+    "Level": 952,
+    "XpToNextLevel": 2414750,
+    "XpTotal": 523033000
+  },
+  {
+    "Level": 953,
+    "XpToNextLevel": 2426000,
+    "XpTotal": 525459000
+  },
+  {
+    "Level": 954,
+    "XpToNextLevel": 2437250,
+    "XpTotal": 527896250
+  },
+  {
+    "Level": 955,
+    "XpToNextLevel": 2448500,
+    "XpTotal": 530344750
+  },
+  {
+    "Level": 956,
+    "XpToNextLevel": 2459750,
+    "XpTotal": 532804500
+  },
+  {
+    "Level": 957,
+    "XpToNextLevel": 2471250,
+    "XpTotal": 535275750
+  },
+  {
+    "Level": 958,
+    "XpToNextLevel": 2482750,
+    "XpTotal": 537758500
+  },
+  {
+    "Level": 959,
+    "XpToNextLevel": 2494000,
+    "XpTotal": 540252500
+  },
+  {
+    "Level": 960,
+    "XpToNextLevel": 2505750,
+    "XpTotal": 542758250
+  },
+  {
+    "Level": 961,
+    "XpToNextLevel": 2517250,
+    "XpTotal": 545275500
+  },
+  {
+    "Level": 962,
+    "XpToNextLevel": 2529000,
+    "XpTotal": 547804500
+  },
+  {
+    "Level": 963,
+    "XpToNextLevel": 2540500,
+    "XpTotal": 550345000
+  },
+  {
+    "Level": 964,
+    "XpToNextLevel": 2552250,
+    "XpTotal": 552897250
+  },
+  {
+    "Level": 965,
+    "XpToNextLevel": 2564250,
+    "XpTotal": 555461500
+  },
+  {
+    "Level": 966,
+    "XpToNextLevel": 2576000,
+    "XpTotal": 558037500
+  },
+  {
+    "Level": 967,
+    "XpToNextLevel": 2588000,
+    "XpTotal": 560625500
+  },
+  {
+    "Level": 968,
+    "XpToNextLevel": 2600000,
+    "XpTotal": 563225500
+  },
+  {
+    "Level": 969,
+    "XpToNextLevel": 2612000,
+    "XpTotal": 565837500
+  },
+  {
+    "Level": 970,
+    "XpToNextLevel": 2624000,
+    "XpTotal": 568461500
+  },
+  {
+    "Level": 971,
+    "XpToNextLevel": 2636250,
+    "XpTotal": 571097750
+  },
+  {
+    "Level": 972,
+    "XpToNextLevel": 2648500,
+    "XpTotal": 573746250
+  },
+  {
+    "Level": 973,
+    "XpToNextLevel": 2660750,
+    "XpTotal": 576407000
+  },
+  {
+    "Level": 974,
+    "XpToNextLevel": 2673000,
+    "XpTotal": 579080000
+  },
+  {
+    "Level": 975,
+    "XpToNextLevel": 2685250,
+    "XpTotal": 581765250
+  },
+  {
+    "Level": 976,
+    "XpToNextLevel": 2697750,
+    "XpTotal": 584463000
+  },
+  {
+    "Level": 977,
+    "XpToNextLevel": 2710250,
+    "XpTotal": 587173250
+  },
+  {
+    "Level": 978,
+    "XpToNextLevel": 2722750,
+    "XpTotal": 589896000
+  },
+  {
+    "Level": 979,
+    "XpToNextLevel": 2735500,
+    "XpTotal": 592631500
+  },
+  {
+    "Level": 980,
+    "XpToNextLevel": 2748000,
+    "XpTotal": 595379500
+  },
+  {
+    "Level": 981,
+    "XpToNextLevel": 2760750,
+    "XpTotal": 598140250
+  },
+  {
+    "Level": 982,
+    "XpToNextLevel": 2773500,
+    "XpTotal": 600913750
+  },
+  {
+    "Level": 983,
+    "XpToNextLevel": 2786500,
+    "XpTotal": 603700250
+  },
+  {
+    "Level": 984,
+    "XpToNextLevel": 2799250,
+    "XpTotal": 606499500
+  },
+  {
+    "Level": 985,
+    "XpToNextLevel": 2812250,
+    "XpTotal": 609311750
+  },
+  {
+    "Level": 986,
+    "XpToNextLevel": 2825250,
+    "XpTotal": 612137000
+  },
+  {
+    "Level": 987,
+    "XpToNextLevel": 2838250,
+    "XpTotal": 614975250
+  },
+  {
+    "Level": 988,
+    "XpToNextLevel": 2851500,
+    "XpTotal": 617826750
+  },
+  {
+    "Level": 989,
+    "XpToNextLevel": 2864750,
+    "XpTotal": 620691500
+  },
+  {
+    "Level": 990,
+    "XpToNextLevel": 2878000,
+    "XpTotal": 623569500
+  },
+  {
+    "Level": 991,
+    "XpToNextLevel": 2891250,
+    "XpTotal": 626460750
+  },
+  {
+    "Level": 992,
+    "XpToNextLevel": 2904500,
+    "XpTotal": 629365250
+  },
+  {
+    "Level": 993,
+    "XpToNextLevel": 2918000,
+    "XpTotal": 632283250
+  },
+  {
+    "Level": 994,
+    "XpToNextLevel": 2931500,
+    "XpTotal": 635214750
+  },
+  {
+    "Level": 995,
+    "XpToNextLevel": 2945000,
+    "XpTotal": 638159750
+  },
+  {
+    "Level": 996,
+    "XpToNextLevel": 2958750,
+    "XpTotal": 641118500
+  },
+  {
+    "Level": 997,
+    "XpToNextLevel": 2972500,
+    "XpTotal": 644091000
+  },
+  {
+    "Level": 998,
+    "XpToNextLevel": 2986250,
+    "XpTotal": 647077250
+  },
+  {
+    "Level": 999,
+    "XpToNextLevel": 3000000,
+    "XpTotal": 650077250
+  }
+]

--- a/FortBackend/Resources/Json/shop/christmas/christmas.json
+++ b/FortBackend/Resources/Json/shop/christmas/christmas.json
@@ -1,221 +1,684 @@
-[
-  {
-    "item": "AthenaCharacter:CID_045_Athena_Commando_M_HolidaySweater",
-    "name": "Yuletide Ranger",
-    "description": "Up on the rooftop...",
-    "items": [],
-    "rarity": "uncommon"
-  },
-  {
-    "item": "AthenaCharacter:CID_046_Athena_Commando_F_HolidaySweater",
-    "name": "Nog Ops",
-    "description": "Have yourself a merry little skirmish.",
-    "items": [],
-    "rarity": "uncommon"
-  },
-  {
-    "item": "AthenaCharacter:CID_047_Athena_Commando_F_HolidayReindeer",
-    "name": "Red-Nosed Raider",
-    "description": "It's time for some reindeer games.",
-    "items": [],
-    "rarity": "rare"
-  },
-  {
-    "item": "AthenaPickaxe:Pickaxe_ID_155_ValentinesFrozen",
-    "name": "Cold Hearted",
-    "description": "No love lost.",
-    "items": [],
-    "rarity": "frozen"
-  },
-  {
-    "item": "AthenaPickaxe:Pickaxe_ID_156_RavenQuillFrozen",
-    "name": "Frozen Beak",
-    "description": "Break the ice.",
-    "items": [],
-    "rarity": "frozen"
-  },
-  {
-    "item": "AthenaCharacter:CID_048_Athena_Commando_F_HolidayGingerbread",
-    "name": "Ginger Gunner",
-    "description": "Spread some holiday fear.",
-    "items": [],
-    "rarity": "epic"
-  },
-  {
-    "item": "AthenaCharacter:CID_049_Athena_Commando_M_HolidayGingerbread",
-    "name": "Merry Marauder",
-    "description": "Sing a slaying song tonight.",
-    "items": [],
-    "rarity": "epic"
-  },
-  {
-    "item": "AthenaCharacter:CID_050_Athena_Commando_M_HolidayNutcracker",
-    "name": "Crackshot",
-    "description": "Get out there and... crack some nuts.",
-    "items": [],
-    "rarity": "legendary"
-  },
-  {
-    "item": "AthenaCharacter:CID_051_Athena_Commando_M_HolidayElf",
-    "name": "Codename E.L.F.",
-    "description": "Elusive. Lethal. Festive.",
-    "items": [],
-    "rarity": "rare"
-  },
-  {
-    "item": "AthenaCharacter:CID_330_Athena_Commando_F_IceQueen",
-    "name": "The Ice Queen",
-    "description": "Long live the queen.",
-    "items": [
-      {
-        "item": "AthenaBackpack:BID_199_IceQueen",
-        "name": "Ice Spikes"
-      }
-    ],
-    "rarity": "legendary"
-  },
-  {
-    "item": "AthenaCharacter:CID_329_Athena_Commando_F_SnowNinja",
-    "name": "Snowstrike",
-    "description": "Strike swiftly, and always leave your mark.",
-    "items": [
-      {
-        "item": "AthenaBackpack:BID_200_SnowNinjaFemale",
-        "nmame": "Snowbrand"
-      }
-    ],
-    "rarity": "epic"
-  },
-  {
-    "item": "AthenaCharacter:CID_298_Athena_Commando_F_IceMaiden",
-    "name": "Glimmer",
-    "description": "Elegantly reclaiming winter's crown.",
-    "items": [
-      {
-        "item": "AthenaBackpack:BID_180_IceMaiden",
-        "name": "Glimmering Cloak"
-      }
-    ],
-    "rarity": "legendary"
-  },
-  {
-    "item": "AthenaCharacter:CID_299_Athena_Commando_M_SnowNinja",
-    "name": "Snowfoot",
-    "description": "Tread lightly, and never leave a trace.",
-    "items": [
-      {
-        "item": "AthenaBackpack:BID_181_SnowNinjaMale",
-        "name": "Snow Star"
-      }
-    ],
-    "rarity": "epic"
-  },
-  {
-    "item": "AthenaCharacter:CID_280_Athena_Commando_M_Snowman",
-    "name": "Slushy Soldier",
-    "description": "Make every day a snow day.",
-    "items": [
-      {
-        "item": "AthenaBackpack:BID_164_SnowmanMale",
-        "name": "Slushy Jr."
-      }
-    ],
-    "rarity": "epic"
-  },
-  {
-    "item": "AthenaPickaxe:Pickaxe_ID_015_HolidayCandyCane",
-    "name": "Candy Axe",
-    "description": "Deck the walls with festive mayhem!",
-    "items": [],
-    "rarity": "epic"
-  },
-  {
-    "item": "AthenaPickaxe:Pickaxe_ID_145_IceMaiden",
-    "name": "Flurry",
-    "description": "Swing flurriously.",
-    "items": [],
-    "rarity": "rare"
-  },
-  {
-    "item": "AthenaCharacter:CID_222_Athena_Commando_F_DarkViking",
-    "name": "Valkyrie",
-    "description": "A chilling revelation.",
-    "items": [
-      {
-        "item": "AthenaBackpack:BID_113_DarkVikingFemale",
-        "name": "Valkyrie Wings"
-      }
-    ],
-    "rarity": "legendary"
-  },
-  {
-    "item": "AthenaPickaxe:Pickaxe_ID_150_IceQueen",
-    "name": "Icebringer",
-    "description": "Bitter cold.",
-    "items": [],
-    "rarity": "rare"
-  },
-  {
-    "item": "AthenaCharacter:CID_311_Athena_Commando_M_Reindeer",
-    "name": "Red-nosed Ranger",
-    "description": "Known for his antler antics.",
-    "items": [],
-    "rarity": "uncommon"
-  },
-  {
-    "item": "AthenaItemWrap:Wrap_007_CandyCane",
-    "name": "Candy Cane",
-    "description": "Show your style.",
-    "items": [],
-    "rarity": "uncommon"
-  },
-  {
-    "item": "AthenaCharacter:CID_316_Athena_Commando_F_WinterHoliday",
-    "name": "Tinseltoes",
-    "description": "Keep the competition on their toes.",
-    "items": [],
-    "rarity": "uncommon"
-  },
-  {
-    "item": "AthenaDance:EID_TakeTheElf",
-    "name": "Take The Elf",
-    "description": "Break out the mistletoe.",
-    "items": [],
-    "rarity": "uncommon"
-  },
-  {
-    "item": "AthenaGlider:Glider_ID_085_SkullTrooper",
-    "name": "Crypt Cruiser",
-    "description": "From beyond the grave!",
-    "items": [],
-    "rarity": "epic"
-  },
-  {
-    "item": "AthenaPickaxe:Pickaxe_ID_137_NutCracker",
-    "name": "Snow Globe",
-    "description": "Shake vigorously.",
-    "items": [],
-    "rarity": "rare"
-  },
-  {
-    "item": "AthenaGlider:Glider_ID_113_Barbarian",
-    "name": "Tusk",
-    "description": "Wild and woolly.",
-    "items": [],
-    "rarity": "uncommon"
-  },
-  {
-    "item": "AthenaGlider:Glider_ID_114_IceQueen",
-    "name": "Winter's Thorn",
-    "description": "Ride out the squall.",
-    "items": [],
-    "rarity": "rare"
-  },
-  {
-    "item": "AthenaGlider:Glider_ID_115_SnowNinja",
-    "name": "Snowblades",
-    "description": "Cut through the cold.",
-    "items": [],
-    "rarity": "rare"
-  }
-]
+{
+  "Bundles": [
+    {
+      "BundleID": 100,
+      "Daily": [
+        {
+          "id": "T3tX5lwbHEPIbCiJtyNPF85KWy1TCyT0G8jFNtHy",
+          "item": "AthenaPickaxe:Pickaxe_ID_022_HolidayGiftWrap",
+          "name": "You Shouldn't Have!",
+          "description": "For the combatant who has everything.",
+          "items": [],
+          "categories": [],
+          "rarity": "uncommon",
+          "season": 1
+        }
+      ],
+      "Weekly": [
+        {
+          "id": "8YJIX4AUq4VSmB4RzkiKDc0CTJ7sUfX7",
+          "item": "AthenaCharacter:CID_045_Athena_Commando_M_HolidaySweater",
+          "name": "Yuletide Ranger",
+          "description": "Up on the rooftop...",
+          "items": [],
+          "categories": [],
+          "rarity": "uncommon",
+          "season": 1
+        },
+        {
+          "id": "KW0LOBn50XfHCPt7mCELJdO1dOtrkona",
+          "item": "AthenaCharacter:CID_046_Athena_Commando_F_HolidaySweater",
+          "name": "Nog Ops",
+          "description": "Have yourself a merry little skirmish.",
+          "items": [],
+          "categories": [],
+          "rarity": "uncommon",
+          "season": 1
+        },
+        {
+          "id": "HhDUZWLEAj8G-HtvOlivT6bxstq6jHn0iitI5JRL",
+          "item": "AthenaGlider:Glider_ID_005_HolidaySweater",
+          "name": "Cozy Coaster",
+          "description": "Snuggle up to the firefight in holiday style.",
+          "items": [],
+          "categories": [],
+          "rarity": "rare",
+          "season": 1
+        }
+      ],
+      "AllowAgain": true
+    },
+    {
+      "BundleID": 101,
+      "Daily": [],
+      "Weekly": [
+        {
+          "id": "k5j867oHVuSXtzuQQZ545kkoWYAB8hnD",
+          "item": "AthenaGlider:Glider_ID_119_ReaperFrozen",
+          "name": "Frozen Feathers",
+          "description": "A cold wind bellows.",
+          "categories": [],
+          "items": [
+            {
+              "item": "AthenaPickaxe:Pickaxe_ID_155_ValentinesFrozen",
+              "name": "Cold Hearted"
+            },
+            {
+              "item": "AthenaPickaxe:Pickaxe_ID_156_RavenQuillFrozen",
+              "name": "Frozen Beak"
+            }
+          ],
+          "BundlePath": "DA_Featured_FrozenItemBundle",
+          "rarity": "rare",
+          "singleprice": 1000,
+          "original_price": 2400,
+          "price": 1000,
+          "season": 7.10
+        }
+      ],
+      "AllowAgain": true
+    },
+    {
+      "BundleID": 102,
+      "Daily": [],
+      "Weekly": [
+        {
+          "id": "xXM2iYHF6YQwa7ymkONctwyzDa9DOx0S",
+          "item": "AthenaCharacter:CID_049_Athena_Commando_M_HolidayGingerbread",
+          "name": "Merry Marauder",
+          "description": "Sing a slaying song tonight.",
+          "categories": [
+            "Panel 100"
+          ],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_186_GingerbreadMale",
+              "name": "Mini Marauder"
+            }
+          ],
+          "variants": [
+            {
+              "channel": "Material",
+              "active": "Mat0",
+              "owned": [
+                "Mat0",
+                "Mat1",
+                "Mat2",
+                "Mat3"
+              ]
+            }
+          ],
+          "rarity": "epic",
+          "season": 1
+        },
+        {
+          "id": "9kWcyFTL9PVT7a95HpqIebGtSlIMNA4Y",
+          "item": "AthenaCharacter:CID_048_Athena_Commando_F_HolidayGingerbread",
+          "name": "Ginger Gunner",
+          "description": "Spread some holiday fear.",
+          "categories": [
+            "Panel 100"
+          ],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_187_GingerbreadFemale",
+              "name": "Giddy Gunner"
+            }
+          ],
+          "rarity": "epic",
+          "variants": [
+            {
+              "channel": "Material",
+              "active": "Mat0",
+              "owned": [
+                "Mat0",
+                "Mat1",
+                "Mat2",
+                "Mat3"
+              ]
+            }
+          ],
+          "season": 1
+        },
+        {
+          "id": "qujCPvIrHKQWxuqH3E4qVcAvAOwkFkzj",
+          "item": "AthenaGlider:Glider_ID_105_Gingerbread",
+          "name": "Gingersled",
+          "description": "That's one sweet ride.",
+          "categories": [
+            "Panel 101"
+          ],
+          "items": [],
+          "rarity": "uncommon",
+          "season": 7.10
+        },
+        {
+          "id": "8uNlEdUj4RAhRwzoUGuIZbgsQklziWb6",
+          "item": "AthenaPickaxe:Pickaxe_ID_139_Gingerbread",
+          "name": "Cookie Cutter",
+          "description": "Sweet vengeance.",
+          "categories": [
+            "Panel 101"
+          ],
+          "items": [],
+          "rarity": "uncommon",
+          "season": 7.10
+        }
+      ],
+      "AllowAgain": true
+    },
+    {
+      "BundleID": 103,
+      "Daily": [
+        {
+          "id": "2iHYDrc2VvcFeD7FwhBpb4RlsrvlOhEf",
+          "item": "AthenaDance:EID_CrackshotClock",
+          "name": "Around the Clock",
+          "description": "Keep time.",
+          "categories": [],
+          "items": [],
+          "variants": [],
+          "rarity": "rare",
+          "season": 11.30
+        },
+        {
+          "id": "UoA4DvfRZDhshjLVRNoqrJ0QVTONFaqN",
+          "item": "AthenaPickaxe:Pickaxe_ID_137_NutCracker",
+          "name": "Snow Globe",
+          "description": "Shake vigorously.",
+          "categories": [],
+          "items": [],
+          "variants": [],
+          "rarity": "rare",
+          "season": 7.10
+        }
+      ],
+      "Weekly": [
+        {
+          "id": "SP7ieSik7jjF4QtqmvyQEuINc5oW7S5K",
+          "item": "AthenaCharacter:CID_050_Athena_Commando_M_HolidayNutcracker",
+          "name": "Crackshot",
+          "description": "Get out there and... crack some nuts.",
+          "categories": [],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_182_NutcrackerMale",
+              "name": "Birdshot",
+              "variants": [
+                {
+                  "channel": "Material",
+                  "active": "Mat1",
+                  "owned": [
+                    "Mat1",
+                    "Mat2"
+                  ]
+                }
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "channel": "Material",
+              "active": "Mat1",
+              "owned": [
+                "Mat1",
+                "Mat2",
+                "Mat3",
+                "Mat4"
+              ]
+            }
+          ],
+          "rarity": "legendary",
+          "season": 1
+        },
+        {
+          "id": "M3uOND6oKEmZZdpiorciyQnDebJD0zHI",
+          "item": "AthenaCharacter:CID_050_Athena_Commando_M_HolidayNutcracker",
+          "name": "Crackabella",
+          "description": "She's a hard nut to crack.",
+          "categories": [],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_183_NutcrackerFemale",
+              "name": "Snackshot",
+              "variants": []
+            }
+          ],
+          "variants": [],
+          "rarity": "epic",
+          "season": 7.10
+        }
+      ],
+      "AllowAgain": true
+    },
+    {
+      "BundleID": 104,
+      "Daily": [],
+      "Weekly": [
+        {
+          "id": "ETQrjl7RUjmN1Yd2Rh9F5WgPvpqfKR0J",
+          "item": "AthenaCharacter:CID_330_Athena_Commando_F_IceQueen",
+          "name": "The Ice Queen",
+          "description": "Long live the queen.",
+          "categories": [],
+          "items": [],
+          "variants": [
+            {
+              "channel": "Material",
+              "active": "Mat0",
+              "owned": [
+                "Mat0",
+                "Mat1",
+                "Mat2",
+                "Mat3"
+              ]
+            }
+          ],
+          "rarity": "legendary",
+          "season": 7.10
+        },
+        {
+          "id": "4oFNhPERgjDTj6jwC62lYDBVoVLsUhXx",
+          "item": "AthenaPickaxe:Pickaxe_ID_150_IceQueen",
+          "name": "Icebringer",
+          "description": "Bitter cold.",
+          "categories": [],
+          "items": [],
+          "variants": [
+            {
+              "channel": "Material",
+              "active": "Mat0",
+              "owned": [
+                "Mat0",
+                "Mat1",
+                "Mat2",
+                "Mat3"
+              ]
+            }
+          ],
+          "rarity": "rare",
+          "season": 7.10
+        }
+      ],
+      "AllowAgain": true
+    },
+    {
+      "BundleID": 105,
+      "Daily": [],
+      "Weekly": [
+        {
+          "id": "v7xilhCkegSiXY0pUNJ8yrOdK0xZfchV",
+          "item": "AthenaCharacter:CID_299_Athena_Commando_M_SnowNinja",
+          "name": "Snowfoot",
+          "description": "Tread lightly, and never leave a trace.",
+          "categories": [],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_181_SnowNinjaMale",
+              "name": "Snow Star",
+              "variants": []
+            }
+          ],
+          "variants": [
+            {
+              "channel": "Material",
+              "active": "Mat1",
+              "owned": [
+                "Mat1",
+                "Mat2"
+              ]
+            }
+          ],
+          "rarity": "legendary",
+          "season": 7.10
+        },
+        {
+          "id": "oc4kVZJVxM07gaMc98FOMdZCOyR0dzhw",
+          "item": "AthenaCharacter:CID_329_Athena_Commando_F_SnowNinja",
+          "name": "Snowstrike",
+          "description": "Strike swiftly, and always leave your mark.",
+          "categories": [],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_200_SnowNinjaFemale",
+              "name": "Snowbrand",
+              "variants": []
+            }
+          ],
+          "variants": [],
+          "rarity": "epic",
+          "season": 7.10
+        },
+        {
+          "id": "XONOLpH6WOPJLsTGGYxl1SlwZpVKzgmf",
+          "item": "AthenaPickaxe:Pickaxe_ID_135_SnowNinja",
+          "name": "Inverted Blade",
+          "description": "Sharp from any direction.",
+          "categories": [
+            "Panel 67"
+          ],
+          "items": [],
+          "variants": [],
+          "rarity": "uncommon",
+          "season": 7.10
+        },
+        {
+          "id": "P0jtNmEhP4tz9K2rBorofB0cPuqqHcLI",
+          "item": "AthenaGlider:Glider_ID_115_SnowNinja",
+          "name": "Snowblades",
+          "description": "Cut through the cold.",
+          "categories": [
+            "Panel 67"
+          ],
+          "items": [],
+          "variants": [],
+          "rarity": "rare",
+          "season": 7.10
+        }
+      ],
+      "AllowAgain": true
+    },
+    {
+      "BundleID": 106,
+      "Daily": [],
+      "Weekly": [
+        {
+          "id": "xs75mmhVdYjmpJs5Rp4pvDCJZFQUPFHd",
+          "item": "AthenaCharacter:CID_298_Athena_Commando_F_IceMaiden",
+          "name": "Glimmer",
+          "description": "Elegantly reclaiming winter's crown.",
+          "categories": [
+            "Panel 21"
+          ],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_180_IceMaiden",
+              "name": "Glimmering Cloak",
+              "variants": []
+            }
+          ],
+          "variants": [],
+          "rarity": "legendary",
+          "season": 7.10
+        },
+        {
+          "id": "MN14NQURekvwTm6mKbcJSFQqR6CKDyRY",
+          "item": "AthenaPickaxe:Pickaxe_ID_145_IceMaiden",
+          "name": "Flurry",
+          "description": "Swing flurriously.",
+          "categories": [
+            "Panel 21"
+          ],
+          "items": [],
+          "variants": [],
+          "rarity": "rare",
+          "season": 7.10
+        },
+        {
+          "id": "EiMloY3mGbr1nO9GT8rQhPhxFBjWNX56",
+          "item": "AthenaGlider:Glider_ID_107_IceMaiden",
+          "name": "Crystal Carriage",
+          "description": "The finest coach in the land.",
+          "categories": [
+            "Panel 21"
+          ],
+          "items": [],
+          "variants": [],
+          "rarity": "rare",
+          "season": 7.10
+        }
+      ],
+      "AllowAgain": true
+    },
+    {
+      "BundleID": 107,
+      "Daily": [],
+      "Weekly": [
+        {
+          "id": "366hQXbFCZxv0cj1CdlGWbxLiiLIfVMb",
+          "item": "AthenaCharacter:CID_298_Athena_Commando_F_IceMaiden",
+          "name": "Krampus",
+          "description": "Here comes anti-claus...",
+          "categories": [],
+          "items": [
+            {
+              "item": "AthenaBackpack:BID_194_Krampus",
+              "name": "Brat Bag",
+              "variants": []
+            }
+          ],
+          "variants": [],
+          "rarity": "legendary",
+          "season": 7.10
+        },
+        {
+          "id": "CP80yVFrgkrL9sLYPzPbIaUBMl0e7wb8",
+          "item": "AthenaPickaxe:Pickaxe_ID_141_Krampus",
+          "name": "Brat Catcher",
+          "description": "Be on your best behavior.",
+          "categories": [],
+          "items": [],
+          "variants": [],
+          "rarity": "rare",
+          "season": 7.10
+        },
+        {
+          "id": "xGFmIv4hoWn9YiZJjGjCvdi5YjON1H5n",
+          "item": "AthenaGlider:Glider_ID_108_Krampus",
+          "name": "Krampus' Little Helper",
+          "description": "The greatest of all time.",
+          "categories": [],
+          "items": [],
+          "variants": [],
+          "rarity": "rare",
+          "season": 7.10
+        }
+      ],
+      "AllowAgain": true
+    }
+    
+  ],
+  "Normal": [
+    {
+      "id": "O8eu63w785LKCx0pvPh2NFQZhVq5I77W",
+      "item": "AthenaCharacter:CID_051_Athena_Commando_M_HolidayElf",
+      "name": "Codename E.L.F.",
+      "description": "Elusive. Lethal. Festive.",
+      "categories": [],
+      "items": [
+        {
+          "item": "AthenaBackpack:BID_445_Elf",
+          "name": "E.L.F. Shield",
+          "variants": [
+            {
+              "channel": "Material",
+              "active": "Mat1",
+              "owned": [
+                "Mat1",
+                "Mat2",
+                "Mat3"
+              ]
+            }
+          ]
+        }
+      ],
+      "variants": [
+        {
+          "channel": "Material",
+          "active": "Mat1",
+          "owned": [
+            "Mat1",
+            "Mat2",
+            "Mat3"
+          ]
+        }
+      ],
+      "rarity": "rare",
+      "season": 1
+    },
+    {
+      "id": "FIkjtr7lbQqb9KFyWiDAEMlZ14VIUFq5",
+      "item": "AthenaCharacter:CID_047_Athena_Commando_F_HolidayReindeer",
+      "name": "Red-Nosed Raider",
+      "description": "It's time for some reindeer games.",
+      "categories": [],
+      "items": [],
+      "rarity": "rare",
+      "season": 1.11
+    },
+    {
+      "id": "LTXwvhloGMmUYJpaA20Jrbv0fyagnh90",
+      "item": "AthenaCharacter:CID_311_Athena_Commando_M_Reindeer",
+      "name": "Red-nosed Ranger",
+      "description": "Known for his antler antics.",
+      "categories": [],
+      "items": [],
+      "rarity": "uncommon",
+      "season": 7.10
+    },
+    {
+      "id": "5sj2FnJTZEvBIZb20oEINlwGtyzlUjE5",
+      "item": "AthenaCharacter:CID_280_Athena_Commando_M_Snowman",
+      "name": "Slushy Soldier",
+      "description": "Make every day a snow day.",
+      "categories": [],
+      "items": [
+        {
+          "item": "AthenaBackpack:BID_164_SnowmanMale",
+          "name": "Slushy Jr."
+        }
+      ],
+      "rarity": "epic",
+      "season": 7.10
+    },
+    {
+      "id": "G93bXxIvDhNEhRppjvMAAmv0aVy3myHx",
+      "item": "AthenaItemWrap:Wrap_007_CandyCane",
+      "name": "Candy Cane",
+      "description": "Show your style.",
+      "categories": [],
+      "items": [],
+      "rarity": "uncommon",
+      "season": 7.10
+    },
+    {
+      "id": "WxthsiLtot5Z7VDz8IIfKQHs30s2UEM6",
+      "item": "AthenaCharacter:CID_222_Athena_Commando_F_DarkViking",
+      "name": "Valkyrie",
+      "description": "A chilling revelation.",
+      "categories": [],
+      "items": [
+        {
+          "item": "AthenaBackpack:BID_113_DarkVikingFemale",
+          "name": "Valkyrie Wings"
+        }
+      ],
+      "rarity": "legendary",
+      "season": 5.41
+    },
+    {
+      "id": "yWf118jRFslzjyzZs8rBOtVgqTN5Gl3j",
+      "item": "AthenaGlider:Glider_ID_070_DarkViking",
+      "name": "Frostwing",
+      "description": "Awoken from ageless slumber.",
+      "categories": [],
+      "items": [],
+      "rarity": "legendary",
+      "season": 5.41
+    },
+    {
+      "id": "hdtBS4xQzcGVRcCqvTkSZ6SB22Jtn0Yt",
+      "item": "AthenaCharacter:CID_316_Athena_Commando_F_WinterHoliday",
+      "name": "Tinseltoes",
+      "description": "Keep the competition on their toes.",
+      "categories": [],
+      "items": [],
+      "rarity": "uncommon",
+      "season": 7.10
+    },
+    {
+      "id": "IGRZR5cHegMfhcujL8JMnztZJBcV7ibj",
+      "item": "AthenaGlider:Glider_ID_113_Barbarian",
+      "name": "Tusk",
+      "description": "Wild and woolly.",
+      "categories": [],
+      "items": [],
+      "rarity": "uncommon",
+      "season": 7.10
+    },
+    {
+      "id": "jcKGjqNdbWHmbhr70DTD8H2SFr3xaVNp",
+      "item": "AthenaCharacter:CID_304_Athena_Commando_M_Gnome",
+      "name": "Grimbles",
+      "description": "This garden gnome is at home on the roam in a snowy biome.",
+      "categories": [],
+      "items": [
+        {
+          "item": "AthenaBackpack:BID_185_GnomeMale",
+          "name": "Luminous Lamp"
+        }
+      ],
+      "variants": [
+        {
+          "channel": "Material",
+          "active": "Mat0",
+          "owned": [
+            "Mat0",
+            "Mat1"
+          ]
+        }
+      ],
+      "rarity": "rare",
+      "season": 7.10
+    },
+    {
+      "id": "mEt9Y11b7QEBK3CGVknqDbcKFNJWSBxn",
+      "item": "AthenaPickaxe:Pickaxe_ID_138_Gnome",
+      "name": "Cold Snap",
+      "description": "Frosted and flowery.",
+      "categories": [],
+      "items": [],
+      "variants": [],
+      "rarity": "rare",
+      "season": 7.10
+    },
+    {
+      "id": "GUf6kNTKiMluzwjsqjdeaLwPdpQIoL2M",
+      "item": "AthenaPickaxe:Pickaxe_ID_134_Snowman",
+      "name": "Icicle",
+      "description": "Cold to the touch.",
+      "categories": [],
+      "items": [],
+      "variants": [],
+      "rarity": "uncommon",
+      "season": 7.10
+    },
+    {
+      "id": "qFXKMNAGyLJVfKNbYDtfv07u6o2Hhht6",
+      "item": "AthenaDance:EID_PresentOpening",
+      "name": "Unwrapped",
+      "description": "What did you get me?",
+      "categories": [],
+      "items": [],
+      "variants": [],
+      "rarity": "uncommon",
+      "season": 7.10
+    },
+    {
+      "id": "eYWJtex220Rwm8vKySGZqJAOQQDPjwYn",
+      "item": "AthenaCharacter:CID_641_Athena_Commando_M_SweaterWeather",
+      "name": "Dolph",
+      "description": "He came to sleigh.",
+      "categories": [],
+      "items": [
+        {
+          "item": "AthenaBackpack:BID_438_SweaterWeather",
+          "name": "Bough Breaker",
+          "variants": []
+        }
+      ],
+      "rarity": "rare",
+      "season": 11.30
+    }
+  ]
+}

--- a/FortBackend/Resources/Json/shop/gliders.json
+++ b/FortBackend/Resources/Json/shop/gliders.json
@@ -40,16 +40,6 @@
     "season": 1
   },
   {
-    "id": "HhDUZWLEAj8G-HtvOlivT6bxstq6jHn0iitI5JRL",
-    "item": "AthenaGlider:Glider_ID_005_HolidaySweater",
-    "name": "Cozy Coaster",
-    "description": "Snuggle up to the firefight in holiday style.",
-    "items": [],
-    "variants": [],
-    "rarity": "rare",
-    "season": 1
-  },
-  {
     "id": "N5jWBU26WGFxmdJH9ICH-E4PjO5krGuA4Ke4rWuH",
     "item": "AthenaGlider:Glider_ID_006_WinterCamo",
     "name": "Snow Squall",
@@ -1020,16 +1010,6 @@
     "season": 7
   },
   {
-    "id": "MYVAanscLR1LFV7Ps91tUnZmGvnqISraYUMYODKa",
-    "item": "AthenaGlider:Glider_ID_119_ReaperFrozen",
-    "name": "Frozen Feathers",
-    "description": "A cold wind bellows.",
-    "items": [],
-    "variants": [],
-    "rarity": "frozen",
-    "season": 7
-  },
-  {
     "id": "KKGHN0tmYtZBmRjhfrWWJepR21boqmPVeMfIHzVZ",
     "item": "AthenaGlider:Glider_ID_120_IceCream",
     "name": "Ice Cream Cruiser",
@@ -1157,16 +1137,6 @@
     "items": [],
     "variants": [],
     "rarity": "legendary",
-    "season": 8
-  },
-  {
-    "id": "AevXd8OaqQjz9HG4cuzcvNBw0FNDUhvcdcruIQDV",
-    "item": "AthenaGlider:Glider_ID_134_DarkVikingFire",
-    "name": "Lavawing",
-    "description": "Awoken by a violent eruption.",
-    "items": [],
-    "variants": [],
-    "rarity": "lava",
     "season": 8
   },
   {

--- a/FortBackend/Resources/Json/shop/halloween.json
+++ b/FortBackend/Resources/Json/shop/halloween.json
@@ -1,229 +1,240 @@
 [
-    {
-        "item": "AthenaCharacter:CID_029_Athena_Commando_F_Halloween",
-        "name": "Ghoul Trooper",
-        "description": "Epic ghoul trooper outfit.",
-        "items": [],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_030_Athena_Commando_M_Halloween",
-        "name": "Skull Trooper",
-        "description": "Victory runs bone-deep.",
-        "items": [],
-        "rarity": "epic"
-    }, 
-    {
-        "item": "AthenaCharacter:CID_102_Athena_Commando_M_Raven",
-        "name": "Raven",
-        "description": "Brooding master of dark skies.",
-        "items": [],
-        "rarity": "legendary"
-    },
-    {
-        "item": "AthenaCharacter:CID_194_Athena_Commando_F_RavenQuill",
-        "name": "Ravage",
-        "description": "Circling overhead, shrouded by night...",
-        "items": [],
-        "rarity": "legendary"
-    },
-    {
-        "item": "AthenaCharacter:CID_220_Athena_Commando_F_Clown",
-        "name": "Peekaboo",
-        "description": "I see you!",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_111_ClownFemale",
-                "name": "Battle Balloon"
-            }
-        ],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_221_Athena_Commando_M_Clown",
-        "name": "Nite Nite",
-        "description": "Sleep tight!",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_112_ClownMale",
-                "name": "Balloon Llama"
-            }
-        ],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_243_Athena_Commando_M_PumpkinSlice",
-        "name": "Hollowhead",
-        "description": "All tricks. No treats.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_129_PumpkinSlice",
-                "name": "Mouldering Cloak"
-            }
-        ],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_244_Athena_Commando_M_PumpkinSuit",
-        "name": "Jack Gourdon",
-        "description": "Squash the competition.",
-        "items": [],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_246_Athena_Commando_F_Grave",
-        "name": "Skull Ranger",
-        "description": "She's got a bone to pick.",
-        "items": [],
-        "rarity": "rare"
-    },
-    {
-        "item": "AthenaCharacter:CID_248_Athena_Commando_M_BlackWidow",
-        "name": "Spider Knight",
-        "description": "They'll fall into your web.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_132_BlackWidowMale",
-                "name": "Spider Shield"
-            }
-        ],
-        "rarity": "legendary"
-    },
-    {
-        "item": "AthenaCharacter:CID_249_Athena_Commando_F_BlackWidow",
-        "name": "Arachne",
-        "description": "Weave a web to victory.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_131_BlackWidowfemale",
-                "name": "Long Legs"
-            }
-        ],
-        "rarity": "legendary"
-    },
-    {
-        "item": "AthenaCharacter:CID_250_Athena_Commando_M_EvilCowboy",
-        "name": "Deadfire",
-        "description": "This town ain't big enough... Reactive: Transforms by dealing damage, or by outliving other players.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_137_EvilCowboy",
-                "name": "Shackled Stone"
-            }
-        ],
-        "rarity": "legendary"
-    },
-    {
-        "item": "AthenaCharacter:CID_251_Athena_Commando_F_Muertos",
-        "name": "Rosa",
-        "description": "Celebrate the unknown. Reactive: Glows in the dark",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_135_MuertosFemale",
-                "name": "Calavera"
-            }
-        ],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_252_Athena_Commando_M_Muertos",
-        "name": "Dante",
-        "description": "Back for more. Reactive: Glows in the dark",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_136_MuertosMale",
-                "name": "Spirit Cape"
-            }
-        ],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_325_Athena_Commando_M_WavyMan",
-        "name": "Bendie",
-        "description": "Plagued by uncontrollable fits of bending.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_201_WavyManMale",
-                "name": "Bendie Inflator"
-            }
-        ],
-        "rarity": "rare"
-    },
-    {
-        "item": "AthenaCharacter:CID_326_Athena_Commando_F_WavyMan",
-        "name": "Twistie",
-        "description": "Partially inflated, and ready to flop to the top.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_202_WavyManFemale",
-                "name": "Twistie Inflator"
-            }
-        ],
-        "rarity": "rare"
-    },
-    {
-        "item": "AthenaCharacter:CID_258_Athena_Commando_F_FuzzyBearHalloween",
-        "name": "Spooky Team Leader",
-        "description": "Find delight in fright.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_139_FuzzyBearHalloween",
-                "name": "Goodie Gourd"
-            }
-        ],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_269_Athena_Commando_M_Wizard",
-        "name": "Castor",
-        "description": "The wandering warlock of Wailing Woods.",
-        "items": [{
-            "item": "AthenaBackpack:BID_149_Wizard",
-            "name": "Spellbinder"
-        }],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_270_Athena_Commando_F_Witch",
-        "name": "Elmira",
-        "description": "She'll literally charm you.",
-        "items": [{
-            "item": "AthenaBackpack:BID_150_Witch",
-            "name": "Tome Pouch"
-        }],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaDance:EID_HalloweenCandy",
-        "name": "Treat Yourself",
-        "description": "Go ahead and take two... or the entire bucket.",
-        "items": [],
-        "rarity": "rare"
-    },
-    {
-        "item": "AthenaCharacter:CID_236_Athena_Commando_F_Scarecrow",
-        "name": "Straw Ops",
-        "description": "The harvest grows near.",
-        "items": [
-            {
-                "item": "AthenaBackpack:BID_125_ScarecrowFemale",
-                "name": "Birdhovel"
-            }
-        ],
-        "rarity": "epic"
-    },
-    {
-        "item": "AthenaCharacter:CID_254_Athena_Commando_M_Zombie",
-        "name": "Brainiac",
-        "description": "Victory takes braaaains.",
-        "items": [],
-        "rarity": "uncommon"
-    },
-    {
-        "item": "AthenaDance:EID_Zombie",
-        "name": "Reanimated",
-        "description": "From beyond the rave!",
-        "items": [],
-        "rarity": "epic"
-    }
+  {
+    "item": "AthenaGlider:Glider_ID_085_SkullTrooper",
+    "name": "Crypt Cruiser",
+    "description": "From beyond the grave!",
+    "items": [],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_029_Athena_Commando_F_Halloween",
+    "name": "Ghoul Trooper",
+    "description": "Epic ghoul trooper outfit.",
+    "items": [],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_030_Athena_Commando_M_Halloween",
+    "name": "Skull Trooper",
+    "description": "Victory runs bone-deep.",
+    "items": [],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_102_Athena_Commando_M_Raven",
+    "name": "Raven",
+    "description": "Brooding master of dark skies.",
+    "items": [],
+    "rarity": "legendary"
+  },
+  {
+    "item": "AthenaCharacter:CID_194_Athena_Commando_F_RavenQuill",
+    "name": "Ravage",
+    "description": "Circling overhead, shrouded by night...",
+    "items": [],
+    "rarity": "legendary"
+  },
+  {
+    "item": "AthenaCharacter:CID_220_Athena_Commando_F_Clown",
+    "name": "Peekaboo",
+    "description": "I see you!",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_111_ClownFemale",
+        "name": "Battle Balloon"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_221_Athena_Commando_M_Clown",
+    "name": "Nite Nite",
+    "description": "Sleep tight!",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_112_ClownMale",
+        "name": "Balloon Llama"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_243_Athena_Commando_M_PumpkinSlice",
+    "name": "Hollowhead",
+    "description": "All tricks. No treats.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_129_PumpkinSlice",
+        "name": "Mouldering Cloak"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_244_Athena_Commando_M_PumpkinSuit",
+    "name": "Jack Gourdon",
+    "description": "Squash the competition.",
+    "items": [],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_246_Athena_Commando_F_Grave",
+    "name": "Skull Ranger",
+    "description": "She's got a bone to pick.",
+    "items": [],
+    "rarity": "rare"
+  },
+  {
+    "item": "AthenaCharacter:CID_248_Athena_Commando_M_BlackWidow",
+    "name": "Spider Knight",
+    "description": "They'll fall into your web.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_132_BlackWidowMale",
+        "name": "Spider Shield"
+      }
+    ],
+    "rarity": "legendary"
+  },
+  {
+    "item": "AthenaCharacter:CID_249_Athena_Commando_F_BlackWidow",
+    "name": "Arachne",
+    "description": "Weave a web to victory.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_131_BlackWidowfemale",
+        "name": "Long Legs"
+      }
+    ],
+    "rarity": "legendary"
+  },
+  {
+    "item": "AthenaCharacter:CID_250_Athena_Commando_M_EvilCowboy",
+    "name": "Deadfire",
+    "description": "This town ain't big enough... Reactive: Transforms by dealing damage, or by outliving other players.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_137_EvilCowboy",
+        "name": "Shackled Stone"
+      }
+    ],
+    "rarity": "legendary"
+  },
+  {
+    "item": "AthenaCharacter:CID_251_Athena_Commando_F_Muertos",
+    "name": "Rosa",
+    "description": "Celebrate the unknown. Reactive: Glows in the dark",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_135_MuertosFemale",
+        "name": "Calavera"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_252_Athena_Commando_M_Muertos",
+    "name": "Dante",
+    "description": "Back for more. Reactive: Glows in the dark",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_136_MuertosMale",
+        "name": "Spirit Cape"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_325_Athena_Commando_M_WavyMan",
+    "name": "Bendie",
+    "description": "Plagued by uncontrollable fits of bending.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_201_WavyManMale",
+        "name": "Bendie Inflator"
+      }
+    ],
+    "rarity": "rare"
+  },
+  {
+    "item": "AthenaCharacter:CID_326_Athena_Commando_F_WavyMan",
+    "name": "Twistie",
+    "description": "Partially inflated, and ready to flop to the top.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_202_WavyManFemale",
+        "name": "Twistie Inflator"
+      }
+    ],
+    "rarity": "rare"
+  },
+  {
+    "item": "AthenaCharacter:CID_258_Athena_Commando_F_FuzzyBearHalloween",
+    "name": "Spooky Team Leader",
+    "description": "Find delight in fright.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_139_FuzzyBearHalloween",
+        "name": "Goodie Gourd"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_269_Athena_Commando_M_Wizard",
+    "name": "Castor",
+    "description": "The wandering warlock of Wailing Woods.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_149_Wizard",
+        "name": "Spellbinder"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_270_Athena_Commando_F_Witch",
+    "name": "Elmira",
+    "description": "She'll literally charm you.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_150_Witch",
+        "name": "Tome Pouch"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaDance:EID_HalloweenCandy",
+    "name": "Treat Yourself",
+    "description": "Go ahead and take two... or the entire bucket.",
+    "items": [],
+    "rarity": "rare"
+  },
+  {
+    "item": "AthenaCharacter:CID_236_Athena_Commando_F_Scarecrow",
+    "name": "Straw Ops",
+    "description": "The harvest grows near.",
+    "items": [
+      {
+        "item": "AthenaBackpack:BID_125_ScarecrowFemale",
+        "name": "Birdhovel"
+      }
+    ],
+    "rarity": "epic"
+  },
+  {
+    "item": "AthenaCharacter:CID_254_Athena_Commando_M_Zombie",
+    "name": "Brainiac",
+    "description": "Victory takes braaaains.",
+    "items": [],
+    "rarity": "uncommon"
+  },
+  {
+    "item": "AthenaDance:EID_Zombie",
+    "name": "Reanimated",
+    "description": "From beyond the rave!",
+    "items": [],
+    "rarity": "epic"
+  }
 ]

--- a/FortBackend/Resources/Json/shop/pickaxes.json
+++ b/FortBackend/Resources/Json/shop/pickaxes.json
@@ -120,16 +120,6 @@
     "season": 1
   },
   {
-    "id": "T3tX5lwbHEPIbCiJtyNPF85KWy1TCyT0G8jFNtHy",
-    "item": "AthenaPickaxe:Pickaxe_ID_022_HolidayGiftWrap",
-    "name": "You Shouldn't Have!",
-    "description": "For the combatant who has everything.",
-    "items": [],
-    "variants": [],
-    "rarity": "uncommon",
-    "season": 1
-  },
-  {
     "id": "cqBHXvqMYRVMafxXuLNHLTYxu4kLpI4EvMMWTP4T",
     "item": "AthenaPickaxe:Pickaxe_ID_023_SkiBoot",
     "name": "Ski Boot",
@@ -1047,16 +1037,6 @@
     "items": [],
     "variants": [],
     "rarity": "rare",
-    "season": 7
-  },
-  {
-    "id": "JOMxmFlqo8jI6XHyyxP1bbtHRDc5wFQ1eMb4FDB6",
-    "item": "AthenaPickaxe:Pickaxe_ID_139_Gingerbread",
-    "name": "Cookie Cutter",
-    "description": "Sweet vengeance.",
-    "items": [],
-    "variants": [],
-    "rarity": "uncommon",
     "season": 7
   },
   {

--- a/FortBackend/Resources/Json/shop/prices.json
+++ b/FortBackend/Resources/Json/shop/prices.json
@@ -29,7 +29,8 @@
     "icon": 500,
     "dc": 1200,
     "dark": 500,
-    "marvel": 1200
+    "marvel": 1200,
+    "lava": 
   },
   "wrap": {
     "uncommon": 300,

--- a/FortBackend/src/App/Routes/ADMIN/AdminCashCup.cs
+++ b/FortBackend/src/App/Routes/ADMIN/AdminCashCup.cs
@@ -63,7 +63,7 @@ namespace FortBackend.src.App.Routes.ADMIN
                             {
                                 CreateBody createBody = JsonConvert.DeserializeObject<CreateBody>(rawRequestBody)!;
 
-                                Console.WriteLine(JsonConvert.SerializeObject(createBody));
+                                Logger.PlainLog(JsonConvert.SerializeObject(createBody));
                                 // stupid as check i could probably do a better way
                                 if (createBody != null && (
                                     string.IsNullOrEmpty(createBody.title) ||

--- a/FortBackend/src/App/Routes/ADMIN/DashboardContentController.cs
+++ b/FortBackend/src/App/Routes/ADMIN/DashboardContentController.cs
@@ -349,8 +349,6 @@ namespace FortBackend.src.App.Routes.ADMIN
                                 {
                                     if (SectionId == 1)
                                     {
-                                        Console.WriteLine(numberBox);
-
                                         Saved.DeserializeGameConfig.Season = numberBox;
                                         Saved.DeserializeGameConfig.ForceSeason = RadioValue;
 
@@ -426,7 +424,6 @@ namespace FortBackend.src.App.Routes.ADMIN
                                                             if (!currentValue.Equals(numberBox))
                                                             {
                                                                 property.SetValue(fortConfig, numberBox);
-                                                                Console.WriteLine(numberBox);
                                                             }
                                                         }
 
@@ -563,7 +560,7 @@ namespace FortBackend.src.App.Routes.ADMIN
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error updating temp data: {ex.Message}");
+                Logger.Error($"Error updating temp data: {ex.Message}", "[Dashboard]");
                 return Json(false);
             }
 

--- a/FortBackend/src/App/Routes/ADMIN/DashboardContentController.cs
+++ b/FortBackend/src/App/Routes/ADMIN/DashboardContentController.cs
@@ -188,7 +188,7 @@ namespace FortBackend.src.App.Routes.ADMIN
             }
             catch (Exception ex)
             {
-                Logger.Error(ex.Message, "DashboardContentID");
+                Logger.Error(ex.Message, "DashboardContentID_INI");
             }
 
             return Json(new
@@ -250,7 +250,7 @@ namespace FortBackend.src.App.Routes.ADMIN
                                 //var Context = contextL;
                                 string? Title = FormRequest["title"];
                                 string? Body = FormRequest["body"];
-                                int numberBox = int.TryParse(FormRequest["NumberBox"], out int tempNumber) ? tempNumber : 0;
+                                float numberBox = float.TryParse(FormRequest["NumberBox"], out float tempNumber) ? tempNumber : 0;
                                 string ? SectionPart = FormRequest["newsId"];
                                 int SectionId = int.TryParse(FormRequest["sectionId"], out int TempcontentId) ? TempcontentId : 0;
                                 string? RadioBox = FormRequest["RadioBox"];
@@ -426,6 +426,14 @@ namespace FortBackend.src.App.Routes.ADMIN
                                                                 property.SetValue(fortConfig, numberBox);
                                                             }
                                                         }
+                                                        else if (Configdata.Type == "float")
+                                                        {
+                                                            if (!currentValue.Equals(numberBox))
+                                                            {
+                                                                property.SetValue(fortConfig, numberBox);
+                                                            }
+                                                        }
+
 
                                                         // just gonna do it every time
                                                         var FortConfigPath = PathConstants.CachedPaths.FortConfig;

--- a/FortBackend/src/App/Routes/ADMIN/DashboardPanelController.cs
+++ b/FortBackend/src/App/Routes/ADMIN/DashboardPanelController.cs
@@ -81,7 +81,7 @@ namespace FortBackend.src.App.Routes.ADMIN
 
                                 if (adminProfileCacheEntry != null)
                                 {
-                                    Console.WriteLine("WANTING TO UPDATE USERS DATA");
+                                    Logger.Log("WANTING TO UPDATE USERS DATA");
                                     await GrabAdminData.EditAdminV2(adminProfileCacheEntry.profileCacheEntry.UserData.Username,
                                         new AdminDataInfo
                                         {

--- a/FortBackend/src/App/Routes/ADMIN/HomeController.cs
+++ b/FortBackend/src/App/Routes/ADMIN/HomeController.cs
@@ -71,9 +71,9 @@ namespace FortBackend.src.App.Routes.ADMIN
 
                 if (!string.IsNullOrEmpty(authToken))
                 {
-                    Console.WriteLine(authToken);
+                    Logger.PlainLog(authToken);
                     AdminData adminData = Saved.CachedAdminData.Data?.FirstOrDefault(e => e.AccessToken.ToLower() == authToken)!;
-                    Console.WriteLine(JsonConvert.SerializeObject(adminData));
+                    Logger.PlainLog(JsonConvert.SerializeObject(adminData));
                     if (adminData != null)
                     {
                         if (adminData.bIsSetup)
@@ -114,7 +114,7 @@ namespace FortBackend.src.App.Routes.ADMIN
                     AdminData adminData = Saved.CachedAdminData.Data?.FirstOrDefault(e => e.AccessToken == authToken);
                     if (adminData != null)
                     {
-                        Console.WriteLine(JsonConvert.SerializeObject(adminData));
+                        Logger.PlainLog(JsonConvert.SerializeObject(adminData));
                         if (adminData != null)
                         {
                             if (adminData.bIsSetup)
@@ -168,7 +168,6 @@ namespace FortBackend.src.App.Routes.ADMIN
 
                 if (FormRequest.TryGetValue("email", out var emailL))
                 {
-                    Console.WriteLine("GI " + emailL);
                     email = emailL;
                 }
                 if (FormRequest.TryGetValue("password", out var passwordL))
@@ -205,7 +204,7 @@ namespace FortBackend.src.App.Routes.ADMIN
                             Expires = DateTime.UtcNow.AddDays(7)
                         });
 
-                        Console.WriteLine("ADDED TOKEN!");
+                        Logger.PlainLog("ADDED TOKEN!");
 
                         return Ok(new { message = "Login successful", Token, setup = true }); // setup? ig
                     }
@@ -241,10 +240,10 @@ namespace FortBackend.src.App.Routes.ADMIN
                         {
                             if (Request.Cookies.TryGetValue("AuthToken", out string? authToken))
                             {
-                                Console.WriteLine(authToken);
+                                Logger.PlainLog(authToken);
                                 if (adminData != null)
                                 {
-                                    Console.WriteLine(adminData.AccessToken);
+                                    Logger.PlainLog(adminData.AccessToken);
                                     if (adminData.AccessToken == authToken)
                                     {
                                         return Ok(new { message = "Login successful", Token, setup = false });
@@ -290,7 +289,6 @@ namespace FortBackend.src.App.Routes.ADMIN
 
                         if (profileCacheEntry != null)
                         {
-                            Console.WriteLine("TEST");
                             if (CryptoGen.VerifyPassword(password, profileCacheEntry.UserData.Password))
                             {
                                 var Token = JWT.GenerateRandomJwtToken(24, Saved.DeserializeConfig.JWTKEY);

--- a/FortBackend/src/App/Routes/ADMIN/NewFolder/ContentController.cs
+++ b/FortBackend/src/App/Routes/ADMIN/NewFolder/ContentController.cs
@@ -155,7 +155,7 @@ namespace FortBackend.src.App.Routes.ADMIN.NewFolder
             }
             catch (Exception ex)
             {
-                Logger.Error(ex.Message, "DashboardContentID");
+                Logger.Error(ex.Message, "DashboardContentID_V2");
             }
 
             return Json(new
@@ -215,7 +215,7 @@ namespace FortBackend.src.App.Routes.ADMIN.NewFolder
             }
             catch (Exception ex)
             {
-                Logger.Error(ex.Message, "DashboardContentID");
+                Logger.Error(ex.Message, "DashboardContentID_CoV2");
             }
 
             return Json(new

--- a/FortBackend/src/App/Routes/ADMIN/NewFolder/ContentUpdate.cs
+++ b/FortBackend/src/App/Routes/ADMIN/NewFolder/ContentUpdate.cs
@@ -33,7 +33,7 @@ namespace FortBackend.src.App.Routes.ADMIN.NewFolder
         public class ServerContentRequest
         {
             public bool ForcedSeason { get; set; }
-            public int Season { get; set; } = 0;
+            public float Season { get; set; } = 0;
             public int WeeklyQuests { get; set; } = 0;
             public bool ShopRotation { get; set; } 
         }

--- a/FortBackend/src/App/Routes/ADMIN/NewFolder/ContentUpdate.cs
+++ b/FortBackend/src/App/Routes/ADMIN/NewFolder/ContentUpdate.cs
@@ -3,6 +3,7 @@ using FortBackend.src.App.Utilities.Constants;
 using FortBackend.src.App.Utilities.Helpers;
 using FortBackend.src.App.Utilities.Helpers.Cached;
 using FortBackend.src.App.Utilities.Saved;
+using FortLibrary;
 using FortLibrary.ConfigHelpers;
 using FortLibrary.Dynamics;
 using Microsoft.Extensions.Primitives;
@@ -48,10 +49,10 @@ namespace FortBackend.src.App.Routes.ADMIN.NewFolder
         {
           
             // News Updates
-            Console.WriteLine(Body);
-            Console.WriteLine(ContentName);
-            Console.WriteLine(ContentID);
-            Console.WriteLine(Index);
+            Logger.PlainLog(Body);
+            Logger.PlainLog(ContentName);
+            Logger.PlainLog(ContentID);
+            Logger.PlainLog(Index);
             if (ContentName == "news")
             {
                 ContentRequest contentRequest = JsonConvert.DeserializeObject<ContentRequest>(Body)!;
@@ -210,7 +211,7 @@ namespace FortBackend.src.App.Routes.ADMIN.NewFolder
                     }
                     else iniConfigFiles.Data = new();
 
-                    Console.WriteLine(ResponseConv.FileName);
+                    Logger.PlainLog(ResponseConv.FileName);
 
                     var lines = ResponseConv.IniValue.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
                     IniConfigData? currentSection = null;
@@ -276,21 +277,21 @@ namespace FortBackend.src.App.Routes.ADMIN.NewFolder
                     List<IniContextRequest> ResponseConv = JsonConvert.DeserializeObject<List<IniContextRequest>>(Body)!;
                     FortConfig fortConfig = Saved.DeserializeConfig;
 
-                    Console.WriteLine("YHEA");
+                    Logger.PlainLog("YHEA");
 
                     // the dashboardconfigdata isnt used anywhere frtom the dashbaord and changing data wont simply work!
                     ResponseConv.ForEach(x =>
                     {
                         ConfigData Configdata = Configtop[x.index];
-                        Console.WriteLine(Configdata.Title);
-                        Console.WriteLine(JsonConvert.SerializeObject(Configdata));
+                        Logger.PlainLog(Configdata.Title);
+                        Logger.PlainLog(JsonConvert.SerializeObject(Configdata));
                         PropertyInfo property = typeof(FortConfig).GetProperty(Configdata.METADATA)!;
                         if (property != null)
                         {
                             var currentValue = property.GetValue(fortConfig);
                             if (currentValue != null)
                             {
-                                Console.WriteLine("E");
+                                Logger.PlainLog("E");
                                 if (Configdata.Type == "string")
                                 {
                                     if (!currentValue.Equals(x.value))
@@ -312,8 +313,8 @@ namespace FortBackend.src.App.Routes.ADMIN.NewFolder
                                 {
                                     // converts value to bool...
                                     bool BoolValue = false;
-                                    Console.WriteLine("TEST");
-                                    Console.WriteLine(x.value);
+                                    Logger.PlainLog("TEST");
+                                    Logger.PlainLog(x.value);
                                     try { BoolValue = bool.Parse(x.value); } catch { };
 
                                     if (!currentValue.Equals(BoolValue))

--- a/FortBackend/src/App/Routes/API/ContentController.cs
+++ b/FortBackend/src/App/Routes/API/ContentController.cs
@@ -41,7 +41,7 @@ namespace FortBackend.src.App.Routes.API
                     AcceptLanguage = "en"; // weird
                 }
 
-                Console.WriteLine(AcceptLanguage);
+                Logger.PlainLog(AcceptLanguage);
 
 
                 var cacheKey = $"ContentEndpointKey-{season}";

--- a/FortBackend/src/App/Routes/API/FortniteController.cs
+++ b/FortBackend/src/App/Routes/API/FortniteController.cs
@@ -305,5 +305,32 @@ namespace FortBackend.src.App.Routes.API
             return Ok(new { });
         }
 
+        [HttpGet("game/v2/homebase/allowed-name-chars")]
+        [AuthorizeToken]
+        public IActionResult AllowNameChars()
+        {
+            try
+            {
+                Response.ContentType = "application/json";
+                return Ok(new
+                {
+                    ranges = new List<int>() {
+                    48, 57, 65, 90, 97, 122, 192, 255, 260, 265, 280, 281, 286, 287, 304, 305,
+                    321, 324, 346, 347, 350, 351, 377, 380, 1024, 1279, 1536, 1791, 4352, 4607,
+                    11904, 12031, 12288, 12351, 12352, 12543, 12592, 12687, 12800, 13055, 13056,
+                    13311, 13312, 19903, 19968, 40959, 43360, 43391, 44032, 55215, 55216, 55295,
+                    63744, 64255, 65072, 65103, 65281, 65470, 131072, 173791, 194560, 195103
+                },
+                    singlePoints = new List<int>() { 32, 39, 45, 46, 95, 126 },
+                    excludedPoints = new List<int>() { 208, 215, 222, 247 }
+                });
+            }
+            catch(Exception ex)
+            {
+                Logger.Error(ex.Message, "AllowNameChars");
+            }
+
+            return Ok(new { });
+        }
     }
 }

--- a/FortBackend/src/App/Routes/API/FortniteController.cs
+++ b/FortBackend/src/App/Routes/API/FortniteController.cs
@@ -210,7 +210,7 @@ namespace FortBackend.src.App.Routes.API
                 {
                     string RequestBody = await reader.ReadToEndAsync();
                     if (string.IsNullOrEmpty(RequestBody)) return Ok(new { }); // uhm?
-                    Console.WriteLine(RequestBody);
+                    
                     //ReportUserClass
                     ReportUserClass reportUserClass = JsonConvert.DeserializeObject<ReportUserClass>(RequestBody)!;
 
@@ -280,16 +280,16 @@ namespace FortBackend.src.App.Routes.API
                                 HttpResponseMessage response32 = await httpClient.PostAsync(Saved.DeserializeConfig.ReportsWebhookUrl, httpContent1);
                                 if (response32.IsSuccessStatusCode)
                                 {
-                                    Console.WriteLine("Message sent successfully!");
+                                    Logger.Log("Message sent successfully!");
                                 }
                                 else
                                 {
-                                    Console.WriteLine($"Failed to send message. Status code: {response32.StatusCode}");
+                                    Logger.Error($"Failed to send message. Status code: {response32.StatusCode}", "ReportFriends");
                                 }
                             }
                             catch (HttpRequestException ex)
                             {
-                                Console.WriteLine($"Error sending request: {ex.Message}");
+                                Logger.Error($"Error sending request: {ex.Message}", "ReportFriends");
                             }
                             //}
 

--- a/FortBackend/src/App/Routes/API/PresenceController.cs
+++ b/FortBackend/src/App/Routes/API/PresenceController.cs
@@ -6,28 +6,28 @@ namespace FortBackend.src.App.Routes.API
     [Route("presence/api/v1")]
     public class PresenceController : ControllerBase
     {
-        [HttpGet("_/{accountId}/settings/subscriptions")]
+        [HttpGet("{_}/{accountId}/settings/subscriptions")]
         public ActionResult GrabSettings(string accountId)
         {
             Response.ContentType = "application/json";
             return Ok(Array.Empty<string>());
         }
 
-        [HttpGet("_/{accountId}/last-online")]
+        [HttpGet("{_}/{accountId}/last-online")]
         public ActionResult GrabLastOnline(string accountId)
         {
             Response.ContentType = "application/json";
             return Ok(Array.Empty<string>());
         }
 
-        [HttpGet("_/{accountId}/subscriptions")]
+        [HttpGet("{_}/{accountId}/subscriptions")]
         public ActionResult SubWow(string accountId)
         {
             Response.ContentType = "application/json";
             return Ok(Array.Empty<string>());
         }
 
-        [HttpGet("_/{accountId}/subscriptions/nudged")]
+        [HttpGet("{_}/{accountId}/subscriptions/nudged")]
         public ActionResult GrabNudged(string accountId)
         {
             Response.ContentType = "application/json";

--- a/FortBackend/src/App/Routes/Friends/FriendController.cs
+++ b/FortBackend/src/App/Routes/Friends/FriendController.cs
@@ -92,7 +92,6 @@ namespace FortBackend.src.App.Routes.Friends
                 {
                     var body = await reader.ReadToEndAsync();
                     var requestData = JsonConvert.DeserializeObject<ProjectUserSearchC>(body);
-                    Console.WriteLine(body);
 
                     // i have issue something i rather do this then !=
                     if(requestData is not null && requestData.productUserIds.Count > 0)

--- a/FortBackend/src/App/Routes/Friends/PartyController.cs
+++ b/FortBackend/src/App/Routes/Friends/PartyController.cs
@@ -39,7 +39,7 @@ namespace FortBackend.src.App.Routes.Friends
             {
                 Response.ContentType = "application/json";
                 var Party = GlobalData.parties.Find(x => x.id == partyId);
-                Console.WriteLine("TESTAAA " + Party);
+                Logger.PlainLog("TESTAAA " + Party);
                 if (Party != null)
                 {
                     return Content(JsonConvert.SerializeObject(Party), "application/json");
@@ -228,7 +228,7 @@ namespace FortBackend.src.App.Routes.Friends
                                     //PatchPatiesC
                                     if (Parties != null && PatchPartyResponse != null)
                                     {
-                                        Console.WriteLine("yeah " + PatchPartyResponse.config);
+                                       Logger.PlainLog("yeah " + PatchPartyResponse.config);
                                         foreach (var prop in PatchPartyResponse.config.GetType().GetProperties())
                                         {
                                             Parties.config[prop.Name] = prop.GetValue(PatchPartyResponse.config)!;
@@ -298,7 +298,7 @@ namespace FortBackend.src.App.Routes.Friends
                                                             updated_at = Parties.updated_at
                                                         }))
                                                     );
-                                                    Console.WriteLine("SEND A XMPP MESSAGE");
+                                                    Logger.PlainLog("SEND A XMPP MESSAGE");
                                                     await SERVER.Send.Client.SendClientMessage(foundClient, message);
                                                     
                                                 }
@@ -312,7 +312,7 @@ namespace FortBackend.src.App.Routes.Friends
                                 }
                                 else
                                 {
-                                    Console.WriteLine("CLIENTINDEX IS NULL!!!");
+                                    Logger.PlainLog("CLIENTINDEX IS NULL!!!");
                                 }
                             }
                         }
@@ -633,11 +633,11 @@ namespace FortBackend.src.App.Routes.Friends
 
                         if (CurrentParty != null)
                         {
-                            Console.WriteLine(JsonConvert.SerializeObject(CurrentParty));
+                            Logger.PlainLog(JsonConvert.SerializeObject(CurrentParty));
                             using (StreamReader reader = new StreamReader(Request.Body, Encoding.UTF8))
                             {
                                 string requestBody = await reader.ReadToEndAsync();
-                                Console.WriteLine("INVITER + " + requestBody);
+                                Logger.PlainLog("INVITER + " + requestBody);
 
                                 var options = new JsonSerializerOptions
                                 {
@@ -648,8 +648,8 @@ namespace FortBackend.src.App.Routes.Friends
 
                                 if (invite != null)
                                 {
-                                    Console.WriteLine($"Member: {invite.MemberDisplayName ?? "N/A"}");
-                                    Console.WriteLine($"Platform: {invite.ConnectionPlatform ?? "N/A"}");
+                                    Logger.PlainLog($"Member: {invite.MemberDisplayName ?? "N/A"}");
+                                    Logger.PlainLog($"Platform: {invite.ConnectionPlatform ?? "N/A"}");
 
                                     var Invites = new
                                     {
@@ -666,11 +666,11 @@ namespace FortBackend.src.App.Routes.Friends
                                     CurrentParty.invites.Add(Invites);
                                     CurrentParty.updated_at = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
 
-                                    Console.WriteLine(profileCacheEntry.AccountId);
+                                    Logger.PlainLog(profileCacheEntry.AccountId);
 
                                     var UserInviting = CurrentParty.members.FirstOrDefault((member) => member.account_id == profileCacheEntry.AccountId);
 
-                                    Console.WriteLine(JsonConvert.SerializeObject(UserInviting));
+                                    Logger.PlainLog(JsonConvert.SerializeObject(UserInviting));
                                     if (UserInviting != null)
                                     {
                                         var foundClient = GlobalData.Clients.FirstOrDefault(client => client.accountId == accountId);
@@ -703,7 +703,7 @@ namespace FortBackend.src.App.Routes.Friends
                                                 }))
                                             );
 
-                                            Console.WriteLine(message.ToString());
+                                            Logger.PlainLog(message.ToString());
 
                                             await SERVER.Send.Client.SendClientMessage(foundClient, message);
                                         }
@@ -713,7 +713,7 @@ namespace FortBackend.src.App.Routes.Friends
                                 }
                                 else
                                 {
-                                    Console.WriteLine("Failed to deserialize the request body.");
+                                    Logger.PlainLog("Failed to deserialize the request body.");
                                 }
                             }
                          }
@@ -748,7 +748,7 @@ namespace FortBackend.src.App.Routes.Friends
                 using (StreamReader reader = new StreamReader(Request.Body, Encoding.UTF8))
                 {
                     string requestBody = await reader.ReadToEndAsync();
-                    Console.WriteLine("Fortnite/parties + " + requestBody);
+
                     if (string.IsNullOrEmpty(requestBody))
                     {
                         throw new BaseError
@@ -1107,10 +1107,10 @@ namespace FortBackend.src.App.Routes.Friends
                                                         if (foundClient != null)
                                                         {
                                                             XNamespace clientNs = "jabber:client";
-                                                            Console.WriteLine(JsonConvert.SerializeObject(JoinParty.connection.meta));
+                                                            Logger.PlainLog(JsonConvert.SerializeObject(JoinParty.connection.meta));
                                                             foreach(var testig in JoinParty.connection.meta)
                                                             {
-                                                                Console.WriteLine(testig.Key + " " + testig.Value);
+                                                                Logger.PlainLog(testig.Key + " " + testig.Value);
                                                             }
                                                             
                         
@@ -1168,7 +1168,7 @@ namespace FortBackend.src.App.Routes.Friends
                                                                    }))
                                                            ));
 
-                                                            Console.WriteLine("joined PARTY");
+                                                            Logger.PlainLog("joined PARTY");
                                                         }
                                                     });
                                                 }
@@ -1179,25 +1179,25 @@ namespace FortBackend.src.App.Routes.Friends
                                                 });
                                             }else
                                             {
-                                                Console.WriteLine("WTF");
+                                                Logger.PlainLog("WTF");
                                             }
                                         }
                                     } else
                                     {
-                                        Console.WriteLine("IT IS -1");
+                                        Logger.PlainLog("IT IS -1");
                                     }
                                 }else
                                 {
-                                    Console.WriteLine("JOIN PARTY IS NULL");
+                                    Logger.PlainLog("JOIN PARTY IS NULL");
                                 }
                             }
                         }else
                         {
-                            Console.WriteLine("ACCOUNT ISNT FOUND");
+                            Logger.PlainLog("ACCOUNT ISNT FOUND");
                         }
                     }else
                     {
-                        Console.WriteLine("ACCOUNT NULL");
+                        Logger.PlainLog("ACCOUNT NULL");
                     }
                     //var MemberIndex = Party.members.FindIndex(x => x.account_id == accountId);
 

--- a/FortBackend/src/App/Routes/Matchmaker/MatchmakerController.cs
+++ b/FortBackend/src/App/Routes/Matchmaker/MatchmakerController.cs
@@ -138,14 +138,9 @@ namespace FortBackend.src.App.Routes.Matchmaker
                 if (profileCacheEntry != null)
                 {
                     var tokenPayload = HttpContext.Items["Payload"] as TokenPayload;
-
-
                     var displayName = tokenPayload?.Dn;
                     var AccountId = tokenPayload?.Sub;
                     var clientId = tokenPayload?.Clid;
-
-                    Console.WriteLine(clientId);
-
 
                     if (profileCacheEntry.AccountData != null && profileCacheEntry.UserData != null)
                     {

--- a/FortBackend/src/App/Routes/Oauth/NewOauthController.cs
+++ b/FortBackend/src/App/Routes/Oauth/NewOauthController.cs
@@ -281,7 +281,7 @@ namespace FortBackend.src.App.Routes.Oauth
                 //refresh_token
                 //deployment_id
 
-                Console.WriteLine(FormRequest);
+                Logger.PlainLog(FormRequest);
                 string refresh_token = "";
                 string grant_type = "";
                 string scope = "";
@@ -369,15 +369,13 @@ namespace FortBackend.src.App.Routes.Oauth
                 var refreshTokenData = GlobalData.RefreshToken.FirstOrDefault(x => x.token == refresh_token);
                 if (refreshTokenData != null && !string.IsNullOrEmpty(refreshTokenData.token))
                 {
-                    Logger.Log("FOIUND A REFRESH TOKEN!!");
+                    Logger.PlainLog("FOIUND A REFRESH TOKEN!!");
                     var accessToken = refreshTokenData.token.Replace("eg1~", "");
                     var handler = new JwtSecurityTokenHandler();
                     var DecodedToken = handler.ReadJwtToken(accessToken);
                     string[] tokenParts = DecodedToken.ToString().Split(".");
 
-                    Console.WriteLine(accessToken);
-
-                    Console.WriteLine(DecodedToken);
+                    Logger.PlainLog(accessToken);
 
                     if (tokenParts.Length == 2)
                     {
@@ -390,7 +388,6 @@ namespace FortBackend.src.App.Routes.Oauth
                             var expTime = DateTimeOffset.FromUnixTimeSeconds(tokenPayload.Exp.Value);
                             if (DateTimeOffset.UtcNow >= expTime)
                             {
-                                Console.WriteLine("ERXPIRED");
                                 throw new BaseError
                                 {
                                     errorCode = "errors.com.epicgames.common.oauth.invalid_request",
@@ -418,7 +415,6 @@ namespace FortBackend.src.App.Routes.Oauth
                                 {
                                     if (JWT.VerifyTokenExpired(access_token_d.token))
                                     {
-                                        Console.WriteLine("EXPIRED");
                                         var DeviceID = Hex.GenerateRandomHexString(16);
 
                                         string AccessToken = JWT.GenerateJwtToken(new[]

--- a/FortBackend/src/App/Routes/Oauth/OauthController.cs
+++ b/FortBackend/src/App/Routes/Oauth/OauthController.cs
@@ -33,9 +33,6 @@ namespace FortBackend.src.App.Routes.Oauth
                 string accessToken = Request.Headers["Authorization"]!;
                 string refreshToken = Request.Headers["RefreshToken"]!;
 
-                Console.WriteLine(accessToken);
-                Console.WriteLine(refreshToken);
-
                 if (!string.IsNullOrEmpty(accessToken) && !string.IsNullOrEmpty(refreshToken))
                 {
                     var handler = new JwtSecurityTokenHandler();
@@ -59,7 +56,7 @@ namespace FortBackend.src.App.Routes.Oauth
 
                         // check the account
                         ProfileCacheEntry profileCacheEntry = await GrabData.Profile(payload.sub.ToString());
-                        Console.WriteLine(profileCacheEntry.AccountId);
+
                         if (!string.IsNullOrEmpty(profileCacheEntry.AccountId) && profileCacheEntry.UserData.banned != true)
                         {
                             var FindAccount = GlobalData.AccessToken.FirstOrDefault(e => e.accountId == profileCacheEntry.AccountId);
@@ -231,7 +228,7 @@ namespace FortBackend.src.App.Routes.Oauth
             }
             else
             {
-                Console.WriteLine("FAKE TOKEN?"); // never should happen
+                Logger.PlainLog("FAKE TOKEN?"); // never should happen ~ isnt worth error
             }
 
             return Ok(new { });
@@ -269,7 +266,6 @@ namespace FortBackend.src.App.Routes.Oauth
                     if (!string.IsNullOrEmpty(TokenType))
                     {
                         token_type = TokenType!;
-                        Console.WriteLine(token_type);
                     }
 
                 }
@@ -297,8 +293,6 @@ namespace FortBackend.src.App.Routes.Oauth
                     if (!string.IsNullOrEmpty(password))
                         Password = password!;
                 }
-
-                Console.WriteLine(grant_type);
 
                 string clientId = "";
                 try

--- a/FortBackend/src/App/Routes/Profile/McpController.cs
+++ b/FortBackend/src/App/Routes/Profile/McpController.cs
@@ -39,8 +39,8 @@ namespace FortBackend.src.App.Routes.Profile
                 using (var reader = new StreamReader(Request.Body, Encoding.UTF8))
                 {
                     var requestbody = await reader.ReadToEndAsync();
-                    Console.WriteLine(requestbody);
-                    Console.WriteLine(mcp);
+                    //Console.WriteLine(requestbody);
+                    //Console.WriteLine(mcp);
                     VersionClass Season = await SeasonUserAgent(Request);
 
                     if (string.IsNullOrEmpty(requestbody))
@@ -70,7 +70,7 @@ namespace FortBackend.src.App.Routes.Profile
                                 case "QueryProfile":
                                     response = await QueryProfile.Init(accountId, ProfileID, Season, RVN, profileCacheEntry);
                                     break;
-
+                                // todo quests
                                 default:
                                     Logger.Error("MISSING MCP REQUEST FOR DEDICATED SERVER -> " + mcp);
                                     response = new Mcp
@@ -150,6 +150,12 @@ namespace FortBackend.src.App.Routes.Profile
                                     break;
                                 case "SetBattleRoyaleBanner":
                                     response = await SetBattleRoyaleBanner.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetBattleRoyaleBannerReq>(requestbody)!);
+                                    break;
+                                case "SetItemFavoriteStatus":
+                                    response = await SetItemFavoriteStatus.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetItemFavoriteStatusReq>(requestbody)!);
+                                    break;
+                                case "SetItemFavoriteStatusBatch":
+                                    response = await SetItemFavoriteStatusBatch.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetItemFavoriteStatusBatchReq>(requestbody)!);
                                     break;
                                 case "PurchaseCatalogEntry":
                                     response = await PurchaseCatalogEntry.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<PurchaseCatalogEntryRequest>(requestbody)!);

--- a/FortBackend/src/App/Routes/Profile/McpController.cs
+++ b/FortBackend/src/App/Routes/Profile/McpController.cs
@@ -136,6 +136,9 @@ namespace FortBackend.src.App.Routes.Profile
                                 case "SetCosmeticLockerSlot":
                                     response = await SetCosmeticLockerSlot.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetCosmeticLockerSlotRequest>(requestbody)!);
                                     break;
+                                case "SetRandomCosmeticLoadout":
+                                    response = await SetRandomCosmeticLoadout.Init(accountId, ProfileID, Season, RVN, profileCacheEntry);
+                                    break;
                                 case "MarkNewQuestNotificationSent":
                                     response = await MarkNewQuestNotificationSent.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<MarkNewQuestNotificationSentRequest>(requestbody)!);
                                     break;
@@ -150,6 +153,15 @@ namespace FortBackend.src.App.Routes.Profile
                                     break;
                                 case "SetBattleRoyaleBanner":
                                     response = await SetBattleRoyaleBanner.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetBattleRoyaleBannerReq>(requestbody)!);
+                                    break;
+                                case "SetCosmeticLockerBanner":
+                                    response = await SetCosmeticLockerBanner.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetCosmeticLockerBannerReq>(requestbody)!);
+                                    break;
+                                case "SetCosmeticLockerName":
+                                    response = await SetCosmeticLockerName.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetCosmeticLockerNameReq>(requestbody)!);
+                                    break;
+                                case "DeleteCosmeticLoadout":
+                                    response = await DeleteCosmeticLoadout.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<DeleteCosmeticLoadoutReq>(requestbody)!);
                                     break;
                                 case "SetItemFavoriteStatus":
                                     response = await SetItemFavoriteStatus.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<SetItemFavoriteStatusReq>(requestbody)!);
@@ -172,10 +184,15 @@ namespace FortBackend.src.App.Routes.Profile
                                 case "BulkEquipBattleRoyaleCustomization":
                                     response = await BulkEquipBattleRoyaleCustomization.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<BulkEquipBattleRoyaleCustomizationResponse>(requestbody)!);
                                     break;
-                                // not proper
-                                //case "CopyCosmeticLoadout":
-                                //    response = await CopyCosmeticLoadout.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<CopyCosmeticLoadoutResponse>(requestbody));
-                                //    break;
+                                case "CopyCosmeticLoadout":
+                                    response = await CopyCosmeticLoadout.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<CopyCosmeticLoadoutReq>(requestbody)!);
+                                    break;
+                                case "PurchaseMultipleCatalogEntries":
+                                    response = await PurchaseMultipleCatalogEntries.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<PurchaseMultipleCatalogEntriesReq>(requestbody)!);
+                                    break;
+                                case "ExchangeGameCurrencyForBattlePassOffer":
+                                    response = await ExchangeGameCurrencyForBattlePassOffer.Init(accountId, ProfileID, Season, RVN, profileCacheEntry, JsonConvert.DeserializeObject<ExchangeGameCurrencyForBattlePassOfferReq>(requestbody)!);
+                                    break;
                                 default:
 
                                         response = new Mcp

--- a/FortBackend/src/App/Routes/Profile/McpControllers/ClientQuestLogin.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/ClientQuestLogin.cs
@@ -52,18 +52,14 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                     }
                 }
 
-
                 // Daily Quests WIP
-                  
+
                 if (profileCacheEntry.AccountData.commoncore.Seasons.Any(x => x.SeasonNumber == Season.Season))
                 {
                     // Response Data ~ DONT CHANGE
                     List<object> MultiUpdates = new List<object>();
                     List<object> MultiUpdatesForCommonCore = new List<object>();
                     int BaseRev = profileCacheEntry.AccountData.athena.RVN;
-
-                    Console.WriteLine(RVN);
-                    Console.WriteLine(BaseRev);
 
                     if (Season.Season == 0)
                     {
@@ -228,8 +224,49 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
 
                     // Until i work on a season that changes this (season 10 omg) i need to redo this
                     (MultiUpdates, MultiUpdatesForCommonCore, profileCacheEntry) = await QuestsDealer.Init(FoundSeason, MultiUpdates, MultiUpdatesForCommonCore, profileCacheEntry);
-                    
+
                     // END OF BATTLE PASS QUESTS SYSTEM
+
+                    // START OF SPECIAL ITEMS
+                    // Granted per second, you may want to put skins of other things in this
+                    if (FoundSeason.special_items == null)
+                        FoundSeason.special_items = new();
+
+                    List<string> SeasonSpecialIg = BattlepassManager.SeasonSpecialItems.FirstOrDefault(e => e.Key == FoundSeason.SeasonNumber).Value;
+
+                    if (SeasonSpecialIg != null && SeasonSpecialIg.Count > 0)
+                    {
+                        foreach (var item in SeasonSpecialIg)
+                        {
+                            if (!FoundSeason.special_items.ContainsKey(item))
+                            {
+                                FoundSeason.special_items.Add(item, new AthenaItem
+                                {
+                                    templateId = item,
+                                    quantity = 1
+                                });
+
+                                MultiUpdates.Add(new MultiUpdateClass
+                                {
+                                    changeType = "itemAdded",
+                                    itemId = item,
+                                    item = new AthenaItem
+                                    {
+                                        templateId = item,
+                                        attributes = new AthenaItemAttributes
+                                        {
+                                            item_seen = false,
+                                        },
+                                        quantity = 1
+                                    }
+                                });
+                            }
+                        }
+                    }
+
+                    // END OF SPECIAL ITEMS
+
+                    //
 
                     // LEVEL SYSTEM & XP
 
@@ -374,7 +411,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                                         string xmlMessage;
                                         byte[] buffer;
                                         WebSocket webSocket = Client.Game_Client;
-                                        Console.WriteLine(webSocket.State);
+                                        Logger.PlainLog(webSocket.State);
                                         if (webSocket != null && webSocket.State == WebSocketState.Open)
                                         {
                                             XNamespace clientNs = "jabber:client";

--- a/FortBackend/src/App/Routes/Profile/McpControllers/CopyCosmeticLoadout.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/CopyCosmeticLoadout.cs
@@ -1,322 +1,274 @@
-﻿//using Amazon.Runtime.Internal.Transform;
-//using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
-//using FortBackend.src.App.Utilities.Classes.EpicResponses.Errors;
-//using FortBackend.src.App.Utilities.Classes.EpicResponses.Profile;
-//using FortBackend.src.App.Utilities.Classes.EpicResponses.Profile.Query.Items;
-//using FortBackend.src.App.Utilities.Helpers.Middleware;
-//using FortBackend.src.App.Utilities.MongoDB.Helpers;
-//using FortLibrary.MongoDB.Module;
-//using MongoDB.Bson;
-//using Newtonsoft.Json;
-//using Newtonsoft.Json.Linq;
-//using System.Collections.Generic;
-//using System.Text.Json;
-//using static FortBackend.src.App.Utilities.Helpers.Grabber;
+﻿using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortLibrary;
+using FortLibrary.EpicResponses.Errors;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Purchases;
+using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortLibrary.MongoDB.Module;
+using MongoDB.Bson;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
 
-//namespace FortBackend.src.App.Routes.Profile.McpControllers
-//{
-//    public class CopyCosmeticLoadout
-//    {
-//        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, CopyCosmeticLoadoutResponse Body)
-//        {
-//            Console.WriteLine(ProfileId);
-//            if (ProfileId == "athena" || ProfileId == "profile0")
-//            {
-//                Dictionary<string, object> UpdatedData = new Dictionary<string, object>();
-//                if (Body.targetIndex > 100 || Body.sourceIndex > 100 || Body.targetIndex < 0 || Body.sourceIndex < 0)
-//                {
-//                    throw new BaseError
-//                    {
-//                        errorCode = "errors.com.epicgames.modules.outOfBounds",
-//                        errorMessage = "OutOfBounds | FR",
-//                        messageVars = new List<string> { "CopyCosmeticLoadout" },
-//                        numericErrorCode = 12801,
-//                        originatingService = "any",
-//                        intent = "prod",
-//                        error_description = "OutOfBounds | FR",
-//                    };
-//                }
-//                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class CopyCosmeticLoadout
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, CopyCosmeticLoadoutReq Body)
+        {
+            if (ProfileId == "athena")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> MultiUpdates = new List<object>();
 
-//                int GrabPlacement3 = profileCacheEntry.AccountData.athena.Items.SelectMany((item, index) => new List<(Dictionary<string, object> Item, int Index)> { (Item: item, Index: index) })
-//                           .TakeWhile(pair => !pair.Item.ContainsKey("sandbox_loadout")).Count();
-//                int GrabPlacement2 = profileCacheEntry.AccountData.athena.Items.SelectMany((item, index) => new List<(Dictionary<string, object> Item, int Index)> { (Item: item, Index: index) })
-//                    .TakeWhile(pair => !pair.Item.ContainsKey(profileCacheEntry.AccountData.athena.last_applied_loadout)).Count();
+                if (Body.targetIndex > 100 || Body.sourceIndex > 100 || Body.targetIndex < 0 || Body.sourceIndex < 0)
+                {
+                    throw new BaseError
+                    {
+                        errorCode = "errors.com.epicgames.modules.outOfBounds",
+                        errorMessage = "OutOfBounds | FR",
+                        messageVars = new List<string> { "CopyCosmeticLoadout" },
+                        numericErrorCode = 12801,
+                        originatingService = "any",
+                        intent = "prod",
+                        error_description = "OutOfBounds | FR",
+                    };
+                }
 
-//                if (Body.targetIndex < profileCacheEntry.AccountData.athena.loadouts.Length && !string.IsNullOrEmpty(profileCacheEntry.AccountData.athena.loadouts[Body.targetIndex]))
-//                {
-//                    string[] loadouts = profileCacheEntry.AccountData.athena.loadouts;
-//                    object objectToModify = profileCacheEntry.AccountData.athena.Items.FirstOrDefault(item => item.ContainsKey(loadouts[Body.sourceIndex]));
-//                    Dictionary<string, object> GrabbedPlaceMent = profileCacheEntry.AccountData.athena.Items[GrabPlacement2] as Dictionary<string, object>;
-//                    Console.WriteLine(profileCacheEntry.AccountData.athena.last_applied_loadout);
+            
+                //profileCacheEntry.AccountData.athena.loadouts_data[Body.targetIndex] = profileCacheEntry.AccountData.athena.CosmeticLoadouts[Body.sourceIndex];
 
-//                    if (objectToModify != null)
-//                    {
-//                        if (!string.IsNullOrEmpty(Body.optNewNameForTarget))
-//                        {
-//                            (Dictionary<string, object>)profileCacheEntry.AccountData.athena.Items[GrabPlacement2][profileCacheEntry.AccountData.athena.last_applied_loadout]["attributes"]["locker_name"] = Body.optNewNameForTarget;
+                // 0 is sandbox_loadout if this is higher then 0 its reverted and we are copying to sandbox_loadout
+                // ^^ 99% sure fortnite deleted the sandbox_loadout and just had presets
+                // also deteals how it probally should be
+                // sandbox_loadout is the loadout i would say should "copied" and "changed" and we shouldn't change the loadout index
+                // but idk mann i could implement this 100 ways
+                // i might change this in the future since Yes sir!
+                //Console.WriteLine(profileCacheEntry.AccountData.athena.loadouts.Count);
+                if (Body.sourceIndex == 0 && Body.targetIndex != 0)
+                {
+                    string RandomNewId = Guid.NewGuid().ToString();
+                    //Body.sourceIndex ~ 0 should always be sandbox loadout
+                    // i wished i couldj ust be like rust
+                    if ((profileCacheEntry.AccountData.athena.loadouts.Count - 1) < Body.targetIndex)
+                    {
+                        var ClonedSandbox = System.Text.Json.JsonSerializer.Deserialize<SandboxLoadout>(
+                            System.Text.Json.JsonSerializer.Serialize(profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"]))!;
 
-//                            //UpdatedData.Add($"athena.Items.{GrabPlacement2}.{profileCacheEntry.AccountData.athena.last_applied_loadout}.attributes.locker_name", Body.optNewNameForTarget);
-//                        }
+                        profileCacheEntry.AccountData.athena.loadouts_data.Add(RandomNewId, ClonedSandbox);
+                        profileCacheEntry.AccountData.athena.loadouts_data[RandomNewId].attributes.locker_name = Body.optNewNameForTarget;
+                        profileCacheEntry.AccountData.athena.loadouts.Add(RandomNewId);
+                        profileCacheEntry.AccountData.athena.last_applied_loadout = RandomNewId;
 
-//                        object objectToModify1 = GrabbedPlaceMent[profileCacheEntry.AccountData.athena.last_applied_loadout];
-//                        if (objectToModify1 is JObject jsonLockerObject)
-//                        {
-//                            UpdatedData.Add($"athena.Items.{GrabPlacement3}.sandbox_loadout.attributes.locker_slots_data", new Dictionary<string, object>
-//                            {
-//                                {
-//                                    "slots", new Dictionary<string, object>
-//                                    {
-//                                        {
-//                                            "musicpack", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["musicpack"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "character", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["character"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "backpack", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["backpack"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "pickaxe", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["pickaxe"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "skydivecontrail", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["skydivecontrail"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "dance", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["dance"]["items"].ToObject<string[]>() ?? new string[] { "", "", "", "", "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "loadingscreen", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["loadingscreen"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "glider", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["glider"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                }
-//                                            }
-//                                        },
-//                                        {
-//                                            "itemwrap", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["itemwrap"]["items"].ToObject<string[]>() ?? new string[] { "", "", "", "", "", "" }
-//                                                }
-//                                            }
-//                                        }
-//                                    }
-//                                }
-//                            });
-//                        }
-//                        Console.WriteLine(profileCacheEntry.AccountData.athena.RVN);
-//                        Console.WriteLine(profileCacheEntry.AccountData.athena.CommandRevision);
-//                        profileCacheEntry.AccountData.athena.RVN += 1;
-//                        profileCacheEntry.AccountData.athena.CommandRevision += 1;
-//                        UpdatedData.Add("athena.last_applied_loadout", loadouts[Body.sourceIndex]);
-//                        //UpdatedData.Add("athena.RVN", profileCacheEntry.AccountData.athena.RVN);
-//                        //UpdatedData.Add("athena.CommandRevision", profileCacheEntry.AccountData.athena.CommandRevision);
-//                    }
-//                    else
-//                    {
-//                        throw new BaseError
-//                        {
-//                            errorCode = "errors.com.epicgames.modules.item_not_found",
-//                            errorMessage = "Couldnt find loadout | FR",
-//                            messageVars = new List<string> { "CopyCosmeticLoadout" },
-//                            numericErrorCode = 12801,
-//                            originatingService = "any",
-//                            intent = "prod",
-//                            error_description = "Couldnt find loadout | FR",
-//                        };
-//                    }
+                        MultiUpdates.Add(new
+                        {
+                            changeType = "itemAdded",
+                            itemId = RandomNewId,
+                            item = ClonedSandbox // doesnr matter this owrks
+                        });
 
-//                    await Handlers.UpdateOne<Account>("accountId", profileCacheEntry.AccountData.AccountId, UpdatedData);
-//                }
-//                else
-//                {
-//                    string RandomNewId = Guid.NewGuid().ToString();
-//                    Dictionary<string, object> GrabbedPlaceMent = profileCacheEntry.AccountData.athena.Items[GrabPlacement3] as Dictionary<string, object>;
-//                    object objectToModify = GrabbedPlaceMent["sandbox_loadout"];
+                        MultiUpdates.Add(new
+                        {
+                            changeType = "statModified",
+                            name = "loadouts",
+                            value = profileCacheEntry.AccountData.athena.loadouts
+                        });
 
-//                    List<Dictionary<string, object>> itemList = new List<Dictionary<string, object>>();
-//                    if (objectToModify is JObject jsonLockerObject)
-//                    {
+                        MultiUpdates.Add(new
+                        {
+                            changeType = "statModified",
+                            name = "last_applied_loadout",
+                            value = RandomNewId
+                        });
 
-//                        //GrabbedPlaceMent.Remove(AccountDataParsed.athena.last_applied_loadout);
-//                        //GrabbedPlaceMent[RandomNewId] = jsonLockerObject;
+                    }
+                    else
+                    {
+                        string Indx2 = profileCacheEntry.AccountData.athena.loadouts[Body.targetIndex];
+                        if (!string.IsNullOrEmpty(Indx2))
+                        {
+                            if (Indx2 != "sandbox_loadout")
+                            {
+                                var ClonedSandbox = System.Text.Json.JsonSerializer.Deserialize<SandboxLoadout>(
+                                    System.Text.Json.JsonSerializer.Serialize(profileCacheEntry.AccountData.athena.loadouts_data!["sandbox_loadout"]))!;
 
-//                        Dictionary<string, object> NewThingy = new Dictionary<string, object>
-//                        {
-//                            {
-//                            RandomNewId, new Dictionary<string, object>
-//                            {
-//                                { "templateId", $"CosmeticLocker:cosmeticlocker_athena" },
-//                                {
-//                                     "attributes", new Dictionary<string, object>
-//                                     {
+                                if(ClonedSandbox.attributes != null)
+                                {
+                                    var Item = profileCacheEntry.AccountData.athena.loadouts_data[Indx2].attributes;
+                                    Item.locker_slots_data = ClonedSandbox.attributes.locker_slots_data;
+                                    if (Item.banner_color_template != ClonedSandbox.attributes.banner_color_template)
+                                    {
+                                        Item.banner_color_template = ClonedSandbox.attributes.banner_color_template;
+                                        MultiUpdates.Add(new
+                                        {
+                                            changeType = "itemAttrChanged", // attr is attribute
+                                            itemId = Indx2,
+                                            attributeName = "banner_color_template",
+                                            attributeValue = Item.banner_icon_template
+                                        });
+                                    }
 
-//                                        { "locker_slots_data", new Dictionary<string, object>
-//                                            {
-//                                                {
-//                                                    "slots", new Dictionary<string, object>
-//                                                    {
-//                                                        {
-//                                                            "musicpack", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["musicpack"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "character", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["character"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "backpack", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["backpack"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "pickaxe", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["pickaxe"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "skydivecontrail", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["skydivecontrail"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "dance", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["dance"]["items"].ToObject<string[]>() ?? new string[] { "", "", "", "", "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "loadingscreen", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["loadingscreen"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "glider", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["glider"]["items"].ToObject<string[]>() ?? new string[] { "" }
-//                                                                }
-//                                                            }
-//                                                        },
-//                                                        {
-//                                                            "itemwrap", new Dictionary<string, object>
-//                                                            {
-//                                                                {
-//                                                                    "items", jsonLockerObject["attributes"]["locker_slots_data"]["slots"]["itemwrap"]["items"].ToObject<string[]>() ?? new string[] { "", "", "", "", "", "" }
-//                                                                }
-//                                                            }
-//                                                        }
-//                                                    }
-//                                                }
-//                                            }
-//                                        },
-//                                        { "use_count", 0 },
-//                                        { "banner_color_template", ""},
-//                                        { "banner_icon_template", ""},
-//                                        { "locker_name", Body.optNewNameForTarget ?? $"FortBackend~{RandomNewId}" },
-//                                        { "item_seen", false},
-//                                        { "favorite", false},
-//                                    }
-//                                },
-//                                {  "quantity", 1 }
-//                            }
-//                            }
-//                        };
+                                    if (Item.banner_icon_template != ClonedSandbox.attributes.banner_icon_template)
+                                    {
+                                        Item.banner_icon_template = ClonedSandbox.attributes.banner_icon_template;
+
+                                        MultiUpdates.Add(new
+                                        {
+                                            changeType = "itemAttrChanged", // attr is attribute
+                                            itemId = Indx2,
+                                            attributeName = "banner_icon_template",
+                                            attributeValue = Item.banner_icon_template
+                                        });
+                                   }
+                              
+                                 
+                                    MultiUpdates.Add(new
+                                    {
+                                        changeType = "itemAttrChanged",
+                                        itemId = Indx2,
+                                        attributeName = "locker_slots_data",
+                                        attributeValue = Item.locker_slots_data
+                                    });
+                                }
+                            }
+                            else
+                            {
+                                Logger.Error("This shouldnt happened </3 ", "CopyLoadout");
+                            }
+                        }
+                    }
+
+                }
+                else
+                {
+                    // copy preset 1 -> preset 0
+                    // 1 -> 0 
+                   
+                    if (Body.targetIndex == 0)
+                    {
+                        string Indx2 = profileCacheEntry.AccountData.athena.loadouts[Body.sourceIndex];
+                        if (!string.IsNullOrEmpty(Indx2))
+                        {
+                            var ClonedSandbox = System.Text.Json.JsonSerializer.Deserialize<SandboxLoadout>(
+                                System.Text.Json.JsonSerializer.Serialize(profileCacheEntry.AccountData.athena.loadouts_data[Indx2]))!;
+
+                            if (ClonedSandbox.attributes != null)
+                            {
+                                var Item = profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes;
+                                Item.locker_slots_data = ClonedSandbox.attributes.locker_slots_data;
+                                if (Item.banner_color_template != ClonedSandbox.attributes.banner_color_template)
+                                {
+                                    Item.banner_color_template = ClonedSandbox.attributes.banner_color_template;
+                                    MultiUpdates.Add(new
+                                    {
+                                        changeType = "itemAttrChanged", // attr is attribute
+                                        itemId = "sandbox_loadout",
+                                        attributeName = "banner_color_template",
+                                        attributeValue = Item.banner_icon_template
+                                    });
+                                }
+
+                                if (Item.banner_icon_template != ClonedSandbox.attributes.banner_icon_template)
+                                {
+                                    Item.banner_icon_template = ClonedSandbox.attributes.banner_icon_template;
+
+                                    MultiUpdates.Add(new
+                                    {
+                                        changeType = "itemAttrChanged", // attr is attribute
+                                        itemId = "sandbox_loadout",
+                                        attributeName = "banner_icon_template",
+                                        attributeValue = Item.banner_icon_template
+                                    });
+                                }
+
+                                MultiUpdates.Add(new
+                                {
+                                    changeType = "itemAttrChanged",
+                                    itemId = "sandbox_loadout",
+                                    attributeName = "locker_slots_data",
+                                    attributeValue = Item.locker_slots_data
+                                });
 
 
-//                        //GrabbedPlaceMent[RandomNewId] = jsonLockerObject;
+                                // when you switch it should also change the preset on the side!!!
+                                if (profileCacheEntry.AccountData.athena.last_applied_loadout != Indx2)
+                                {
+                                    profileCacheEntry.AccountData.athena.last_applied_loadout = Indx2;
+                                    MultiUpdates.Add(new
+                                    {
+                                        changeType = "statModified",
+                                        name = "last_applied_loadout",
+                                        value = Indx2
+                                    });
+                                }
+                            }
+                        }
+                    }
 
-//                        itemList.Add(NewThingy);
+
+                    //string Indx = profileCacheEntry.AccountData.athena.loadouts[Body.targetIndex];
+                    //string Indx2 = profileCacheEntry.AccountData.athena.loadouts[Body.sourceIndex];
+                    //if (!string.IsNullOrEmpty(Indx))
+                    //{
+                    //    SandboxLoadout Sandblx = profileCacheEntry.AccountData.athena.loadouts_data[Indx];
+                    //    profileCacheEntry.AccountData.athena.last_applied_loadout = Indx;
+                    //    profileCacheEntry.AccountData.athena.loadouts_data[Indx2] = Sandblx;
+                    //    if(!string.IsNullOrEmpty(Body.optNewNameForTarget))
+                    //    {
+                    //        profileCacheEntry.AccountData.athena.loadouts_data[Indx2].attributes.locker_name = Body.optNewNameForTarget;
+                    //    }
 
 
-//                        //Console.WriteLine($"Modified Locker: {JsonConvert.SerializeObject(jsonLockerObject)}");
-//                    }
+                    //    MultiUpdates.Add(new
+                    //    {
+                    //        changeType = "statModified",
+                    //        name = "last_applied_loadout",
+                    //        value = Body.targetIndex
+                    //    });
 
-//                    //await Handlers.PushOne<Account>("accountId", profileCacheEntry.AccountData.AccountId, new Dictionary<string, object>
-//                    //{
-//                    //    {
-//                    //        $"athena.items", itemList
-//                    //    }
-//                    //});
+                    //    MultiUpdates.Add(new
+                    //    {
+                    //        changeType = "statModified",
+                    //        name = "active_loadout_index",
+                    //        value = Body.targetIndex
+                    //    });
+                    //}
+                   
+                }
 
 
-//                    //await Handlers.PushOne<Account>("accountId", profileCacheEntry.AccountData.AccountId, new Dictionary<string, object>
-//                    //{
-//                    //    {
-//                    //        $"athena.loadouts", RandomNewId
-//                    //    }
-//                    //}, false);
-//                }
+                if (MultiUpdates.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.UtcNow;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
 
-//                Mcp response = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
-//                response.profileRevision = profileCacheEntry.AccountData.athena.RVN;
-//                response.profileChangesBaseRevision = BaseRev;
-//                response.profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision;
-//                return response;
-//            }
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    MultiUpdates = test.profileChanges;
+                }
 
-//            return new Mcp();
-//        }
-//    }
-//}
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = MultiUpdates,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/DeleteCosmeticLoadout.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/DeleteCosmeticLoadout.cs
@@ -1,0 +1,122 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortLibrary;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Quests;
+using FortLibrary.MongoDB.Module;
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class DeleteCosmeticLoadout
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, DeleteCosmeticLoadoutReq Body)
+        {
+            if (ProfileId == "athena" || ProfileId == "profile0")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> ProfileChanges = new List<object>();
+
+                // this is my idea of the function from a few tests
+                // if you are trying to delete the preset that YOU arent using at the momenet this will be the response
+                /*
+                 * 3
+                 * -1
+                 * True
+                 */
+                //
+                // 3 means that this is the preset we will delete <3
+                // -1 means that we dont need to switch to a different preset
+                // BUT if you are tryinf to delete the one that you are using this is the response
+                /*
+                 *  4
+                 *  3
+                 *  True
+                 */
+                // ^^ deleting the last preset with it equiped, 
+                // 4 is the preset we are deleting
+                // 3 is the preset we will be going to
+                // True is to make it empty? but wouldnt we just remove it from the array
+
+                string Indx2 = profileCacheEntry.AccountData.athena.loadouts![Body.index];
+                if (!string.IsNullOrEmpty(Indx2))
+                {
+                    // We check if someone is trying to delete sandbox, if so we are cooked </3
+                    if (Indx2 != "sandbox_loadout")
+                    {
+                        if(Body.fallbackLoadoutIndex != -1)
+                        {
+                            string Indx3 = profileCacheEntry.AccountData.athena.loadouts![Body.fallbackLoadoutIndex];
+                            if (!string.IsNullOrEmpty(Indx3))
+                            {
+                                profileCacheEntry.AccountData.athena.last_applied_loadout = Indx3;
+
+                                // I'm not sure if its supposed to auto copy it, it feels wrong to do that
+                                ProfileChanges.Add(new
+                                {
+                                    changeType = "statModified",
+                                    name = "last_applied_loadout",
+                                    value = Indx3
+                                });
+                            }
+                        }
+
+                        // delete the loadout from array and preset list
+                        if(profileCacheEntry.AccountData.athena.loadouts.Find((e) => e == Indx2) != null)
+                        {
+                            profileCacheEntry.AccountData.athena.loadouts.Remove(Indx2);
+
+                            ProfileChanges.Add(new
+                            {
+                                changeType = "itemRemoved",
+                                itemId = Indx2,
+                            });
+
+                            ProfileChanges.Add(new
+                            {
+                                changeType = "statModified",
+                                name = "loadouts",
+                                value = profileCacheEntry.AccountData.athena.loadouts
+                            });
+                        }
+                    }
+
+                }
+
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
+
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    ProfileChanges = test.profileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/EquipBattleRoyaleCustomization.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/EquipBattleRoyaleCustomization.cs
@@ -9,6 +9,7 @@ using FortLibrary.EpicResponses.Errors;
 using FortLibrary.MongoDB.Module;
 using FortLibrary.Dynamics;
 using FortBackend.src.App.Utilities.Saved;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 
 namespace FortBackend.src.App.Routes.Profile.McpControllers
 {
@@ -18,6 +19,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
         {
             if (ProfileId == "athena" || ProfileId == "profile0")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.athena.RVN;
                 List<object> ProfileChanges = new List<object>();
               //  var UpdatedData = profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes.locker_slots_data.slots;
@@ -159,30 +161,14 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                     if (ProfileChanges.Count > 0)
                     {
                         profileCacheEntry.LastUpdated = DateTime.UtcNow;
-                        profileCacheEntry.AccountData.athena.RVN += 1;
-                        profileCacheEntry.AccountData.athena.CommandRevision += 1;
-                       // profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes.locker_slots_data.slots = UpdatedData;
+                        profileCacheEntry.AccountData.athena.BumpRevisions();
                     }
 
-                    if (BaseRev != RVN)
+                    if (BaseRev_G != RVN)
                     {
                         Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
                         ProfileChanges = test.profileChanges;
                     }
-
-                    //if(Season.Season == 1)
-                    //{
-                    //    return new Mcp()
-                    //    {
-                    //        profileRevision = profileCacheEntry.AccountData.athena.RVN,
-                    //        profileId = ProfileId,
-                    //        profileChangesBaseRevision = BaseRev,
-                    //        profileChanges = ProfileChanges,
-                    //        profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
-                    //        serverTime = DateTime.Parse(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")),
-                    //        responseVersion = 1
-                    //    };
-                    //}
 
                     return new Mcp()
                     {

--- a/FortBackend/src/App/Routes/Profile/McpControllers/ExchangeGameCurrencyForBattlePassOffer.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/ExchangeGameCurrencyForBattlePassOffer.cs
@@ -1,0 +1,198 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.BattlepassManagement;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortBackend.src.XMPP.SERVER.Send;
+using FortLibrary;
+using FortLibrary.Dynamics;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Purchases;
+using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortLibrary.EpicResponses.Profile.Quests;
+using FortLibrary.MongoDB.Module;
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class ExchangeGameCurrencyForBattlePassOffer
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, ExchangeGameCurrencyForBattlePassOfferReq Body)
+        {
+            if (ProfileId == "athena")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                int BaseRev_C = profileCacheEntry.AccountData.commoncore.RVN;
+                List<object> ProfileChanges = new();
+                List<object> MultiUpdates = new();
+                List<NotificationsItemsClassOG> NotificationsItems = new();
+
+                SeasonClass seasonObject = profileCacheEntry.AccountData.commoncore.Seasons!.FirstOrDefault(season => season.SeasonNumber == Season.Season)!;
+                CommonCoreItem CurrentVbucks = profileCacheEntry.AccountData.commoncore.Items["Currency"];
+                int OGBucks = CurrentVbucks.quantity;
+                if (seasonObject != null)
+                {
+                    
+
+                    if (BattlepassManager.BattlePassPItems.TryGetValue(Season.Season, out var bpItems) && bpItems.Count > 0)
+                    {
+                        var bpLookup = bpItems.ToDictionary(e => e.OfferId);
+
+                        var resolvedItems = Body.offerItemIdList
+                        .Select(id => bpLookup.TryGetValue(id, out var item) ? item : null)
+                        .Where(item => item != null)
+                        .OrderBy(item => item!.templateId.Contains("CosmeticVariantToken:", StringComparison.Ordinal));
+
+                        foreach (var bpItm in resolvedItems)
+                        {
+                            if(bpItm is null) continue;
+
+                            if (bpItm.bRequireBp && !seasonObject.BookPurchased) continue;
+                            if (seasonObject.battlestars_currency >= bpItm.Price)
+                            {
+                                var SeasonOffer = seasonObject.season_offers.Find((e) => e.offerId == bpItm.OfferId);
+                                if (SeasonOffer != null) continue; // they own it
+
+                                Console.WriteLine(bpItm.templateId);
+
+                                seasonObject.battlestars_currency -= bpItm.Price;
+
+                                (profileCacheEntry, seasonObject, ProfileChanges, CurrentVbucks.quantity, NotificationsItems) =
+                                    await BattlePassRewardsV2.Init(bpItm, profileCacheEntry, seasonObject, ProfileChanges, CurrentVbucks.quantity, NotificationsItems);
+
+                                seasonObject.season_offers.Add(new()
+                                {
+                                    offerId = bpItm.OfferId,
+                                    bIsFreePassReward = bpItm.bRequireBp,
+                                    purchaseDate = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                                    lootResult = new() { 
+                                        new() {
+                                            itemType = bpItm.templateId,
+                                            itemGuid = bpItm.templateId,
+                                            itemProfile = !bpItm.templateId.Contains("HomebaseBannerIcon") ? "athena" : "common_core",
+                                            quantity = bpItm.Quantity
+                                        } 
+                                    },
+                                    currencyType = "battlestars",
+                                    totalCurrencyPaid = bpItm.Price
+                                });
+                            }
+                        }
+                        
+
+                    }//2E4B9D3E411F2CA6F7F7E8BAAD9348FF
+
+                    if(OGBucks != CurrentVbucks.quantity)
+                    {
+                        MultiUpdates.Add(new
+                        {
+                            changeType = "itemQuantityChanged",
+                            itemId = "Currency",
+                            quantity = CurrentVbucks.quantity
+                        });
+                    }
+
+                    ProfileChanges.Add(new
+                    {
+                        changeType = "statModified",
+                        name = "purchased_bp_offers",
+                        value = seasonObject.season_offers
+                    });
+
+                    ProfileChanges.Add(new
+                    {
+                        changeType = "statModified",
+                        name = "battlestars",
+                        value = seasonObject.battlestars_currency
+                    });
+
+                    ProfileChanges.Add(new
+                    {
+                        changeType = "statModified",
+                        name = "battlestars_season_total",
+                        value = seasonObject.battlestars_currency
+                    });
+                }
+
+                if (NotificationsItems.Count > 0)
+                {
+                    // this season doesnt need it?!?! else it doubles
+                    //var RandomOfferId = Guid.NewGuid().ToString();
+                    //MultiUpdates.Add(new ApplyProfileChangesClassV2
+                    //{
+                    //    changeType = "itemAdded",
+                    //    itemId = RandomOfferId,
+                    //    item = new
+                    //    {
+                    //        templateId = "GiftBox:gb_battlepassoffers",
+                    //        attributes = new
+                    //        {
+                    //            max_level_bonus = 0,
+                    //            fromAccountId = "",
+                    //            lootList = NotificationsItems
+                    //        },
+                    //        quantity = 1
+                    //    }
+                    //});
+
+                    //profileCacheEntry.AccountData.commoncore.Gifts.Add(RandomOfferId, new GiftCommonCoreItem
+                    //{
+                    //    templateId = "GiftBox:gb_battlepassoffers",
+                    //    attributes = new GiftCommonCoreItemAttributes
+                    //    {
+                    //        lootList = NotificationsItems
+                    //    },
+                    //    quantity = 1
+                    //});
+
+                    //await XmppGift.NotifyUser(profileCacheEntry.AccountId);
+                }
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
+
+                if (MultiUpdates.Count > 0)
+                    profileCacheEntry.AccountData.commoncore.BumpRevisions();
+
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    ProfileChanges = test.profileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    multiUpdate = new List<object>()
+                    {
+                        new
+                        {
+                            profileRevision = profileCacheEntry.AccountData.commoncore.RVN,
+                            profileId = "common_core",
+                            profileChangesBaseRevision = BaseRev_C,
+                            profileChanges = MultiUpdates,
+                            profileCommandRevision = profileCacheEntry.AccountData.commoncore.CommandRevision,
+                        }
+                    },
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/FortRerollDailyQuest.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/FortRerollDailyQuest.cs
@@ -14,6 +14,7 @@ using FortLibrary.EpicResponses.Profile.Quests;
 using FortBackend.src.App.Utilities.Quests;
 using FortLibrary.Dynamics;
 using FortLibrary.EpicResponses.Profile.Purchases;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 
 namespace FortBackend.src.App.Routes.Profile.McpControllers
 {
@@ -24,11 +25,11 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
             string currentDate = DateTime.UtcNow.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
             if (ProfileId == "athena")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.athena.RVN;
 
                 List<object> MultiUpdates = new List<object>();
                 List<object> NotificationsUpdates = new List<object>();
-                List<object> ProfileChanges = new List<object>();
 
                 // ill need to make quest adding its own file
                 if (!string.IsNullOrEmpty(requestBodyy.questId))
@@ -158,37 +159,25 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                 }
 
                 if (MultiUpdates.Count > 0)
-                {
-                    profileCacheEntry.AccountData.athena.RVN += 1;
-                    profileCacheEntry.AccountData.athena.CommandRevision += 1;
-                }
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
 
-                if (BaseRev != RVN)
+                if (BaseRev_G != RVN)
                 {
                     Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
-                    ProfileChanges = test.profileChanges;
-                }
-                else
-                {
-                    ProfileChanges = MultiUpdates;
+                    MultiUpdates = test.profileChanges;
                 }
 
                 return new Mcp()
                 {
-                    profileRevision = profileCacheEntry.AccountData.commoncore.RVN,
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
                     profileId = ProfileId,
                     profileChangesBaseRevision = BaseRev,
-                    profileChanges = ProfileChanges,
+                    profileChanges = MultiUpdates,
                     notifications = NotificationsUpdates,
-                    profileCommandRevision = profileCacheEntry.AccountData.commoncore.CommandRevision,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
                     serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
                     responseVersion = 1
                 };
-        
-
-
-
-              
             }
             return new Mcp();
         }

--- a/FortBackend/src/App/Routes/Profile/McpControllers/MarkItemSeen.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/MarkItemSeen.cs
@@ -3,6 +3,7 @@ using FortLibrary.EpicResponses.Profile;
 using FortLibrary.MongoDB.Module;
 using FortLibrary;
 using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 
 namespace FortBackend.src.App.Routes.Profile.McpControllers
 {
@@ -14,9 +15,9 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
 
             if (ProfileId == "athena" || ProfileId == "profile0")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.athena.RVN;
 
-               
                 List<object> MultiUpdates = new List<object>();
                 List<object> ProfileChanges = new List<object>();
                 
@@ -63,17 +64,24 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                     });
                 }
 
+                /*
+                 * 
+                 *                 int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                int BaseRev_C = profileCacheEntry.AccountData.commoncore.RVN;
+                */
+
                 if (MultiUpdates.Count > 0)
                 {
                     profileCacheEntry.AccountData.athena.RVN += 1;
                     profileCacheEntry.AccountData.athena.CommandRevision += 1;
                 }
 
-                //if (BaseRev != RVN)
-                //{
-                //    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
-                //    ProfileChanges = test.profileChanges;
-                //}
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    MultiUpdates = test.profileChanges;
+                }
                 //else
                 //{
                 //    ProfileChanges = MultiUpdates;

--- a/FortBackend/src/App/Routes/Profile/McpControllers/MarkItemSeen.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/MarkItemSeen.cs
@@ -19,11 +19,10 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                
                 List<object> MultiUpdates = new List<object>();
                 List<object> ProfileChanges = new List<object>();
-           
+                
                 foreach (string item in Body.itemIds)
                 {
-                    Console.WriteLine(item);
-
+                    
                     if(profileCacheEntry.AccountData.athena.Items.ContainsKey(item))
                     {
                         profileCacheEntry.AccountData.athena.Items[item].attributes.item_seen = true;
@@ -40,15 +39,17 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                         // Wow MartItemSeen Works On Quests
                         if (seasonObject != null)
                         {
-                            Console.WriteLine("2");
                             if (seasonObject.Quests.ContainsKey(item))
                             {
-                                Console.WriteLine("JHAHAHAH");
                                 seasonObject.Quests[item].attributes.item_seen = true;
                             }
                             else if (seasonObject.DailyQuests.Daily_Quests.ContainsKey(item))
                             {
                                 seasonObject.DailyQuests.Daily_Quests[item].attributes.item_seen = true;
+                            }
+                            else if (seasonObject.special_items.ContainsKey(item))
+                            {
+                                seasonObject.special_items[item].attributes.item_seen = true;
                             }
                         }
 

--- a/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/BP/BattlePurchase.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/BP/BattlePurchase.cs
@@ -14,6 +14,7 @@ using FortBackend.src.App.Utilities;
 using FortLibrary.MongoDB.Module;
 using static FortBackend.src.App.Utilities.Helpers.Grabber;
 using Newtonsoft.Json;
+using FortBackend.src.XMPP.SERVER.Send;
 
 namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog.BP
 {
@@ -29,295 +30,257 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog.BP
             {
                 if (FreeTier.Count > 0)
                 {
-                    if (Season.Season > 1)
+                    if (Season.Season <= 1)
+                        return (seasonObject, currencyItem, ApplyProfileChanges, MultiUpdates, profileCacheEntry); 
+
+                    List<Battlepass> PaidTier = BattlepassManager.PaidBattlePassItems.FirstOrDefault(e => e.Key == Season.Season).Value;
+
+                    if (PaidTier != null)
                     {
-                        List<Battlepass> PaidTier = BattlepassManager.PaidBattlePassItems.FirstOrDefault(e => e.Key == Season.Season).Value;
-
-                        if (PaidTier != null)
+                        if (PaidTier.Count > 0)
                         {
-                            if (PaidTier.Count > 0)
+
+                            currencyItem.quantity -= Price;
+
+
+                            seasonObject.BookPurchased = true;
+
+                            ApplyProfileChanges.Add(new
                             {
+                                changeType = "statModified",
+                                name = "book_purchased",
+                                value = true
+                            });
 
-                                currencyItem.quantity -= Price;
-
-
-                                seasonObject.BookPurchased = true;
-
-                                ApplyProfileChanges.Add(new
+                            if (WeeklyQuestManager.WeeklyQuestsSeasonAboveDictionary.TryGetValue($"Season{seasonObject.SeasonNumber}", out List<WeeklyQuestsJson> WeeklyQuestsArray))
+                            {
+                                if (WeeklyQuestsArray.Count > 0)
                                 {
-                                    changeType = "statModified",
-                                    name = "book_purchased",
-                                    value = true
-                                });
-
-                                if (WeeklyQuestManager.WeeklyQuestsSeasonAboveDictionary.TryGetValue($"Season{seasonObject.SeasonNumber}", out List<WeeklyQuestsJson> WeeklyQuestsArray))
-                                {
-                                    if (WeeklyQuestsArray.Count > 0)
+                                    List<string> ResponseIgIdrk = new List<string>();
+                                    var ResponseId = "";
+                                    foreach (var kvp in WeeklyQuestsArray)
                                     {
-                                        List<string> ResponseIgIdrk = new List<string>();
-                                        var ResponseId = "";
-                                        foreach (var kvp in WeeklyQuestsArray)
+                                        ResponseIgIdrk.Add($"ChallengeBundle:{kvp.BundleId}");
+                                        ResponseId = $"ChallengeBundleSchedule:{kvp.BundleSchedule}";
+
+                                        List<string> QuestTestResponse = new List<string>();
+                                        foreach (var Bundles in kvp.BundlesObject)
                                         {
-                                            ResponseIgIdrk.Add($"ChallengeBundle:{kvp.BundleId}");
-                                            ResponseId = $"ChallengeBundleSchedule:{kvp.BundleSchedule}";
+                                            if (Bundles.quest_data.ExtraQuests) continue;
 
-                                            List<string> QuestTestResponse = new List<string>();
-                                            foreach (var Bundles in kvp.BundlesObject)
+                                            QuestTestResponse.Add(Bundles.templateId);
+
+                                            DailyQuestsData QuestData = seasonObject.Quests.FirstOrDefault(e => e.Key == Bundles.templateId).Value;
+                                            if (QuestData == null)
                                             {
-                                                if (Bundles.quest_data.ExtraQuests) continue;
+                                                List<DailyQuestsObjectiveStates> QuestObjectStats = new List<DailyQuestsObjectiveStates>();
 
-                                                QuestTestResponse.Add(Bundles.templateId);
-
-                                                DailyQuestsData QuestData = seasonObject.Quests.FirstOrDefault(e => e.Key == Bundles.templateId).Value;
-                                                if (QuestData == null)
+                                                foreach (WeeklyObjectsObjectives ObjectiveItems in Bundles.Objectives)
                                                 {
-                                                    List<DailyQuestsObjectiveStates> QuestObjectStats = new List<DailyQuestsObjectiveStates>();
+                                                    //season_xp_gained
 
-                                                    foreach (WeeklyObjectsObjectives ObjectiveItems in Bundles.Objectives)
+                                                    QuestObjectStats.Add(new DailyQuestsObjectiveStates
                                                     {
-                                                        //season_xp_gained
-
-                                                        QuestObjectStats.Add(new DailyQuestsObjectiveStates
-                                                        {
-                                                            Name = $"completion_{ObjectiveItems.BackendName}",
-                                                            Value = 0,
-                                                            MaxValue = ObjectiveItems.Count
-                                                        });
-                                                    }
-
-                                                    seasonObject.Quests.Add($"{Bundles.templateId}", new DailyQuestsData
-                                                    {
-                                                        templateId = $"{Bundles.templateId}",
-                                                        attributes = new DailyQuestsDataDB
-                                                        {
-                                                            challenge_bundle_id = $"ChallengeBundle:{kvp.BundleId}",
-                                                            sent_new_notification = false,
-                                                            ObjectiveState = QuestObjectStats
-                                                        },
-                                                        quantity = 1
-                                                    });
-
-
-                                                    var ItemObjectResponse = new
-                                                    {
-                                                        templateId = $"{Bundles.templateId}",
-                                                        attributes = new Dictionary<string, object>
-                                                        {
-                                                            { "creation_time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
-                                                            { "level", -1 },
-                                                            { "item_seen", false },
-                                                            { "playlists", new List<object>() },
-                                                            { "sent_new_notification", true },
-                                                            { "challenge_bundle_id", $"ChallengeBundle:{kvp.BundleId}" },
-                                                            { "xp_reward_scalar", 1 },
-                                                            { "challenge_linked_quest_given", "" },
-                                                            { "quest_pool", "" },
-                                                            { "quest_state", "Active" },
-                                                            { "bucket", "" },
-                                                            { "last_state_change_time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
-                                                            { "challenge_linked_quest_parent", "" },
-                                                            { "max_level_bonus", 0 },
-                                                            { "xp", 0 },
-                                                            { "quest_rarity", "uncommon" },
-                                                            { "favorite", false },
-                                                            // { $"completion_{dailyQuests.Properties.Objectives[0].BackendName}", 0 }
-                                                        },
-                                                        quantity = 1
-                                                    };
-
-                                                    foreach (DailyQuestsObjectiveStates yklist in QuestObjectStats)
-                                                    {
-                                                        ItemObjectResponse.attributes.Add(yklist.Name, yklist.Value);
-                                                    }
-
-                                                    ApplyProfileChanges.Add(new MultiUpdateClass
-                                                    {
-                                                        changeType = "itemAdded",
-                                                        itemId = $"{Bundles.templateId}",
-                                                        item = ItemObjectResponse
+                                                        Name = $"completion_{ObjectiveItems.BackendName}",
+                                                        Value = 0,
+                                                        MaxValue = ObjectiveItems.Count
                                                     });
                                                 }
-                                            }
 
-                                            var AthenaItemChallengeBundle = new AthenaItemDynamic
-                                            {
-                                                templateId = $"ChallengeBundle:{kvp.BundleId}",
-                                                attributes = new Dictionary<string, object>
+                                                seasonObject.Quests.Add($"{Bundles.templateId}", new DailyQuestsData
                                                 {
-                                                    { "has_unlock_by_completion", false },
-                                                    { "num_quests_completed", 0 },
-                                                    { "level", 0 },
-                                                    { "grantedquestinstanceids", QuestTestResponse.ToArray() },
-                                                    { "item_seen",  true },
-                                                    { "max_allowed_bundle_level", 0 },
-                                                    { "num_granted_bundle_quests", QuestTestResponse.Count() },
-                                                    { "max_level_bonus", 0 },
-                                                    { "challenge_bundle_schedule_id", ResponseId },
-                                                    { "num_progress_quests_completed", 0 },
-                                                    { "xp", 0 },
-                                                    { "favorite", false }
-                                                },
-                                                quantity = 1,
-                                            };
+                                                    templateId = $"{Bundles.templateId}",
+                                                    attributes = new DailyQuestsDataDB
+                                                    {
+                                                        challenge_bundle_id = $"ChallengeBundle:{kvp.BundleId}",
+                                                        sent_new_notification = false,
+                                                        ObjectiveState = QuestObjectStats
+                                                    },
+                                                    quantity = 1
+                                                });
 
-                                            ApplyProfileChanges.Add(new
-                                            {
-                                                changeType = "itemRemoved",
-                                                itemId = $"ChallengeBundle:{kvp.BundleId}"
-                                            });
 
-                                            ApplyProfileChanges.Add(new MultiUpdateClass
-                                            {
-                                                changeType = "itemAdded",
-                                                itemId = $"ChallengeBundle:{kvp.BundleId}",
-                                                item = AthenaItemChallengeBundle
-                                            });
+                                                var ItemObjectResponse = new
+                                                {
+                                                    templateId = $"{Bundles.templateId}",
+                                                    attributes = new Dictionary<string, object>
+                                                    {
+                                                        { "creation_time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
+                                                        { "level", -1 },
+                                                        { "item_seen", false },
+                                                        { "playlists", new List<object>() },
+                                                        { "sent_new_notification", true },
+                                                        { "challenge_bundle_id", $"ChallengeBundle:{kvp.BundleId}" },
+                                                        { "xp_reward_scalar", 1 },
+                                                        { "challenge_linked_quest_given", "" },
+                                                        { "quest_pool", "" },
+                                                        { "quest_state", "Active" },
+                                                        { "bucket", "" },
+                                                        { "last_state_change_time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
+                                                        { "challenge_linked_quest_parent", "" },
+                                                        { "max_level_bonus", 0 },
+                                                        { "xp", 0 },
+                                                        { "quest_rarity", "uncommon" },
+                                                        { "favorite", false },
+                                                        // { $"completion_{dailyQuests.Properties.Objectives[0].BackendName}", 0 }
+                                                    },
+                                                    quantity = 1
+                                                };
+
+                                                foreach (DailyQuestsObjectiveStates yklist in QuestObjectStats)
+                                                {
+                                                    ItemObjectResponse.attributes.Add(yklist.Name, yklist.Value);
+                                                }
+
+                                                ApplyProfileChanges.Add(new MultiUpdateClass
+                                                {
+                                                    changeType = "itemAdded",
+                                                    itemId = $"{Bundles.templateId}",
+                                                    item = ItemObjectResponse
+                                                });
+                                            }
                                         }
 
-                                        var ItemTestObjectResponse = new
+                                        var AthenaItemChallengeBundle = new AthenaItemDynamic
                                         {
-                                            templateId = ResponseId,
+                                            templateId = $"ChallengeBundle:{kvp.BundleId}",
                                             attributes = new Dictionary<string, object>
-                                                                {
-                                                                    { "unlock_epoch", DateTime.MinValue.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
-                                                                    { "max_level_bonus", 0 },
-                                                                    { "level", 0 },
-                                                                    { "item_seen", true },
-                                                                    { "xp", 0 },
-                                                                    { "favorite", false },
-                                                                    { "granted_bundles", ResponseIgIdrk.ToArray() }
-                                                                },
+                                            {
+                                                { "has_unlock_by_completion", false },
+                                                { "num_quests_completed", 0 },
+                                                { "level", 0 },
+                                                { "grantedquestinstanceids", QuestTestResponse.ToArray() },
+                                                { "item_seen",  true },
+                                                { "max_allowed_bundle_level", 0 },
+                                                { "num_granted_bundle_quests", QuestTestResponse.Count() },
+                                                { "max_level_bonus", 0 },
+                                                { "challenge_bundle_schedule_id", ResponseId },
+                                                { "num_progress_quests_completed", 0 },
+                                                { "xp", 0 },
+                                                { "favorite", false }
+                                            },
                                             quantity = 1,
                                         };
 
-                                        MultiUpdates.Add(new
+                                        ApplyProfileChanges.Add(new
                                         {
                                             changeType = "itemRemoved",
-                                            itemId = ResponseId,
+                                            itemId = $"ChallengeBundle:{kvp.BundleId}"
                                         });
 
-
-                                        MultiUpdates.Add(new MultiUpdateClass
+                                        ApplyProfileChanges.Add(new MultiUpdateClass
                                         {
                                             changeType = "itemAdded",
-                                            itemId = ResponseId,
-                                            item = ItemTestObjectResponse
+                                            itemId = $"ChallengeBundle:{kvp.BundleId}",
+                                            item = AthenaItemChallengeBundle
                                         });
                                     }
-                                }
 
-
-
-
-                                List<NotificationsItemsClassOG> ItemsGivenToUser = new List<NotificationsItemsClassOG>();
-                                foreach (Battlepass BattlePass in FreeTier)
-                                {
-                                    if (!NeedItems) break;
-                                    //We don't need this check on purchase as we "WANT" the user to get them items
-                                    //if (BookLevelOG <= BattlePass.Level) continue;
-                                    if (BattlePass.Level > seasonObject.BookLevel) break;
-
-                                    (profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser) = await BattlePassRewards.Init(BattlePass.Rewards, profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser);
-                                }
-                                foreach (Battlepass BattlePass in PaidTier)
-                                {
-                                    if (!NeedItems) break;
-                                    //if (BookLevelOG <= BattlePass.Level) continue;
-                                    if (BattlePass.Level > seasonObject.BookLevel) break;
-
-
-                                    (profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser) = await BattlePassRewards.Init(BattlePass.Rewards, profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser);
-                                }
-
-                                // after to get the correct price
-                                MultiUpdates.Add(new
-                                {
-                                    changeType = "itemQuantityChanged",
-                                    itemId = "Currency",
-                                    quantity = currencyItem.quantity
-                                });
-                                /*
-                                 *   NewItemsGiven.Add(new Dictionary<string, object>
+                                    var ItemTestObjectResponse = new
                                     {
-                                        { "itemType", FreeRewards["TemplateId"].ToString() },
-                                        { "itemGuid", FreeRewards["TemplateId"].ToString() },
-                                        { "quantity", int.Parse(FreeRewards["Quantity"].ToString() ?? "1") }
-                                    });
-                                */
-                                var RandomOfferId = Guid.NewGuid().ToString();
-                                MultiUpdates.Add(new ApplyProfileChangesClassV2
-                                {
-                                    changeType = "itemAdded",
-                                    itemId = RandomOfferId,
-                                    item = new
-                                    {
-                                        templateId = Season.Season >= 5 ? "GiftBox:gb_battlepasspurchased" : "GiftBox:gb_battlepass",
-                                        attributes = new
+                                        templateId = ResponseId,
+                                        attributes = new Dictionary<string, object>
                                         {
-                                            max_level_bonus = 0,
-                                            fromAccountId = "",
-                                            lootList = ItemsGivenToUser
+                                            { "unlock_epoch", DateTime.MinValue.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
+                                            { "max_level_bonus", 0 },
+                                            { "level", 0 },
+                                            { "item_seen", true },
+                                            { "xp", 0 },
+                                            { "favorite", false },
+                                            { "granted_bundles", ResponseIgIdrk.ToArray() }
                                         },
-                                        quantity = 1
-                                    }
-                                });
+                                        quantity = 1,
+                                    };
 
-                                profileCacheEntry.AccountData.commoncore.Gifts.Add(RandomOfferId, new GiftCommonCoreItem
+                                    MultiUpdates.Add(new
+                                    {
+                                        changeType = "itemRemoved",
+                                        itemId = ResponseId,
+                                    });
+
+
+                                    MultiUpdates.Add(new MultiUpdateClass
+                                    {
+                                        changeType = "itemAdded",
+                                        itemId = ResponseId,
+                                        item = ItemTestObjectResponse
+                                    });
+                                }
+                            }
+
+                            List<NotificationsItemsClassOG> ItemsGivenToUser = new List<NotificationsItemsClassOG>();
+                            foreach (Battlepass BattlePass in FreeTier)
+                            {
+                                if (!NeedItems) break;
+                                //We don't need this check on purchase as we "WANT" the user to get them items
+                                //if (BookLevelOG <= BattlePass.Level) continue;
+                                if (BattlePass.Level > seasonObject.BookLevel) break;
+
+                                (profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser) = await BattlePassRewards.Init(BattlePass.Rewards, profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser);
+                            }
+                            foreach (Battlepass BattlePass in PaidTier)
+                            {
+                                if (!NeedItems) break;
+                                //if (BookLevelOG <= BattlePass.Level) continue;
+                                if (BattlePass.Level > seasonObject.BookLevel) break;
+
+
+                                (profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser) = await BattlePassRewards.Init(BattlePass.Rewards, profileCacheEntry, seasonObject, ApplyProfileChanges, currencyItem, NeedItems, ItemsGivenToUser);
+                            }
+
+                            // after to get the correct price
+                            MultiUpdates.Add(new
+                            {
+                                changeType = "itemQuantityChanged",
+                                itemId = "Currency",
+                                quantity = currencyItem.quantity
+                            });
+                            /*
+                                *   NewItemsGiven.Add(new Dictionary<string, object>
+                                {
+                                    { "itemType", FreeRewards["TemplateId"].ToString() },
+                                    { "itemGuid", FreeRewards["TemplateId"].ToString() },
+                                    { "quantity", int.Parse(FreeRewards["Quantity"].ToString() ?? "1") }
+                                });
+                            */
+                            var RandomOfferId = Guid.NewGuid().ToString();
+                            MultiUpdates.Add(new ApplyProfileChangesClassV2
+                            {
+                                changeType = "itemAdded",
+                                itemId = RandomOfferId,
+                                item = new
                                 {
                                     templateId = Season.Season >= 5 ? "GiftBox:gb_battlepasspurchased" : "GiftBox:gb_battlepass",
-                                    attributes = new GiftCommonCoreItemAttributes
+                                    attributes = new
                                     {
+                                        max_level_bonus = 0,
+                                        fromAccountId = "",
                                         lootList = ItemsGivenToUser
                                     },
                                     quantity = 1
-                                });
-
-                                if (!string.IsNullOrEmpty(profileCacheEntry.AccountId))
-                                {
-                                    Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == profileCacheEntry.AccountId)!;
-
-                                    if (Client != null)
-                                    {
-                                        string xmlMessage;
-                                        byte[] buffer;
-                                        WebSocket webSocket = Client.Game_Client;
-                                        Logger.PlainLog(webSocket.State);
-                                        if (webSocket != null && webSocket.State == WebSocketState.Open)
-                                        {
-                                            XNamespace clientNs = "jabber:client";
-
-                                            var message = new XElement(clientNs + "message",
-                                              new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
-                                              new XAttribute("to", profileCacheEntry.AccountId),
-                                              new XElement(clientNs + "body", JsonConvert.SerializeObject(new
-                                              {
-                                                  payload = new { },
-                                                  type = "com.epicgames.gift.received",
-                                                  timestamp = DateTime.UtcNow.ToString("o")
-                                              }))
-                                            );
-
-                                            xmlMessage = message.ToString();
-                                            buffer = Encoding.UTF8.GetBytes(xmlMessage);
-
-                                            Logger.PlainLog(xmlMessage);
-
-                                            await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
-                                        }
-
-                                    }
-
                                 }
-                            }
-                            else
+                            });
+
+                            profileCacheEntry.AccountData.commoncore.Gifts.Add(RandomOfferId, new GiftCommonCoreItem
                             {
-                                Logger.Error("PaidTier file is null [] ? battlepass tiering disabled");
-                            }
+                                templateId = Season.Season >= 5 ? "GiftBox:gb_battlepasspurchased" : "GiftBox:gb_battlepass",
+                                attributes = new GiftCommonCoreItemAttributes
+                                {
+                                    lootList = ItemsGivenToUser
+                                },
+                                quantity = 1
+                            });
+
+                            await XmppGift.NotifyUser(profileCacheEntry.AccountId);
                         }
                         else
                         {
-                            Logger.Log("Unsupported season");
+                            Logger.Error("PaidTier file is null [] ? battlepass tiering disabled");
                         }
+                    }
+                    else
+                    {
+                        Logger.Log("Unsupported season");
                     }
                 }
                 else

--- a/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/BP/BattlePurchase.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/BP/BattlePurchase.cs
@@ -281,7 +281,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog.BP
                                         string xmlMessage;
                                         byte[] buffer;
                                         WebSocket webSocket = Client.Game_Client;
-                                        Console.WriteLine(webSocket.State);
+                                        Logger.PlainLog(webSocket.State);
                                         if (webSocket != null && webSocket.State == WebSocketState.Open)
                                         {
                                             XNamespace clientNs = "jabber:client";
@@ -300,7 +300,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog.BP
                                             xmlMessage = message.ToString();
                                             buffer = Encoding.UTF8.GetBytes(xmlMessage);
 
-                                            Console.WriteLine(xmlMessage);
+                                            Logger.PlainLog(xmlMessage);
 
                                             await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
                                         }

--- a/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/PurchaseBattlepass.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/PurchaseBattlepass.cs
@@ -409,7 +409,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog
                                                         string xmlMessage;
                                                         byte[] buffer;
                                                         WebSocket webSocket = Client.Game_Client;
-                                                        Console.WriteLine(webSocket.State);
+                                                        Logger.PlainLog(webSocket.State);
                                                         if (webSocket != null && webSocket.State == WebSocketState.Open)
                                                         {
                                                             XNamespace clientNs = "jabber:client";
@@ -428,7 +428,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog
                                                             xmlMessage = message.ToString();
                                                             buffer = Encoding.UTF8.GetBytes(xmlMessage);
 
-                                                            Console.WriteLine(xmlMessage);
+                                                            Logger.PlainLog(xmlMessage);
 
                                                             await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
                                                         }

--- a/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/PurchaseItem.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalog/PurchaseItem.cs
@@ -70,7 +70,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog
                         };
                     }
 
-                    Console.WriteLine(HasUserHaveItem);
+                    Logger.PlainLog(HasUserHaveItem);
 
                     NotificationsItems.Add(new NotificationsItemsClass
                     {
@@ -138,7 +138,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog
                         };
                     }
 
-                    Console.WriteLine($"Currency Item Quantity: {CurrentVbucks.quantity}");
+                    Logger.PlainLog($"Currency Item Quantity: {CurrentVbucks.quantity}");
 
                     if (ShopContent.price > int.Parse(CurrentVbucks.quantity.ToString()))
                     {
@@ -239,7 +239,6 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.PurchaseCatalog
                         responseVersion = 1
                     };
                     string mcpJson = JsonConvert.SerializeObject(mcp, Formatting.Indented);
-                    Console.WriteLine(mcpJson);
                     return mcp;
                 }
                 else

--- a/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalogEntry.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalogEntry.cs
@@ -69,7 +69,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
 
                                 if (OfferId.Contains(":/"))
                                 {
-                                    Mcp mcp = await PurchaseItem.Init(Season, ProfileId, Body, profileCacheEntry);
+                                    Mcp mcp = await PurchaseItem.Init(Season, ProfileId, Body, profileCacheEntry, RVN);
                                     return mcp;
                                 }
                                 else
@@ -91,8 +91,6 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                                             error_description = "Catalog Limit is at least 1!",
                                         };
                                     }
-
-                                    var SingleTierOffer = battlepass.catalogEntries.FirstOrDefault(e => e.offerId == OfferId && e.devName.Contains("SingleTier"));
 
                                     if (battlepass != null)
                                     {

--- a/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalogEntry.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseCatalogEntry.cs
@@ -20,7 +20,6 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
     {
         public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, PurchaseCatalogEntryRequest Body)
         {
-            Console.WriteLine(ProfileId);
             if (ProfileId == "common_core" || ProfileId == "profile0")
             {
                 List<SeasonClass> Seasons = profileCacheEntry.AccountData.commoncore.Seasons;

--- a/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseMultipleCatalogEntries.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/PurchaseMultipleCatalogEntries.cs
@@ -1,0 +1,199 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.BattlepassManagement;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortBackend.src.XMPP.SERVER.Send;
+using FortLibrary;
+using FortLibrary.Dynamics;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Purchases;
+using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortLibrary.EpicResponses.Profile.Quests;
+using FortLibrary.EpicResponses.Storefront;
+using FortLibrary.MongoDB.Module;
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class PurchaseMultipleCatalogEntries
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, PurchaseMultipleCatalogEntriesReq Body)
+        {
+            if (ProfileId == "common_core")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.commoncore.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                int BaseRev_C = profileCacheEntry.AccountData.commoncore.RVN;
+
+                List<object> ProfileChanges = new List<object>();
+                List<object> MultiUpdates = new List<object>();
+
+                SeasonClass seasonObject = profileCacheEntry.AccountData.commoncore.Seasons?.FirstOrDefault(season => season.SeasonNumber == Season.Season)!;
+
+                if (seasonObject != null)
+                {
+                    StoreBattlepassPages battlepass = BattlepassManager.BattlePasses.FirstOrDefault(e => e.Key == Season.Season).Value;
+                    if (Body.purchaseInfoList.Count > 0)
+                    {
+                        foreach (PurchaseInfoList InfoList in Body.purchaseInfoList)
+                        {
+                            if (InfoList.purchaseQuantity <= 0) continue;
+                            //if(InfoList.expectedTotalPrice) we wont use this price so idc
+
+
+                            catalogEntrieStore ShopContent = new catalogEntrieStore();
+
+                            foreach (catalogEntrieStore storefront in battlepass.catalogEntries)
+                            {
+                                if (storefront.offerId == InfoList.offerId)
+                                {
+                                    var test = InfoList.purchaseQuantity * storefront.prices[0].finalPrice;
+
+                                    if (test > 0)
+                                    {
+                                        var currencyItem = profileCacheEntry.AccountData.commoncore.Items["Currency"];
+
+                                        if (test > currencyItem.quantity) continue;
+
+                                        currencyItem.quantity -= test;
+
+                                       //seasonObject.battlestars_currency += (5 * InfoList.purchaseQuantity);
+                                        seasonObject.Level += InfoList.purchaseQuantity;
+                                        bool NeedItems = true;
+                                        var OgBattleStars = seasonObject.battlestars_currency;
+                                        // todo update level
+                                        (seasonObject, NeedItems) = await LevelUpdater.Init(seasonObject.SeasonNumber, seasonObject, NeedItems);
+
+                                        ProfileChanges.Add(new
+                                        {
+                                            changeType = "statModified",
+                                            name = "level",
+                                            value = seasonObject.Level
+                                        });
+
+                                        if (OgBattleStars != seasonObject.battlestars_currency)
+                                        {
+                                            ProfileChanges.Add(new
+                                            {
+                                                changeType = "statModified",
+                                                name = "battlestars",
+                                                value = seasonObject.battlestars_currency
+                                            });
+
+                                            ProfileChanges.Add(new
+                                            {
+                                                changeType = "statModified",
+                                                name = "battlestars_season_total",
+                                                value = seasonObject.battlestars_currency
+                                            });
+
+                                        }
+
+                                        MultiUpdates.Add(new
+                                        {
+                                            changeType = "itemQuantityChanged",
+                                            itemId = "Currency",
+                                            quantity = currencyItem.quantity
+                                        });
+
+                                        List<NotificationsItemsClassOG> ItemsGivenToUser = new()
+                                        {
+                                            new()
+                                            {
+                                                itemGuid = "AccountResource:AthenaBattleStar",
+                                                itemType = "AccountResource:AthenaBattleStar",
+                                                quantity = (5 * InfoList.purchaseQuantity)
+                                            }
+                                        };
+
+                                        var RandomOfferId = Guid.NewGuid().ToString();
+                                        MultiUpdates.Add(new ApplyProfileChangesClassV2
+                                        {
+                                            changeType = "itemAdded",
+                                            itemId = RandomOfferId,
+                                            item = new
+                                            {
+                                                templateId = "GiftBox:gb_battlepassoffers",
+                                                attributes = new
+                                                {
+                                                    max_level_bonus = 0,
+                                                    fromAccountId = "",
+                                                    lootList = ItemsGivenToUser
+                                                },
+                                                quantity = 1
+                                            }
+                                        });
+
+                                        profileCacheEntry.AccountData.commoncore.Gifts.Add(RandomOfferId, new GiftCommonCoreItem
+                                        {
+                                            templateId = "GiftBox:gb_battlepassoffers",
+                                            attributes = new GiftCommonCoreItemAttributes
+                                            {
+                                                lootList = ItemsGivenToUser
+                                            },
+                                            quantity = 1
+                                        });
+
+                                        await XmppGift.NotifyUser(profileCacheEntry.AccountId);
+                                    }
+
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
+
+                if (MultiUpdates.Count > 0)
+                    profileCacheEntry.AccountData.commoncore.BumpRevisions();
+
+                List<dynamic> ProfileChangesV2= new List<dynamic>();
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await CommonCoreResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    ProfileChangesV2 = test.profileChanges;
+                }
+                else
+                {
+                    ProfileChangesV2 = MultiUpdates;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.commoncore.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev_C,
+                    profileChanges = ProfileChangesV2,
+                    multiUpdate = new List<object>()
+                    {
+                        new
+                        {
+                            profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                            profileId = "athena",
+                            profileChangesBaseRevision = BaseRev,
+                            profileChanges = ProfileChanges,
+                            profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                        }
+                    },
+                    profileCommandRevision = profileCacheEntry.AccountData.commoncore.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/QueryResponses/AthenaResponse.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/QueryResponses/AthenaResponse.cs
@@ -36,7 +36,6 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses
         {
             try
             {
-                Console.WriteLine(RVN);
                 bool FoundSeasonDataInProfile = profileCacheEntry.AccountData.commoncore.Seasons.Any(season => season.SeasonNumber == Season.Season);
 
                 if (!FoundSeasonDataInProfile)
@@ -57,6 +56,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses
                         BookXP = 0,
                         BookPurchased = false,
                         Quests = new Dictionary<string, DailyQuestsData>(),
+                        special_items = new(),
                         DailyQuests = new DailyQuests
                         {
                             Interval = "0001-01-01T00:00:00.000Z",
@@ -79,8 +79,6 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses
 
                     if (seasonObject != null)
                     {
-                        Console.WriteLine("e " + profileCacheEntry.AccountData.athena.RVN);
-                        Console.WriteLine("e2 " + profileCacheEntry.AccountData.athena.CommandRevision);
                         if (profileCacheEntry.AccountData.athena.RVN == profileCacheEntry.AccountData.athena.CommandRevision)
                         {
                             profileCacheEntry.AccountData.athena.RVN =+ 1;
@@ -183,6 +181,9 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses
                                     ProfileChange.Profile.items.Add(kvp.Key, kvp.Value);
                                 }
                             }
+
+                            foreach (var kvp in seasonObject.special_items)
+                                ProfileChange.Profile.items.Add(kvp.Key, kvp.Value);
 
 
                             // THIS IS INST THE PROPER WAY BUT IT'S BETTER NTO STORING THIS IN THE CODE UNLESS IS ACTUALLY NEEDED

--- a/FortBackend/src/App/Routes/Profile/McpControllers/QueryResponses/AthenaResponse.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/QueryResponses/AthenaResponse.cs
@@ -112,9 +112,9 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses
                                         {
                                             attributes = new AthenaStatsAttributes
                                             {
-                                                use_random_loadout = false,
+                                                use_random_loadout = profileCacheEntry.AccountData.athena.random_loadout,
                                                 past_seasons = new List<object>(),
-                                                loadouts =  profileCacheEntry.AccountData.athena.loadouts,
+                                                loadouts =  profileCacheEntry.AccountData.athena.loadouts!,
                                                 mfa_reward_claimed = false,
                                                 rested_xp_overflow = 0,
                                                 last_xp_interaction = "9999-12-10T22:14:37.647Z",
@@ -138,8 +138,8 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses
                                                 rested_xp_mult = 0,
                                                 season_match_boost = seasonObject.season_match_boost,
                                                 season_friend_match_boost = seasonObject.season_friend_match_boost,
-                                                active_loadout_index = Array.IndexOf(profileCacheEntry.AccountData.athena.loadouts, profileCacheEntry.AccountData.athena.last_applied_loadout),
-                                                purchased_bp_offers = new List<object> { },
+                                                active_loadout_index = 0/*profileCacheEntry.AccountData.athena.loadouts.FindIndex((e) => e == profileCacheEntry.AccountData.athena.last_applied_loadout)*/,
+                                                purchased_bp_offers = seasonObject.season_offers,
                                                 last_applied_loadout = profileCacheEntry.AccountData.athena.last_applied_loadout?.ToString() ?? "",
                                                 xp = seasonObject.SeasonXP,
                                                 rested_xp = seasonObject.SeasonXP,
@@ -176,7 +176,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses
                             }
                             else
                             {
-                                foreach (var kvp in profileCacheEntry.AccountData.athena.Items)
+                                foreach (var kvp in profileCacheEntry.AccountData.athena.Items!)
                                 {
                                     ProfileChange.Profile.items.Add(kvp.Key, kvp.Value);
                                 }

--- a/FortBackend/src/App/Routes/Profile/McpControllers/RemoveGiftBox.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/RemoveGiftBox.cs
@@ -42,7 +42,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                 }
                 else if(requestBodyy.giftBoxItemIds.Count() > 0)
                 {
-                    Console.WriteLine(requestBodyy.giftBoxItemIds.Count());
+                    Logger.PlainLog(requestBodyy.giftBoxItemIds.Count());
                     foreach (var GiftBoxID in requestBodyy.giftBoxItemIds)
                     {
                         GiftCommonCoreItem GiftBoxItem = profileCacheEntry.AccountData.commoncore.Gifts.FirstOrDefault(e => e.Key == GiftBoxID).Value;

--- a/FortBackend/src/App/Routes/Profile/McpControllers/RemoveGiftBox.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/RemoveGiftBox.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 
 namespace FortBackend.src.App.Routes.Profile.McpControllers
 {
@@ -19,6 +20,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
             string currentDate = DateTime.UtcNow.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
             if (ProfileId == "common_core")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.commoncore.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.commoncore.RVN;
 
                 List<object> MultiUpdates = new List<object>();
@@ -63,12 +65,11 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
 
                 if (MultiUpdates.Count > 0)
                 {
-                    profileCacheEntry.AccountData.commoncore.RVN += 1;
-                    profileCacheEntry.AccountData.commoncore.CommandRevision += 1;
+                    profileCacheEntry.AccountData.commoncore.BumpRevisions();
                     profileCacheEntry.LastUpdated = DateTime.UtcNow;
                 }
 
-                if (BaseRev != RVN)
+                if (BaseRev_G != RVN)
                 {
                     Mcp test = await CommonCoreResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
                     ProfileChanges = test.profileChanges;

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetCosmeticLockerBanner.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetCosmeticLockerBanner.cs
@@ -1,0 +1,88 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortLibrary;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Quests;
+using FortLibrary.MongoDB.Module;
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class SetCosmeticLockerBanner
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, SetCosmeticLockerBannerReq Body)
+        {
+            if (ProfileId == "athena" || ProfileId == "profile0")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> ProfileChanges = new List<object>();
+
+                if(!string.IsNullOrEmpty(Body.lockerItem))
+                {
+                    var UpdatedData = profileCacheEntry.AccountData.athena.loadouts_data![Body.lockerItem].attributes;
+
+                    if (!string.IsNullOrEmpty(Body.bannerIconTemplateName))
+                    {
+                        UpdatedData.banner_icon_template = Body.bannerIconTemplateName;
+
+                        ProfileChanges.Add(new
+                        {
+                            changeType = "itemAttrChanged",
+                            itemId = Body.lockerItem,
+                            attributeName = "banner_icon_template",
+                            attributeValue = UpdatedData.banner_icon_template
+                        });
+
+                    }
+
+                    if (!string.IsNullOrEmpty(Body.bannerColorTemplateName))
+                    {
+                        UpdatedData.banner_color_template = Body.bannerColorTemplateName;
+
+                        ProfileChanges.Add(new
+                        {
+                            changeType = "itemAttrChanged",
+                            itemId = Body.lockerItem,
+                            attributeName = "banner_color_template",
+                            attributeValue = UpdatedData.banner_color_template
+                        });
+                    }
+                }
+                
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
+
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    ProfileChanges = test.profileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+                
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetCosmeticLockerName.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetCosmeticLockerName.cs
@@ -1,0 +1,74 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortLibrary;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Quests;
+using FortLibrary.MongoDB.Module;
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class SetCosmeticLockerName
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, SetCosmeticLockerNameReq Body)
+        {
+            if (ProfileId == "athena" || ProfileId == "profile0")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> ProfileChanges = new List<object>();
+
+                if (!string.IsNullOrEmpty(Body.lockerItem))
+                {
+                    var UpdatedData = profileCacheEntry.AccountData.athena.loadouts_data![Body.lockerItem].attributes;
+
+                    if (!string.IsNullOrEmpty(Body.name))
+                    {
+                        UpdatedData.locker_name = Body.name;
+
+                        ProfileChanges.Add(new
+                        {
+                            changeType = "itemAttrChanged",
+                            itemId = Body.lockerItem,
+                            attributeName = "locker_name",
+                            attributeValue = UpdatedData.locker_name
+                        });
+                    }
+                }
+
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
+
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    ProfileChanges = test.profileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetCosmeticLockerSlot.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetCosmeticLockerSlot.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
 using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 using FortBackend.src.App.Utilities.MongoDB.Helpers;
 using FortBackend.src.App.Utilities.Saved;
 using FortLibrary;
@@ -22,6 +23,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
         {
             if (ProfileId == "athena" || ProfileId == "profile0")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.athena.RVN;
                 List<object> ProfileChanges = new List<object>();
                 //var UpdatedData = profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes.locker_slots_data;
@@ -37,6 +39,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                 {
                     "",
                     "cid_random",
+                    "bid_random",
                     "glider_random",
                     "pickaxe_random",
                     "pickaxe_random",
@@ -162,29 +165,22 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                 if (ProfileChanges.Count > 0)
                 {
                     profileCacheEntry.LastUpdated = DateTime.Now;
-                    profileCacheEntry.AccountData.athena.RVN += 1;
-                    profileCacheEntry.AccountData.athena.CommandRevision += 1;
-                   // profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes.locker_slots_data = UpdatedData;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
                 }
-                
-                List<dynamic> ProfileChangesV2 = new List<dynamic>();
-                if (Season.SeasonFull >= 12.20)
+
+                if (BaseRev_G != RVN)
                 {
                     Mcp AthenaData = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
-                    ProfileChangesV2 = AthenaData.profileChanges;
-                }
-                else
-                {
-                    ProfileChangesV2 = ProfileChanges;
+                    ProfileChanges = AthenaData.profileChanges;
                 }
 
                 return new Mcp()
                 {
-                    profileRevision = profileCacheEntry.AccountData.athena.RVN + 1,
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
                     profileId = ProfileId,
-                    profileChangesBaseRevision = BaseRev + 1,
-                    profileChanges = ProfileChangesV2,
-                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision + 1,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
                     serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
                     responseVersion = 1
                 };

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetItemFavoriteStatus.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetItemFavoriteStatus.cs
@@ -1,0 +1,85 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortBackend.src.App.Utilities.Saved;
+using FortLibrary;
+using FortLibrary.EpicResponses.Errors;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortLibrary.MongoDB.Module;
+using FortLibrary.Shop;
+
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using System.Linq;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class SetItemFavoriteStatus
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, SetItemFavoriteStatusReq Body)
+        {
+            if (ProfileId == "athena" || ProfileId == "profile0")
+            {
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> ProfileChanges = new List<object>();
+                List<dynamic> MultiUpdates = new List<dynamic>();
+                if (profileCacheEntry.AccountData.athena.Items.ContainsKey(Body.targetItemId))
+                {
+                    profileCacheEntry.AccountData.athena.Items[Body.targetItemId].attributes.favorite = Body.bFavorite;
+                }
+                else
+                {
+                    SeasonClass seasonObject = profileCacheEntry.AccountData.commoncore.Seasons?.FirstOrDefault(season => season.SeasonNumber == Season.Season)!;
+
+                    if (seasonObject != null)
+                        if (seasonObject.special_items.ContainsKey(Body.targetItemId))
+                        {
+                            seasonObject.special_items[Body.targetItemId].attributes.favorite = Body.bFavorite;
+                        }
+                }
+
+                ProfileChanges.Add(new
+                {
+                    itemId = Body.targetItemId,
+                    attributeName = "favorite",
+                    attributeValue = Body.bFavorite
+                });
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.RVN += 1;
+                    profileCacheEntry.AccountData.athena.CommandRevision += 1;
+                    // profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes.locker_slots_data = UpdatedData;
+                }
+
+                if (Season.SeasonFull >= 12.20)
+                {
+                    Mcp AthenaData = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    MultiUpdates = AthenaData.profileChanges;
+                }
+                else
+                {
+                    MultiUpdates = ProfileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN + 1,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev + 1,
+                    profileChanges = MultiUpdates,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision + 1,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetItemFavoriteStatus.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetItemFavoriteStatus.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
 using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 using FortBackend.src.App.Utilities.MongoDB.Helpers;
 using FortBackend.src.App.Utilities.Saved;
 using FortLibrary;
@@ -24,9 +25,10 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
         {
             if (ProfileId == "athena" || ProfileId == "profile0")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.athena.RVN;
                 List<object> ProfileChanges = new List<object>();
-                List<dynamic> MultiUpdates = new List<dynamic>();
+
                 if (profileCacheEntry.AccountData.athena.Items.ContainsKey(Body.targetItemId))
                 {
                     profileCacheEntry.AccountData.athena.Items[Body.targetItemId].attributes.favorite = Body.bFavorite;
@@ -52,28 +54,22 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                 if (ProfileChanges.Count > 0)
                 {
                     profileCacheEntry.LastUpdated = DateTime.Now;
-                    profileCacheEntry.AccountData.athena.RVN += 1;
-                    profileCacheEntry.AccountData.athena.CommandRevision += 1;
-                    // profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes.locker_slots_data = UpdatedData;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
                 }
 
-                if (Season.SeasonFull >= 12.20)
+                if (BaseRev_G != RVN)
                 {
                     Mcp AthenaData = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
-                    MultiUpdates = AthenaData.profileChanges;
-                }
-                else
-                {
-                    MultiUpdates = ProfileChanges;
+                    ProfileChanges = AthenaData.profileChanges;
                 }
 
                 return new Mcp()
                 {
-                    profileRevision = profileCacheEntry.AccountData.athena.RVN + 1,
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
                     profileId = ProfileId,
-                    profileChangesBaseRevision = BaseRev + 1,
-                    profileChanges = MultiUpdates,
-                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision + 1,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
                     serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
                     responseVersion = 1
                 };

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetItemFavoriteStatusBatch.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetItemFavoriteStatusBatch.cs
@@ -1,0 +1,96 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortBackend.src.App.Utilities.Saved;
+using FortLibrary;
+using FortLibrary.EpicResponses.Errors;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortLibrary.MongoDB.Module;
+using FortLibrary.Shop;
+
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using System.Linq;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    public class SetItemFavoriteStatusBatch
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, SetItemFavoriteStatusBatchReq Body)
+        {
+            if (ProfileId == "athena" || ProfileId == "profile0")
+            {
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> ProfileChanges = new List<object>();
+                List<dynamic> MultiUpdates = new List<dynamic>();
+                SeasonClass seasonObject = profileCacheEntry.AccountData.commoncore.Seasons?.FirstOrDefault(season => season.SeasonNumber == Season.Season)!;
+
+                for (int i = 0; i < Body.itemIds.Count; i++)
+                {
+                    var Item = Body.itemIds[i];
+                    var Favorite = Body.itemFavStatus[i];
+
+                    if (profileCacheEntry.AccountData.athena.Items.ContainsKey(Item))
+                    {
+                        profileCacheEntry.AccountData.athena.Items[Item].attributes.favorite = Favorite;
+                    }
+                    else
+                    {
+                        if (seasonObject != null)
+                        {
+                            if (seasonObject.special_items.ContainsKey(Item))
+                            {
+                                seasonObject.special_items[Item].attributes.favorite = Favorite;
+                            }
+                        }
+                    }
+
+                    ProfileChanges.Add(new
+                    {
+                        itemId = Item,
+                        attributeName = "item_seen",
+                        attributeValue = Favorite
+                    });
+                }
+                
+
+               
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.RVN += 1;
+                    profileCacheEntry.AccountData.athena.CommandRevision += 1;
+                    // profileCacheEntry.AccountData.athena.loadouts_data["sandbox_loadout"].attributes.locker_slots_data = UpdatedData;
+                }
+
+                if (Season.SeasonFull >= 12.20)
+                {
+                    Mcp AthenaData = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    MultiUpdates = AthenaData.profileChanges;
+                }
+                else
+                {
+                    MultiUpdates = ProfileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN + 1,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev + 1,
+                    profileChanges = MultiUpdates,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision + 1,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetPartyAssistQuest.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetPartyAssistQuest.cs
@@ -6,6 +6,7 @@ using FortLibrary.EpicResponses.Profile.Quests;
 using Discord;
 using System.Xml.Linq;
 using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 
 namespace FortBackend.src.App.Routes.Profile.McpControllers
 {
@@ -15,6 +16,7 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
         {
             if (ProfileId == "athena" || ProfileId == "profile0")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.athena.RVN;
 
                 SeasonClass FoundSeason = profileCacheEntry.AccountData.commoncore?.Seasons.FirstOrDefault(x => x.SeasonNumber == Season.Season)!;
@@ -54,11 +56,10 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                 if (ProfileChanges.Count > 0)
                 {
                     profileCacheEntry.LastUpdated = DateTime.Now;
-                    profileCacheEntry.AccountData.athena.RVN += 1;
-                    profileCacheEntry.AccountData.athena.CommandRevision += 1;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
                 }
 
-                if (BaseRev != RVN)
+                if (BaseRev_G != RVN)
                 {
                     Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
                     ProfileChanges = test.profileChanges;
@@ -66,11 +67,11 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
 
                 return new Mcp()
                 {
-                    profileRevision = profileCacheEntry.AccountData.athena.RVN + 1,
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
                     profileId = ProfileId,
-                    profileChangesBaseRevision = BaseRev + 1,
+                    profileChangesBaseRevision = BaseRev,
                     profileChanges = ProfileChanges,
-                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision + 1,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
                     serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
                     responseVersion = 1
                 };

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetRandomCosmeticLoadout.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetRandomCosmeticLoadout.cs
@@ -1,0 +1,59 @@
+﻿using Discord;
+using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.Helpers.Middleware;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortBackend.src.App.Utilities.MongoDB.Helpers;
+using FortLibrary;
+using FortLibrary.EpicResponses.Profile;
+using FortLibrary.EpicResponses.Profile.Quests;
+using FortLibrary.MongoDB.Module;
+//using MongoDB.Bson.IO;
+using Newtonsoft.Json;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    // no body!!!! idk how this endpoint even works.. ik its random so must be the random flag 
+    public class SetRandomCosmeticLoadout
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry)
+        {
+            if (ProfileId == "athena" || ProfileId == "profile0")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> ProfileChanges = new List<object>();
+
+                // this makes no sense, use_random_loadout isnt used for season 2
+                // videos that show it is legit from 12.20 that didnt have the random preset option
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
+
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    ProfileChanges = test.profileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/SetRandomCosmeticLoadoutFlag.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/SetRandomCosmeticLoadoutFlag.cs
@@ -1,0 +1,61 @@
+﻿using FortBackend.src.App.Routes.Profile.McpControllers.QueryResponses;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortLibrary;
+using FortLibrary.EpicResponses.Profile;
+using static FortBackend.src.App.Utilities.Helpers.Grabber;
+
+namespace FortBackend.src.App.Routes.Profile.McpControllers
+{
+    // on everything i wouldnt add this if fortnite didnt try to force it ;(
+    public class SetRandomCosmeticLoadoutFlag
+    {
+        public static async Task<Mcp> Init(string AccountId, string ProfileId, VersionClass Season, int RVN, ProfileCacheEntry profileCacheEntry, SetRandomCosmeticLoadoutFlagReq Body)
+        {
+            if (ProfileId == "athena" || ProfileId == "profile0")
+            {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
+                int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                List<object> ProfileChanges = new List<object>();
+                //"random" : false
+                // this makes no sense, use_random_loadout isnt used for season 2
+                // videos that show it is legit from 12.20 that didnt have the random preset option
+
+                // enabled might break it anyways
+                profileCacheEntry.AccountData.athena.random_loadout = Body.random;
+
+                ProfileChanges.Add(new
+                {
+                    changeType = "statModified",
+                    name = "use_random_loadout",
+                    value = Body.random
+                });
+
+                if (ProfileChanges.Count > 0)
+                {
+                    profileCacheEntry.LastUpdated = DateTime.Now;
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                }
+
+                if (BaseRev_G != RVN)
+                {
+                    Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
+                    ProfileChanges = test.profileChanges;
+                }
+
+                return new Mcp()
+                {
+                    profileRevision = profileCacheEntry.AccountData.athena.RVN,
+                    profileId = ProfileId,
+                    profileChangesBaseRevision = BaseRev,
+                    profileChanges = ProfileChanges,
+                    profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
+                    serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    responseVersion = 1
+                };
+
+            }
+
+            return new Mcp();
+        }
+    }
+}

--- a/FortBackend/src/App/Routes/Profile/McpControllers/UpdateQuestClientObjectives.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/UpdateQuestClientObjectives.cs
@@ -44,7 +44,6 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                     {
                         foreach(AdvancedCon Advanced in requestBodyy.advance)
                         {
-                            Console.WriteLine(Advanced.statName);
                             if (Advanced.statName.Contains("quest_"))
                             {
                                 var match = Regex.Match(Advanced.statName, @"^(.*?)(_\d+)?$"); ;
@@ -79,8 +78,8 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                                             attributeValue = Advanced.count
                                         });
 
-                                        Console.WriteLine(FoundSeason.Quests[$"Quest:{QuestStatName}"].templateId);
-                                        Console.WriteLine(FoundSeason.Quests[$"Quest:{QuestStatName}"].attributes.ObjectiveState[OBStateNumber].Name);
+                                        Logger.PlainLog(FoundSeason.Quests[$"Quest:{QuestStatName}"].templateId);
+                                        Logger.PlainLog(FoundSeason.Quests[$"Quest:{QuestStatName}"].attributes.ObjectiveState[OBStateNumber].Name);
 
                                         if (FoundSeason.Quests[$"Quest:{QuestStatName}"].attributes.ObjectiveState.All(os => os.Value == os.MaxValue))
                                         {
@@ -173,8 +172,8 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                     });
                 }
 
-                Console.WriteLine(BaseRev);
-                Console.WriteLine(RVN);
+                Logger.PlainLog(BaseRev);
+                Logger.PlainLog(RVN);
                 if (BaseRev != RVN)
                 {
                     Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);

--- a/FortBackend/src/App/Routes/Profile/McpControllers/UpdateQuestClientObjectives.cs
+++ b/FortBackend/src/App/Routes/Profile/McpControllers/UpdateQuestClientObjectives.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using static System.Net.Mime.MediaTypeNames;
 using FortBackend.src.App.Utilities.Helpers.QuestsManagement;
 using System.Text.RegularExpressions;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 
 namespace FortBackend.src.App.Routes.Profile.McpControllers
 {
@@ -30,13 +31,13 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
             string currentDate = DateTime.UtcNow.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
             if (ProfileId == "athena" || ProfileId == "profile0")
             {
+                int BaseRev_G = profileCacheEntry.AccountData.athena.GetBaseRevision(Season.Season);
                 int BaseRev = profileCacheEntry.AccountData.athena.RVN;
+                int BaseRev_C = profileCacheEntry.AccountData.commoncore.RVN;
+                List<object> MultiUpdates = new();
+                List<object> MultiUpdatesForCommonCore = new();
 
-                List<object> MultiUpdates = new List<object>();
-                List<object> MultiUpdatesForCommonCore = new List<object>();
-                List<object> ProfileChanges = new List<object>();
-
-                SeasonClass FoundSeason = profileCacheEntry.AccountData.commoncore?.Seasons.FirstOrDefault(x => x.SeasonNumber == Season.Season)!;
+                SeasonClass FoundSeason = profileCacheEntry.AccountData.commoncore.Seasons.FirstOrDefault(x => x.SeasonNumber == Season.Season)!;
                 
                 if (FoundSeason != null)
                 {
@@ -129,59 +130,34 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                                 // NOT ADDED YET
                                 Logger.Error($"UpdateQuestClientObject doesnt have {Advanced.statName}");
                             }
-
-
-                            //foreach(string QuestData in FoundSeason.Quests.Keys)
-                            //{
-                            //    //FoundSeason.Quests[QuestData].attributes.ObjectiveState.Find(match => match.Name == $"completion_{Advanced.statName}").;
-                            //    //if (FoundSeason.Quests.TryGetValue(Advanced.statName, out var AvgQuest))
-                            //    //{
-                            //    //    //FoundSeason.Quests[$"Quest:{Advanced.statName}"].attributes.
-                            //    //}
-                            //}
-                          
                         }
                         
                     }
-                }
-
-                
+                }       
 
                 if (MultiUpdates.Count > 0)
-                {
-                    profileCacheEntry.AccountData.athena.RVN += 1;
-                    profileCacheEntry.AccountData.athena.CommandRevision += 1;
-                }
-
-
+                    profileCacheEntry.AccountData.athena.BumpRevisions();
+                
                 List<object> MultiCommonCoreUpdate = new List<object>();
                 if (MultiUpdatesForCommonCore.Count > 0)
                 {
-                    var BeofreUpdate = profileCacheEntry.AccountData.commoncore.RVN;
                     profileCacheEntry.LastUpdated = DateTime.Now;
-                    profileCacheEntry.AccountData.commoncore.RVN += 1;
-                    profileCacheEntry.AccountData.commoncore.CommandRevision += 1;
+                    profileCacheEntry.AccountData.commoncore.BumpRevisions();
 
                     MultiCommonCoreUpdate.Add(new
                     {
                         profileRevision = profileCacheEntry.AccountData.commoncore.RVN,
                         profileId = "common_core",
-                        profileChangesBaseRevision = BeofreUpdate,
+                        profileChangesBaseRevision = BaseRev_C,
                         profileChanges = MultiUpdatesForCommonCore,
                         profileCommandRevision = profileCacheEntry.AccountData.commoncore.CommandRevision,
                     });
                 }
 
-                Logger.PlainLog(BaseRev);
-                Logger.PlainLog(RVN);
-                if (BaseRev != RVN)
+                if (BaseRev_G != RVN)
                 {
                     Mcp test = await AthenaResponse.Grab(AccountId, ProfileId, Season, RVN, profileCacheEntry);
-                    ProfileChanges = test.profileChanges;
-                }
-                else
-                {
-                    ProfileChanges = MultiUpdates;
+                    MultiUpdates = test.profileChanges;
                 }
 
                 return new Mcp()
@@ -189,18 +165,13 @@ namespace FortBackend.src.App.Routes.Profile.McpControllers
                     profileRevision = profileCacheEntry.AccountData.athena.RVN,
                     profileId = ProfileId,
                     profileChangesBaseRevision = BaseRev,
-                    profileChanges = ProfileChanges,
+                    profileChanges = MultiUpdates,
                     multiUpdate = MultiCommonCoreUpdate,
-                    //notifications = NotificationsUpdates,
                     profileCommandRevision = profileCacheEntry.AccountData.athena.CommandRevision,
                     serverTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
                     responseVersion = 1
                 };
-        
 
-
-
-              
             }
             return new Mcp();
         }

--- a/FortBackend/src/App/Routes/Storefront/Catalog.cs
+++ b/FortBackend/src/App/Routes/Storefront/Catalog.cs
@@ -155,10 +155,18 @@ namespace FortBackend.src.App.Routes.Storefront
                     List<CatalogRequirements> requirements = new List<CatalogRequirements>();
                     List<itemGrants> itemGrants = new List<itemGrants>();
                     //Item itemIg = WeeklyItems.items.FirstOrDefault(item => !string.IsNullOrEmpty(item.description));
-                    var DisplayAsset = $"DA_Daily_{WeeklyItems.item}";
+                    var DisplayAsset = $"DA_Featured_{WeeklyItems.item}";
                     if (!string.IsNullOrEmpty(WeeklyItems.BundlePath))
                     {
                         DisplayAsset = WeeklyItems.BundlePath;
+                    }
+                    else {
+                        var Items = WeeklyItems.item.Split(':');
+
+                        if(Items.Length > 0)
+                        {
+                            DisplayAsset = $"DA_Featured_{Items[1]}";
+                        }
                     }
 
 

--- a/FortBackend/src/App/Service.cs
+++ b/FortBackend/src/App/Service.cs
@@ -127,25 +127,34 @@ namespace FortBackend.src.App
                 if (!string.IsNullOrEmpty(json))
                 {
                     ShopJson shopData = JsonConvert.DeserializeObject<ShopJson>(json)!;
-                    if(shopData.ShopItems.Daily.Count == 0 &&
+                    if (shopData.ShopItems.Daily.Count == 0 &&
                         shopData.ShopItems.Weekly.Count == 0)
-                    {
                         // Shop is empty... how about we generate a new shop
-                        var GeneraterShocked = new Thread(async () => {
+                        (new Thread(async () =>
+                        {
                             await GenerateShop.Init();
-                        });
-
-                        GeneraterShocked.Start();
+                        })).Start();
+                    
+                    else if (DateTime.TryParse(shopData.expiration, out DateTime expirationDate))
+                    {
+                        if (DateTime.Now > expirationDate)
+                        {
+                            Logger.Warn("Shop auto re-generated due to being expired", "[SHOP]");
+                            (new Thread(async () =>
+                            {
+                                await GenerateShop.Init();
+                            })).Start();
+                        }
                     }
+
                 }
                 else
                 {
                     // need to clean this up!
-                    var GeneraterShocked = new Thread(async () => {
+                    (new Thread(async () =>
+                    {
                         await GenerateShop.Init();
-                    });
-
-                    GeneraterShocked.Start();
+                    })).Start();
                 }
 
                 var ItemShopGenThread = new Thread(async () =>

--- a/FortBackend/src/App/Service.cs
+++ b/FortBackend/src/App/Service.cs
@@ -45,6 +45,8 @@ namespace FortBackend.src.App
 
             startup.ConfigureServices(builder.Services);
 
+            Logger.SetLogLevel(Saved.DeserializeConfig.LogLevel);
+
             if (Saved.DeserializeConfig.HTTPS)
             {
                 Saved.BackendCachedData.DefaultProtocol = "https://";

--- a/FortBackend/src/App/Utilities/ADMIN/DashboardConfigData.cs
+++ b/FortBackend/src/App/Utilities/ADMIN/DashboardConfigData.cs
@@ -51,6 +51,13 @@ namespace FortBackend.src.App.Utilities.ADMIN
                             Type = "string",
                             Value = FortConfigData.MatchmakerIP
                         },
+                        new ConfigData
+                        {
+                            Title = "Log Level",
+                            METADATA = "LogLevel",
+                            Type = "int",
+                            Value = FortConfigData.LogLevel
+                        },
                     }
                  },
                 new ConfigTop

--- a/FortBackend/src/App/Utilities/Constants/PathConstants.cs
+++ b/FortBackend/src/App/Utilities/Constants/PathConstants.cs
@@ -25,6 +25,8 @@ namespace FortBackend.src.App.Utilities.Constants
             public static readonly string ShopGliders = Path.Combine(BaseDir, "Json/shop/gliders.json");
             public static readonly string ShopPickaxe = Path.Combine(BaseDir, "Json/shop/pickaxes.json");
             public static readonly string ShopWrap = Path.Combine(BaseDir, "Json/shop/wrap.json");
+
+            public static readonly string ChristmasItems = Path.Combine(BaseDir, "Json/shop/christmas/christmas.json");
         }
 
         public class Templates
@@ -58,7 +60,7 @@ namespace FortBackend.src.App.Utilities.Constants
 
         public class CachedPaths
         {
-            public static readonly string FortConfig = Path.Combine(BaseDir, "config.json");
+            public static readonly string FortConfig = Path.Combine(BaseDir, "Config.json");
             public static readonly string FortGame = Path.Combine(BaseDir, "GameConfig.json");
             public static readonly string FullLocker = Path.Combine(BaseDir, "Json/Profiles/FullLocker.json");
             public static readonly string DefaultBanner = Path.Combine(BaseDir, "Json/Profiles/Banners/DefaultBanners.json");

--- a/FortBackend/src/App/Utilities/Discord/Helpers/SlashCommand.cs
+++ b/FortBackend/src/App/Utilities/Discord/Helpers/SlashCommand.cs
@@ -109,7 +109,7 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error handling command: {ex.Message}");
+                Logger.Error($"Error handling command: {ex.Message}", "SlashCommands");
               //  await command.RespondAsync("testr", ephemeral: true);
             }
         }

--- a/FortBackend/src/App/Utilities/Discord/Helpers/command/create.cs
+++ b/FortBackend/src/App/Utilities/Discord/Helpers/command/create.cs
@@ -107,12 +107,9 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                         }
                                         else
                                         {
-                                            await command.RespondAsync("How tf did you get gere", ephemeral: true);
+                                            await command.RespondAsync("Database is null! :D", ephemeral: true);
                                         }
 
-
-
-                                      
                                     }
                                     else
                                     {
@@ -140,14 +137,8 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
 
                                 await command.RespondAsync(embed: embed.Build(), ephemeral: true);
                             }
-                        }
-
-
-                       
-                           
+                        }   
                     }
-
-                   
                 }
                 else
                 {

--- a/FortBackend/src/App/Utilities/Discord/Helpers/command/who.cs
+++ b/FortBackend/src/App/Utilities/Discord/Helpers/command/who.cs
@@ -3,8 +3,10 @@ using Discord.WebSocket;
 using FortBackend.src.App.Utilities.Helpers.Middleware;
 using FortBackend.src.App.Utilities.Helpers.UserManagement;
 using FortBackend.src.App.Utilities.MongoDB;
+using FortBackend.src.App.Utilities.MongoDB.Extentions;
 using FortBackend.src.App.Utilities.MongoDB.Helpers;
 using FortBackend.src.XMPP.Data;
+using FortBackend.src.XMPP.SERVER.Send;
 using FortLibrary;
 using FortLibrary.EpicResponses.Profile.Purchases;
 using FortLibrary.EpicResponses.Profile.Query.Items;
@@ -234,7 +236,7 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                                 }
                                             }
                                             var RandomOfferId = Guid.NewGuid().ToString();
-                                            int Season = -1;
+                                            float Season = -1;
                                             if (Saved.Saved.DeserializeGameConfig.ForceSeason)
                                             {
                                                 Season = Saved.Saved.DeserializeGameConfig.Season;
@@ -257,42 +259,10 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                                 },
                                                 quantity = 1
                                             });
-                                            profileCacheEntry.AccountData.commoncore.RVN += 1;
-                                            profileCacheEntry.AccountData.commoncore.CommandRevision += 1;
 
-                                            Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == profileCacheEntry.AccountId)!;
+                                            profileCacheEntry.AccountData.commoncore.BumpRevisions();
 
-                                            if (Client != null)
-                                            {
-                                                string xmlMessage;
-                                                byte[] buffer;
-                                                WebSocket webSocket = Client.Game_Client;
-
-                                                if (webSocket != null && webSocket.State == WebSocketState.Open)
-                                                {
-                                                    XNamespace clientNs = "jabber:client";
-
-                                                    var message = new XElement(clientNs + "message",
-                                                        new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
-                                                        new XAttribute("to", profileCacheEntry.AccountId),
-                                                        new XElement(clientNs + "body", JsonConvert.SerializeObject(new
-                                                        {
-                                                            payload = new { },
-                                                            type = "com.epicgames.gift.received",
-                                                            timestamp = DateTime.UtcNow.ToString("o")
-                                                        }))
-                                                    );
-
-                                                    xmlMessage = message.ToString();
-                                                    buffer = Encoding.UTF8.GetBytes(xmlMessage);
-
-                                                    //  Console.WriteLine(xmlMessage);
-
-                                                    await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
-                                                }
-
-                                            }
-
+                                            await XmppGift.NotifyUser(profileCacheEntry.AccountId);
                                             await interaction.RespondAsync($"Gave {Vbucks} to {profileCacheEntry.UserData.Username}", ephemeral: true);
                                         }
                                         else
@@ -324,41 +294,9 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                                 attributes = new GiftCommonCoreItemAttributes { },
                                                 quantity = 1
                                             });
-                                            profileCacheEntry.AccountData.commoncore.RVN += 1;
-                                            profileCacheEntry.AccountData.commoncore.CommandRevision += 1;
+                                            profileCacheEntry.AccountData.commoncore.BumpRevisions();
 
-                                            Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == profileCacheEntry.AccountId)!;
-
-                                            if (Client != null)
-                                            {
-                                                string xmlMessage;
-                                                byte[] buffer;
-                                                WebSocket webSocket = Client.Game_Client;
-
-                                                if (webSocket != null && webSocket.State == WebSocketState.Open)
-                                                {
-                                                    XNamespace clientNs = "jabber:client";
-
-                                                    var message = new XElement(clientNs + "message",
-                                                        new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
-                                                        new XAttribute("to", profileCacheEntry.AccountId),
-                                                        new XElement(clientNs + "body", JsonConvert.SerializeObject(new
-                                                        {
-                                                            payload = new { },
-                                                            type = "com.epicgames.gift.received",
-                                                            timestamp = DateTime.UtcNow.ToString("o")
-                                                        }))
-                                                    );
-
-                                                    xmlMessage = message.ToString();
-                                                    buffer = Encoding.UTF8.GetBytes(xmlMessage);
-
-                                                    Logger.PlainLog(xmlMessage);
-
-                                                    await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
-                                                }
-
-                                            }
+                                            await XmppGift.NotifyUser(profileCacheEntry.AccountId);
                                         }
                                     }
 
@@ -439,62 +377,85 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                                 //});
                                             }
 
-                                            profileCacheEntry.UserData.temp_banned = true;
-
-                                            await Handlers.UpdateOne<User>("DiscordId", RespondBack.DiscordId, new Dictionary<string, object>()
+                                            if(Days != 0)
                                             {
-                                                { "temp_banned", true }
+                                                profileCacheEntry.UserData.temp_banned = true;
+ 
+                                                profileCacheEntry.AccountData.commoncore.ban_status = new BanStatus()
+                                                {
+                                                    bRequiresUserAck = true,
+                                                    banReasons = new List<string>() { "Exploiting" },
+                                                    bBanHasStarted = true,
+                                                    banStartTimeUtc = DateTime.UtcNow,
+                                                    banDurationDays = Days,
+                                                    exploitProgramName = "Exploiting",
+                                                    additionalInfo = "",
+                                                    competitiveBanReason = "Exploiting"
+                                                };
+                                            }
+                                            else
+                                            {
+                                                profileCacheEntry.UserData.temp_banned = false;
+
+                                                profileCacheEntry.AccountData.commoncore.ban_status = new BanStatus();
+                                            }
+
+
+
+                                                profileCacheEntry.AccountData.commoncore.BumpRevisions();
+
+                                            var RandomOfferId = Guid.NewGuid().ToString();
+                                            profileCacheEntry.AccountData.commoncore.Gifts.Add(RandomOfferId, new GiftCommonCoreItem
+                                            {
+                                                templateId = "GiftBox:gb_tournamentaction",
+                                                attributes = new GiftCommonCoreItemAttributes { },
+                                                quantity = 1
                                             });
 
+                                            await XmppGift.NotifyUser(profileCacheEntry.AccountId);
 
-                                            profileCacheEntry.AccountData.commoncore.ban_status = new BanStatus()
-                                            {
-                                                bRequiresUserAck = true,
-                                                banReasons = new List<string>() { "Exploiting" },
-                                                bBanHasStarted = true,
-                                                banStartTimeUtc = DateTime.UtcNow,
-                                                banDurationDays = Days,
-                                                exploitProgramName = "Exploiting",
-                                                additionalInfo = "",
-                                                competitiveBanReason = "Exploiting"
-                                            };
+                                        //    Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == profileCacheEntry.AccountId)!;
 
+                                        //    if (Client != null)
+                                        //    {
+                                        //        string xmlMessage;
+                                        //        byte[] buffer;
+                                        //        WebSocket webSocket = Client.Game_Client;
+                                        //        //GB_TournamentAction
 
-                                            profileCacheEntry.AccountData.commoncore.RVN += 1;
-                                            profileCacheEntry.AccountData.commoncore.CommandRevision += 1;
+                                        //        if (webSocket != null && webSocket.State == WebSocketState.Open)
+                                        //        {
+                                        //            XNamespace clientNs = "jabber:client";
 
-                                            Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == profileCacheEntry.AccountId)!;
+                                        //            var message = new XElement(clientNs + "message",
+                                        //                new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
+                                        //                new XAttribute("to", profileCacheEntry.AccountId),
+                                        //                new XElement(clientNs + "body", JsonConvert.SerializeObject(new
+                                        //                {
+                                        //                    payload = new {
+                                        //                        bRequiresUserAck = true,
+                                        //                        banReasons = new List<string>() { "Exploiting" },
+                                        //                        bBanHasStarted = true,
+                                        //                        banStartTimeUtc = DateTime.UtcNow,
+                                        //                        banDurationDays = Days,
+                                        //                        exploitProgramName = "Exploiting",
+                                        //                        additionalInfo = "",
+                                        //                        competitiveBanReason = "Exploiting"
+                                        //                    },
+                                        //                    type = "com.epicgames.ban_status.received",
+                                        //                    timestamp = DateTime.UtcNow.ToString("o")
+                                        //                }))
+                                        //            );
 
-                                            if (Client != null)
-                                            {
-                                                string xmlMessage;
-                                                byte[] buffer;
-                                                WebSocket webSocket = Client.Game_Client;
+                                        //            xmlMessage = message.ToString();
+                                        //            buffer = Encoding.UTF8.GetBytes(xmlMessage);
 
-                                                if (webSocket != null && webSocket.State == WebSocketState.Open)
-                                                {
-                                                    XNamespace clientNs = "jabber:client";
+                                        //            //  Console.WriteLine(xmlMessage);
 
-                                                    var message = new XElement(clientNs + "message",
-                                                        new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
-                                                        new XAttribute("to", profileCacheEntry.AccountId),
-                                                        new XElement(clientNs + "body", JsonConvert.SerializeObject(new
-                                                        {
-                                                            payload = new { },
-                                                            type = "com.epicgames.ban_status.received",
-                                                            timestamp = DateTime.UtcNow.ToString("o")
-                                                        }))
-                                                    );
+                                        //            await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
+                                        //        }
 
-                                                    xmlMessage = message.ToString();
-                                                    buffer = Encoding.UTF8.GetBytes(xmlMessage);
-
-                                                    //  Console.WriteLine(xmlMessage);
-
-                                                    await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
-                                                }
-
-                                            }
+                                        //    }
                                         }
 
                                         //// do this last

--- a/FortBackend/src/App/Utilities/Discord/Helpers/command/who.cs
+++ b/FortBackend/src/App/Utilities/Discord/Helpers/command/who.cs
@@ -65,7 +65,7 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                         Logger.Error("Failed To Find User!", "DiscordBot");
                         return;
                     }
-                    Console.WriteLine(UserId);
+                    Logger.PlainLog(UserId);
                     FindDiscordID = await Handlers.FindOne<User>("DiscordId", UserId, true);
                     if(FindDiscordID != null && FindDiscordID != "Error")
                     {
@@ -150,7 +150,7 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                             {
                                 ulong messageId = MessageComp.Message.Id;
                                 InProgess = true;
-                                Console.WriteLine(SelectedAction);
+                                Logger.PlainLog(SelectedAction);
                                 if (SelectedAction == "ban")
                                 {
                                     var modalBuilder = new ModalBuilder()
@@ -310,7 +310,7 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                     if (components.First(e => e.CustomId == "banAssist").Value != null)
                                     {
                                         BanAssistUser = components.First(e => e.CustomId == "banAssist").Value;
-                                        Console.WriteLine(BanAssistUser);
+                                        Logger.PlainLog(BanAssistUser);
 
                                         ProfileCacheEntry profileCacheEntry = await GrabData.ProfileDiscord(BanAssistUser);
 
@@ -353,7 +353,7 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                                     xmlMessage = message.ToString();
                                                     buffer = Encoding.UTF8.GetBytes(xmlMessage);
 
-                                                    Console.WriteLine(xmlMessage);
+                                                    Logger.PlainLog(xmlMessage);
 
                                                     await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
                                                 }
@@ -535,7 +535,7 @@ namespace FortBackend.src.App.Utilities.Discord.Helpers.command
                                         IMongoCollection<StoreInfo> StoreInfocollection = MongoDBStart.Database?.GetCollection<StoreInfo>("StoreInfo")!;
                                         var filter = Builders<StoreInfo>.Filter.AnyEq(b => b.UserIds, RespondBack.AccountId);
                                         var count = await StoreInfocollection.CountDocumentsAsync(filter);
-                                        Console.WriteLine(count.ToString());
+                                        Logger.PlainLog(count.ToString());
                                         if (count > 0)
                                         {
                                             await StoreInfocollection.DeleteOneAsync(filter);

--- a/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlePassRewards.cs
+++ b/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlePassRewards.cs
@@ -10,6 +10,7 @@ using FortLibrary.MongoDB.Module;
 using FortLibrary.Shop;
 using Microsoft.IdentityModel.Tokens;
 using System.Linq;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
 {
@@ -67,6 +68,23 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                                     quantity = 1
                                 }
                             });
+                        }
+                        // this is only used for paid tiers where "FREE TIERS" just doenst work
+                        // xp as well ig
+                        else if (iteminfo.TemplateId.Contains("AccountResource:"))
+                        {
+
+                            var testfr = iteminfo.TemplateId.Split(':')[1];
+                            if (testfr == "AthenaBattleStar")
+                            {
+                                FoundSeason.battlestars_currency += iteminfo.Quantity;
+                            }
+                            else
+                            {
+                                FoundSeason.SeasonXP += iteminfo.Quantity;
+                                (FoundSeason, NeedItems) = await LevelUpdater.Init(FoundSeason.SeasonNumber, FoundSeason, NeedItems);
+                                NeedItems = true; // force it as we don't want this to become false here
+                            }
                         }
                         else if (iteminfo.TemplateId.Contains("Athena"))
                         {
@@ -221,13 +239,6 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                         else if (iteminfo.TemplateId.Contains("Currency:"))
                         {
                             currencyItem.quantity += iteminfo.Quantity;
-                        }
-                        else if (iteminfo.TemplateId.Contains("AccountResource:"))
-                        {
-                            FoundSeason.SeasonXP += iteminfo.Quantity;
-
-                            (FoundSeason, NeedItems) = await LevelUpdater.Init(FoundSeason.SeasonNumber, FoundSeason, NeedItems);
-                            NeedItems = true; // force it as we don't want this to become false here
                         }
                         else
                         {

--- a/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlePassRewards.cs
+++ b/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlePassRewards.cs
@@ -128,7 +128,7 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                         }
                         else if (iteminfo.TemplateId.Contains("CosmeticVariantToken:"))
                         {
-                            Console.WriteLine(iteminfo.connectedTemplate);
+                            Logger.PlainLog(iteminfo.connectedTemplate);
                             if (!string.IsNullOrEmpty(iteminfo.connectedTemplate))
                             {
                                 AthenaItem athenaItem = profileCacheEntry.AccountData.athena.Items.FirstOrDefault(e => e.Key == iteminfo.connectedTemplate).Value;

--- a/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlePassRewardsV2.cs
+++ b/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlePassRewardsV2.cs
@@ -1,0 +1,166 @@
+﻿using Discord;
+using FortBackend.src.App.Utilities.Discord.Helpers.command;
+using FortBackend.src.App.Utilities.Quests;
+using FortLibrary;
+using FortLibrary.Dynamics;
+using FortLibrary.EpicResponses.Profile.Purchases;
+using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortLibrary.EpicResponses.Profile.Quests;
+using FortLibrary.MongoDB.Module;
+using FortLibrary.Shop;
+using Microsoft.IdentityModel.Tokens;
+using System.Linq;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
+{
+    // this is for season 17 and above due to claiming worked differently
+    public class BattlePassRewardsV2
+    {
+        public static async Task<(ProfileCacheEntry profileCacheEntry, SeasonClass FoundSeason, List<object> MultiUpdates, 
+            int currency, List<NotificationsItemsClassOG> applyProfileChanges)> Init(SeasonBPPurchase ItemToClaim, ProfileCacheEntry profileCacheEntry, SeasonClass FoundSeason, List<object> MultiUpdates, int currency, List<NotificationsItemsClassOG> applyProfileChanges = null)
+        {
+          
+            if (!profileCacheEntry.AccountData.athena.Items.ContainsKey(ItemToClaim.templateId))
+            {
+                if (!profileCacheEntry.AccountData.commoncore.Items.ContainsKey(ItemToClaim.templateId))
+                {
+                    if (ItemToClaim.templateId.Contains("HomebaseBannerIcon"))
+                    {
+                        profileCacheEntry.AccountData.commoncore.Items.Add(ItemToClaim.templateId, new CommonCoreItem
+                        {
+                            templateId = ItemToClaim.templateId,
+                            attributes = new CommonCoreItemAttributes
+                            {
+                                item_seen = false
+                            },
+                            quantity = ItemToClaim.Quantity,
+                        });
+
+                        MultiUpdates.Add(new MultiUpdateClass
+                        {
+                            changeType = "itemAdded",
+                            itemId = ItemToClaim.templateId,
+                            item = new AthenaItem
+                            {
+                                templateId = ItemToClaim.templateId,
+                                attributes = new AthenaItemAttributes
+                                {
+                                    item_seen = false,
+                                },
+                                quantity = 1
+                            }
+                        });
+                    }
+
+                    else if (ItemToClaim.templateId.Contains("Athena"))
+                    {
+
+                        MultiUpdates.Add(new MultiUpdateClass
+                        {
+                            changeType = "itemAdded",
+                            itemId = ItemToClaim.templateId,
+                            item = new AthenaItem
+                            {
+                                templateId = ItemToClaim.templateId,
+                                attributes = new AthenaItemAttributes
+                                {
+                                    item_seen = false,
+                                },
+                                quantity = 1
+                            }
+                        });
+
+                        profileCacheEntry.AccountData.athena.Items.Add(ItemToClaim.templateId, new AthenaItem
+                        {
+                            templateId = ItemToClaim.templateId,
+                            attributes = new AthenaItemAttributes
+                            {
+                                favorite = false,
+                                item_seen = false,
+                                level = 1,
+                                max_level_bonus = 0,
+                                rnd_sel_cnt = 0,
+                                variants = ItemToClaim.variants,
+                                xp = 0
+                            },
+                            quantity = ItemToClaim.Quantity,
+                        });
+                    }
+                    else if (ItemToClaim.templateId.Contains("CosmeticVariantToken:"))
+                    {
+                        // not the best way
+                        var variantsByItem = ItemToClaim.new_variants
+                          .Where(v => !string.IsNullOrEmpty(v.connectedItem))
+                          .GroupBy(v => v.connectedItem);
+
+                        foreach (var group in variantsByItem)
+                        {
+                            var itemId = group.Key;
+
+                            if (!profileCacheEntry.AccountData.athena.Items.TryGetValue(itemId, out var athenaItem))
+                            {
+                                Logger.Error(itemId, "You don't own the connected template?");
+                                continue;
+                            }
+
+                            var itemVariants = athenaItem.attributes.variants;
+
+                            foreach (var variant in group)
+                            {
+                                var existingT = itemVariants
+                                    .FirstOrDefault(v => v.channel == variant.channel);
+
+                                if (existingT != null)
+                                {
+                                    existingT.owned.AddRange(variant.added);
+                                }
+                                else
+                                {
+                                    itemVariants.Add(new AthenaItemVariants
+                                    {
+                                        channel = variant.channel,
+                                        active = variant.added.First(),
+                                        owned = variant.added
+                                    });
+                                }
+                            }
+
+                            profileCacheEntry.AccountData.athena.Items[itemId].attributes.variants = itemVariants;
+
+                            MultiUpdates.Add(new
+                            {
+                                changeType = "itemAttrChanged",
+                                itemId = itemId,
+                                attributeName = "variants",
+                                attributeValue = itemVariants
+                            });
+
+                        }
+                    }
+                    else if (ItemToClaim.templateId.Contains("Currency:"))
+                    {
+                        currency += ItemToClaim.Quantity;
+                    }
+
+
+                    var existing = applyProfileChanges.FirstOrDefault(e => e.itemType == ItemToClaim.templateId);
+                    if (existing != null)
+                        existing.quantity += ItemToClaim.Quantity;
+                    else
+                    {
+                        applyProfileChanges.Add(new NotificationsItemsClassOG
+                        {
+                            itemType = ItemToClaim.templateId,
+                            itemGuid = ItemToClaim.templateId,
+                            quantity = ItemToClaim.Quantity
+                        });
+                    }
+                }
+            }
+            
+
+            return (profileCacheEntry, FoundSeason, MultiUpdates, currency, applyProfileChanges);
+        }
+    }
+}

--- a/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlepassManager.cs
+++ b/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlepassManager.cs
@@ -15,6 +15,7 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
         public static Dictionary<int, List<SeasonXP>> SeasonBattlePassXPItems = new Dictionary<int, List<SeasonXP>>();
 
         public static Dictionary<int, List<SeasonBP>> SeasonBattleStarsItems = new Dictionary<int, List<SeasonBP>>();
+        public static Dictionary<int, List<string>> SeasonSpecialItems = new Dictionary<int, List<string>>();
 
         public static void Init()
         {
@@ -26,6 +27,21 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                 //Console.WriteLine(seasonFolder);
                 int season = int.Parse(seasonFolder.Split("\\Season")[1]);
 
+                var SeasonSpecialFolder = Path.Combine(seasonFolder, "SeasonSpecial.json");
+
+                if (File.Exists(SeasonSpecialFolder))
+                {
+                    string seasonSpecialD = File.ReadAllText(SeasonSpecialFolder);
+
+                    if (!string.IsNullOrEmpty(seasonSpecialD))
+                    {
+                        List<string> seasonSpecial = JsonConvert.DeserializeObject<List<string>>(seasonSpecialD)!;
+                    
+                        if(seasonSpecial.Count > 0)
+                            SeasonSpecialItems.Add(season, seasonSpecial);
+                        
+                    }
+                }
 
                 var SeasonXPFolder = Path.Combine(seasonFolder, "SeasonXP.json");
 

--- a/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlepassManager.cs
+++ b/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/BattlepassManager.cs
@@ -16,6 +16,8 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
 
         public static Dictionary<int, List<SeasonBP>> SeasonBattleStarsItems = new Dictionary<int, List<SeasonBP>>();
         public static Dictionary<int, List<string>> SeasonSpecialItems = new Dictionary<int, List<string>>();
+        public static Dictionary<int, List<SeasonBPPurchase>> BattlePassPItems = new Dictionary<int, List<SeasonBPPurchase>>();
+
 
         public static void Init()
         {
@@ -26,6 +28,9 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                 if (!seasonFolder.Contains("Season")) continue;
                 //Console.WriteLine(seasonFolder);
                 int season = int.Parse(seasonFolder.Split("\\Season")[1]);
+
+                if (Saved.Saved.DeserializeGameConfig.ForceSeason)
+                    if ((int)Saved.Saved.DeserializeGameConfig.Season != season) continue;
 
                 var SeasonSpecialFolder = Path.Combine(seasonFolder, "SeasonSpecial.json");
 
@@ -60,10 +65,8 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                         {
                             Logger.Error($"Failed To Load Season {season} ({Path.GetFileName(SeasonXPFolder)})", "BattlepassManager");
                         }
-                        //JsonConvert.DeserializeObject<List<SeasonXP>>(SeasonData)
                     }
                 }
-                // string battlepassFilePath = Path.Combine(seasonFolder, "BattlePass.json");
 
                 var SeasonBattleStarsFolder = Path.Combine(seasonFolder, "SeasonBP.json");
 
@@ -83,7 +86,6 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                             if(season > 1)
                                 Logger.Error($"Failed To Load Season {season} ({Path.GetFileName(SeasonBattleStarsFolder)})", "BattlepassManager");
                         }
-                        //JsonConvert.DeserializeObject<List<SeasonXP>>(SeasonData)
                     }
                 }
 
@@ -116,6 +118,30 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                     else
                     {
                         Logger.Error($"The season {season} doesn't contain a battlepass!", "BattlepassManager");
+                    }
+                }
+
+
+                if(season >= 17)
+                {
+                    string BpItemsFilePath = Path.Combine(seasonFolder, "BP_Items.json");
+
+                    if (File.Exists(BpItemsFilePath))
+                    {
+                        string seasonData = File.ReadAllText(BpItemsFilePath);
+
+                        if (!string.IsNullOrEmpty(seasonData))
+                        {
+                            List<SeasonBPPurchase> battleP = JsonConvert.DeserializeObject<List<SeasonBPPurchase>>(seasonData)!;
+                            if (battleP != null && battleP.Count > 0)
+                            {
+                                BattlePassPItems.Add(season, battleP);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Logger.Error($"The season {season} doesn't contain a *BP_Items*!", "BattlepassManager");
                     }
                 }
 
@@ -174,8 +200,6 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                     Logger.Error($"The season {season} doesn't contain a SeasonFreeBattlePass!", "BattlepassManager");
                 }
             }
-
-            ///JsonConvert.DeserializeObject<List<SeasonXP>>(SeasonData)
 
             Logger.Log($"Loaded BattlePasses [{BattlePasses.Count}/{seasonFolders.Count()}]", "BattlpassManager");
             Logger.Log($"Loaded FreeBattlePasses [{FreeBattlePassItems.Count}/{seasonFolders.Count()}]", "BattlpassManager");

--- a/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/LevelUpdater.cs
+++ b/FortBackend/src/App/Utilities/Helpers/BattlepassManagement/LevelUpdater.cs
@@ -9,16 +9,13 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
     public class LevelUpdater
     {
         public static async Task<(SeasonClass FoundSeason, bool NeedItems)> Init(int Season, SeasonClass FoundSeason, bool NeedItems)
-        {//
-         // var SeasonXPFolder = Path.Combine(PathConstants.BaseDir, $"Json\\Season\\Season{Season}\\SeasonXP.json");
-         ////  var SeasonBattleStarsFolder = Path.Combine(PathConstants.BaseDir, $"Json\\Season\\Season{Season}\\SeasonBP.json");
-
+        {
             List<SeasonBP> seasonBPStars = BattlepassManager.SeasonBattleStarsItems.FirstOrDefault(e => e.Key == (FoundSeason.SeasonNumber)).Value;
             List<SeasonXP> seasonXp = BattlepassManager.SeasonBattlePassXPItems.FirstOrDefault(e => e.Key == FoundSeason.SeasonNumber).Value;
 
             if(seasonBPStars == null || seasonBPStars.Count <= 0)
             {
-                if (Season > 1 && Season <= 10)
+                if (Season > 1 && Season < 11)
                 {
                     Logger.Error("Missing Season Battlestars data on " + Season); // shouldn't happen?
                 }
@@ -72,16 +69,19 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                             }
 
                             // Battle stars are implemented again in chapter 2 season 7
-                            if (Season > 10 && Season < 17)
+                            if (Season >= 11)
                             {
-                                NeedItems = true;
-                                FoundSeason.BookLevel = FoundSeason.Level;
-                            }
-
-                            if (Season >= 17)
-                            {
-                                // Implement newer battlestar system...
-                                Logger.Error("LEVEL UP, STARS ARE NOT SUPPORTED ON SEASON 17 AND ABOVE", "ClientQuestLogiN");
+                                if (FoundSeason.BookLevel != FoundSeason.Level)
+                                {
+                                    var StarsToGive = FoundSeason.Level - FoundSeason.BookLevel;
+                                    if (FoundSeason.Level <= 200)
+                                    {
+                                        FoundSeason.BookLevel = FoundSeason.Level;
+                                        if (StarsToGive > 0)
+                                            FoundSeason.battlestars_currency += StarsToGive * 5;
+                                        NeedItems = true;
+                                    }
+                                }
                             }
                         }
 
@@ -93,7 +93,7 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
 
 
                 // They are added back during chapter 2 season 7 but they don't auto claim
-                if (Season > 1 && Season <= 10)
+                if (Season > 1 && Season < 11)
                 {
                     //Logger.Error("s");
                     while (FoundSeason.BookXP >= 10)
@@ -110,6 +110,22 @@ namespace FortBackend.src.App.Utilities.Helpers.BattlepassManagement
                     {
                         FoundSeason.BookLevel = 100;
                         //NeedItems = true;
+                    }
+                }
+                else
+                {
+                    if(Season >= 11)
+                    {
+                        if(FoundSeason.BookLevel != FoundSeason.Level)
+                        {
+                            var StarsToGive = FoundSeason.Level - FoundSeason.BookLevel;
+                            if (FoundSeason.Level <= 200)
+                            {
+                                FoundSeason.BookLevel = FoundSeason.Level;
+                                if (StarsToGive > 0)
+                                    FoundSeason.battlestars_currency += StarsToGive * 5;
+                            }
+                        }
                     }
                 }
             }

--- a/FortBackend/src/App/Utilities/Helpers/Cached/CachedData.cs
+++ b/FortBackend/src/App/Utilities/Helpers/Cached/CachedData.cs
@@ -150,6 +150,8 @@ namespace FortBackend.src.App.Utilities.Helpers.Cached
                 {
                     Logger.Log($"Force Season Is On [{DeserializeGameConfig.Season}]", "FortConfig");
                 }
+                else
+                    Logger.Warn($"Force Season is recommended!!", "FortConfig");
 
                 Logger.Log("Loaded Config", "FortGameConfig");
             }
@@ -295,9 +297,11 @@ namespace FortBackend.src.App.Utilities.Helpers.Cached
             try
             {
                 string filePath = await File.ReadAllTextAsync(ShopBundlesPath);
+                string filePath2 = await File.ReadAllTextAsync(PathConstants.ShopJson.ChristmasItems);
 
                 BackendCachedData.ShopBundles = JsonConvert.DeserializeObject<List<ShopBundles>>(filePath)!; ;
                 BackendCachedData.ShopBundlesFiltered = JsonConvert.DeserializeObject<List<ShopBundles>>(filePath)!; ;
+                BackendCachedData.ShopFestiveItems.Add("christmas", JsonConvert.DeserializeObject<FestiveShopItems>(filePath2)!);
 
                 LoadShopCache.LoadAndFilterShopBundles(DeserializeGameConfig.Season);
                 LoadShopCache.LoadItems(DeserializeGameConfig.Season);

--- a/FortBackend/src/App/Utilities/Helpers/Grabber.cs
+++ b/FortBackend/src/App/Utilities/Helpers/Grabber.cs
@@ -94,7 +94,7 @@ namespace FortBackend.src.App.Utilities.Helpers
                                     }
                                     else
                                     {
-                                        VersionIG.Season = saved.Season;
+                                        VersionIG.Season = (int)saved.Season;
                                     }
                                 }
                                 else
@@ -138,7 +138,7 @@ namespace FortBackend.src.App.Utilities.Helpers
 
                     if (saved.ForceSeason)
                     {
-                        VersionIG.Season = saved.Season;
+                        VersionIG.Season = (int)saved.Season;
                     }
                 }
                 catch (Exception ex)

--- a/FortBackend/src/App/Utilities/Helpers/QuestsManagement/BattlePassLevelUp.cs
+++ b/FortBackend/src/App/Utilities/Helpers/QuestsManagement/BattlePassLevelUp.cs
@@ -107,7 +107,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                                 string xmlMessage;
                                                 byte[] buffer;
                                                 WebSocket webSocket = Client.Game_Client;
-                                                Console.WriteLine(webSocket.State);
+                                                Logger.PlainLog(webSocket.State);
                                                 if (webSocket != null && webSocket.State == WebSocketState.Open)
                                                 {
                                                     XNamespace clientNs = "jabber:client";
@@ -126,7 +126,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                                     xmlMessage = message.ToString();
                                                     buffer = Encoding.UTF8.GetBytes(xmlMessage);
 
-                                                    Console.WriteLine(xmlMessage);
+                                                    Logger.PlainLog(xmlMessage);
 
                                                     await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
                                                 }

--- a/FortBackend/src/App/Utilities/Helpers/QuestsManagement/BattlePassLevelUp.cs
+++ b/FortBackend/src/App/Utilities/Helpers/QuestsManagement/BattlePassLevelUp.cs
@@ -1,15 +1,16 @@
 ﻿using FortBackend.src.App.Utilities.Helpers.BattlepassManagement;
 using FortBackend.src.XMPP.Data;
+using FortBackend.src.XMPP.SERVER.Send;
+using FortLibrary;
 using FortLibrary.Dynamics;
 using FortLibrary.EpicResponses.Profile.Purchases;
 using FortLibrary.EpicResponses.Profile.Query.Items;
+using FortLibrary.MongoDB.Module;
 using FortLibrary.XMPP;
-using FortLibrary;
 using System.ComponentModel;
 using System.Net.WebSockets;
 using System.Text;
 using System.Xml.Linq;
-using FortLibrary.MongoDB.Module;
 using static FortBackend.src.App.Utilities.Helpers.Grabber;
 
 namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
@@ -80,7 +81,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                             quantity = 1
                                         });
 
-                                        MultiUpdatesForCommonCore.Add( new ApplyProfileChangesClassV2
+                                        MultiUpdatesForCommonCore.Add(new ApplyProfileChangesClassV2
                                         {
                                             changeType = "itemAdded",
                                             itemId = RandomOfferId,
@@ -98,41 +99,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                         });
 
 
-                                        if (!string.IsNullOrEmpty(profileCacheEntry.AccountId))
-                                        {
-                                            Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == profileCacheEntry.AccountId)!;
-
-                                            if (Client != null)
-                                            {
-                                                string xmlMessage;
-                                                byte[] buffer;
-                                                WebSocket webSocket = Client.Game_Client;
-                                                Logger.PlainLog(webSocket.State);
-                                                if (webSocket != null && webSocket.State == WebSocketState.Open)
-                                                {
-                                                    XNamespace clientNs = "jabber:client";
-
-                                                    var message = new XElement(clientNs + "message",
-                                                      new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
-                                                      new XAttribute("to", profileCacheEntry.AccountId),
-                                                      new XElement(clientNs + "body", Newtonsoft.Json.JsonConvert.SerializeObject(new
-                                                      {
-                                                          payload = new { },
-                                                          type = "com.epicgames.gift.received",
-                                                          timestamp = DateTime.UtcNow.ToString("o")
-                                                      }))
-                                                    );
-
-                                                    xmlMessage = message.ToString();
-                                                    buffer = Encoding.UTF8.GetBytes(xmlMessage);
-
-                                                    Logger.PlainLog(xmlMessage);
-
-                                                    await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
-                                                }
-
-                                            }
-                                        }
+                                        await XmppGift.NotifyUser(profileCacheEntry.AccountId);
                                     }
                                 }
                                 else

--- a/FortBackend/src/App/Utilities/Helpers/QuestsManagement/QuestsDealer.cs
+++ b/FortBackend/src/App/Utilities/Helpers/QuestsManagement/QuestsDealer.cs
@@ -141,7 +141,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                     attributeValue = FoundSeason.Quests[AllBundles.templateId].attributes.quest_state
                                 });
 
-                                Console.WriteLine(!AllBundles.quest_data.ExtraQuests && !AllBundles.quest_data.Steps);
+                                Logger.PlainLog(!AllBundles.quest_data.ExtraQuests && !AllBundles.quest_data.Steps);
 
                                 if (!AllBundles.quest_data.ExtraQuests && !AllBundles.quest_data.Steps)
                                 {
@@ -425,7 +425,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                         }
                                         else if (GrantedItems.TemplateId.Contains("CosmeticVariantToken:"))
                                         {
-                                            Console.WriteLine(GrantedItems.connectedTemplate);
+                                            Logger.PlainLog(GrantedItems.connectedTemplate);
                                             if (!string.IsNullOrEmpty(GrantedItems.connectedTemplate))
                                             {
                                                 AthenaItem athenaItem = profileCacheEntry.AccountData.athena.Items.FirstOrDefault(e => e.Key == GrantedItems.connectedTemplate).Value;
@@ -550,7 +550,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                 if (FoundNewQuest != null)
                                 {
                                     // ADD NEW QUESTS
-                                    Console.WriteLine($"I WANT TO ADD {FoundNewQuest.templateId}");
+                                    Logger.PlainLog($"I WANT TO ADD {FoundNewQuest.templateId}");
 
                                     List<DailyQuestsObjectiveStates> QuestObjectStats = new List<DailyQuestsObjectiveStates>();
 
@@ -620,7 +620,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                                 }
                                 else
                                 {
-                                    Console.WriteLine("I DONT SUPPORT " + Quests.TemplateId);
+                                    Logger.PlainLog("I DONT SUPPORT " + Quests.TemplateId);
                                 }
                             }
 
@@ -896,7 +896,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                         string xmlMessage;
                         byte[] buffer;
                         WebSocket webSocket = Client.Game_Client;
-                        Console.WriteLine(webSocket.State);
+                        Logger.PlainLog(webSocket.State);
                         if (webSocket != null && webSocket.State == WebSocketState.Open)
                         {
                             XNamespace clientNs = "jabber:client";

--- a/FortBackend/src/App/Utilities/Helpers/QuestsManagement/QuestsDealer.cs
+++ b/FortBackend/src/App/Utilities/Helpers/QuestsManagement/QuestsDealer.cs
@@ -2,6 +2,7 @@
 using FortBackend.src.App.Utilities.Helpers.BattlepassManagement;
 using FortBackend.src.App.Utilities.Quests;
 using FortBackend.src.XMPP.Data;
+using FortBackend.src.XMPP.SERVER.Send;
 using FortLibrary;
 using FortLibrary.Dynamics;
 using FortLibrary.EpicResponses.Profile.Purchases;
@@ -886,41 +887,7 @@ namespace FortBackend.src.App.Utilities.Helpers.QuestsManagement
                     });
                 }
 
-
-                if (!string.IsNullOrEmpty(profileCacheEntry.AccountId))
-                {
-                    Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == profileCacheEntry.AccountId)!;
-
-                    if (Client != null)
-                    {
-                        string xmlMessage;
-                        byte[] buffer;
-                        WebSocket webSocket = Client.Game_Client;
-                        Logger.PlainLog(webSocket.State);
-                        if (webSocket != null && webSocket.State == WebSocketState.Open)
-                        {
-                            XNamespace clientNs = "jabber:client";
-
-                            var message = new XElement(clientNs + "message",
-                              new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
-                              new XAttribute("to", profileCacheEntry.AccountId),
-                              new XElement(clientNs + "body", Newtonsoft.Json.JsonConvert.SerializeObject(new
-                              {
-                                  payload = new { },
-                                  type = "com.epicgames.gift.received",
-                                  timestamp = DateTime.UtcNow.ToString("o")
-                              }))
-                            );
-
-                            xmlMessage = message.ToString();
-                            buffer = Encoding.UTF8.GetBytes(xmlMessage);
-
-                            await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
-                        }
-
-                    }
-                }
-
+                await XmppGift.NotifyUser(profileCacheEntry.AccountId);
             }
 
 

--- a/FortBackend/src/App/Utilities/Helpers/UserManagement/BanAndWebHooks.cs
+++ b/FortBackend/src/App/Utilities/Helpers/UserManagement/BanAndWebHooks.cs
@@ -109,7 +109,7 @@ namespace FortBackend.src.App.Utilities.Helpers.UserManagement
                 }
                 else
                 {
-                    Console.WriteLine("Why is this null");
+                    Logger.Error("Why is this null");
                 }
 
                 var embed2 = new

--- a/FortBackend/src/App/Utilities/Helpers/UserManagement/UnbanAndWebhooks.cs
+++ b/FortBackend/src/App/Utilities/Helpers/UserManagement/UnbanAndWebhooks.cs
@@ -46,7 +46,7 @@ namespace FortBackend.src.App.Utilities.Helpers.UserManagement
                 }
                 else
                 {
-                    Console.WriteLine("Why is this null");
+                    Logger.Error("Why is this null");
                 }
 
                 var embed2 = new

--- a/FortBackend/src/App/Utilities/MongoDB/Helpers/CreateBlank.cs
+++ b/FortBackend/src/App/Utilities/MongoDB/Helpers/CreateBlank.cs
@@ -19,7 +19,7 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
             }
             catch
             {
-                Console.WriteLine($"Failed to create blank collection -> {collectionName}");
+                Logger.Error($"Failed to create blank collection -> {collectionName}", "MongoDB");
             }
         }
 

--- a/FortBackend/src/App/Utilities/MongoDB/Helpers/GrabAdminData.cs
+++ b/FortBackend/src/App/Utilities/MongoDB/Helpers/GrabAdminData.cs
@@ -37,7 +37,7 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
                         AdminData? cachedAdminData = Saved.Saved.CachedAdminData.Data?.FirstOrDefault(e => e.AdminUserEmail == CheckAdminUser.profileCacheEntry.UserData.Email);
                         if(cachedAdminData != null)
                         {
-                            Console.WriteLine("CHANGING ROLES");
+                            Logger.Log("CHANGING ROLES");
                             cachedAdminData.RoleId = adminInfo.Role;
                         }
 

--- a/FortBackend/src/App/Utilities/MongoDB/Helpers/GrabData.cs
+++ b/FortBackend/src/App/Utilities/MongoDB/Helpers/GrabData.cs
@@ -38,7 +38,7 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
                     }
                     else
                     {
-                        Console.WriteLine("Bypass? Invaild Account");
+                        Logger.PlainLog("Bypass? Invaild Account"); // can just be someone trying to call endpoints without auth
                     }
                 }
                 else
@@ -48,7 +48,7 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
                         //Console.WriteLine("RETURNING CORRET DATA <3");
                         return GrabData.Value;
                     }
-                    Console.WriteLine("what? how");
+                    Logger.Error("what? how");
                 }
             }
             catch (Exception ex)
@@ -81,7 +81,7 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
                     }
                     else
                     {
-                        Console.WriteLine("Bypass? Invaild Account");
+                        Logger.PlainLog("Bypass? Invaild Account"); // can just be someone trying to call endpoints without auth
                     }
                 }
                 else
@@ -91,7 +91,7 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
                         //Console.WriteLine("RETURNING CORRET DATA <3");
                         return GrabData.Value;
                     }
-                    Console.WriteLine("what? how");
+                    Logger.PlainLog("what? how");
                 }
             }
             catch (Exception ex)
@@ -152,7 +152,7 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
                         //Console.WriteLine("RETURNING CORRET DATA <3");
                         return GrabData.Value;
                     }
-                    Console.WriteLine("what? how");
+                    Logger.PlainLog("what? how");
                 }
             }
             catch (Exception ex)

--- a/FortBackend/src/App/Utilities/MongoDB/Helpers/Handlers.cs
+++ b/FortBackend/src/App/Utilities/MongoDB/Helpers/Handlers.cs
@@ -64,7 +64,6 @@ namespace FortBackend.src.App.Utilities.MongoDB.Helpers
                 var regexPattern = (BsonRegularExpression)null!;
                 if (!string.IsNullOrEmpty(CustomRegex))
                 {
-                    Console.WriteLine("T");
                     regexPattern = new BsonRegularExpression(CustomRegex, "i");
                 }
                 else

--- a/FortBackend/src/App/Utilities/Quests/WeeklyQuestManager.cs
+++ b/FortBackend/src/App/Utilities/Quests/WeeklyQuestManager.cs
@@ -25,7 +25,7 @@ namespace FortBackend.src.App.Utilities.Quests
                         // TO FORCE SEASON!!!
                         if (Saved.Saved.DeserializeGameConfig.ForceSeason)
                         {
-                            if (!(Path.GetFileName(folder) == $"Season{Saved.Saved.DeserializeGameConfig.Season}")) continue;
+                            if (!(Path.GetFileName(folder) == $"Season{(int)Saved.Saved.DeserializeGameConfig.Season}")) continue;
                         }
                             //Path.GetFileName(folder)
                               

--- a/FortBackend/src/App/Utilities/Saved/Config.cs
+++ b/FortBackend/src/App/Utilities/Saved/Config.cs
@@ -34,6 +34,7 @@ namespace FortBackend.src.App.Utilities.Saved
         public List<ShopItems> ShopEmotesItems { get; set; } = new List<ShopItems>();
         public List<ShopItems> ShopGlidersItems { get; set; } = new List<ShopItems>();
         public List<ShopItems> ShopWrapItems { get; set; } = new List<ShopItems>();
+        public Dictionary<string, FestiveShopItems> ShopFestiveItems { get; set; } = new();
 
         public ShopJson CurrentShop { get; set; } = new ShopJson();
         public List<ItemsSaved> OGShop { get; set; } = new List<ItemsSaved>();

--- a/FortBackend/src/App/Utilities/Shop/Helpers/DiscordWebsocket.cs
+++ b/FortBackend/src/App/Utilities/Shop/Helpers/DiscordWebsocket.cs
@@ -39,7 +39,6 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
             };
 
             string jsonEmbed = JsonConvert.SerializeObject(embed, Formatting.Indented);
-            Console.WriteLine(jsonEmbed);
 
             var embed2 = new
             {
@@ -50,8 +49,6 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
             };
 
             string jsonEmbed1 = JsonConvert.SerializeObject(embed2, Formatting.Indented);
-            Console.WriteLine(jsonEmbed1);
-
             string jsonPayload2 = JsonConvert.SerializeObject(new { embeds = new[] { embed2 } });
             string jsonPayload1 = JsonConvert.SerializeObject(new { embeds = new[] { embed } });
 
@@ -65,16 +62,16 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
                     HttpResponseMessage response2 = await httpClient.PostAsync(webhookUrl, httpContent2);
                     if (response2.IsSuccessStatusCode && response32.IsSuccessStatusCode)
                     {
-                        Console.WriteLine("Message sent successfully!");
+                        Logger.Log("Message sent successfully!", "DiscWebSocket");
                     }
                     else
                     {
-                        Console.WriteLine($"Failed to send message. Status code: {response2.StatusCode}");
+                        Logger.Error($"Failed to send message. Status code: {response2.StatusCode}", "DiscWebSocket");
                     }
                 }
                 catch (HttpRequestException ex)
                 {
-                    Console.WriteLine($"Error sending request: {ex.Message}");
+                    Logger.Error($"Error sending request: {ex.Message}", "DisWebSocket");
                 }
             }
 

--- a/FortBackend/src/App/Utilities/Shop/Helpers/Generate.cs
+++ b/FortBackend/src/App/Utilities/Shop/Helpers/Generate.cs
@@ -22,9 +22,9 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
             if (skinItems != null)
             {
                 int randomIndex = random.Next(skinItems.Count);
-                Console.WriteLine(randomIndex);
+                Logger.PlainLog(randomIndex);
                 ShopBundles RandomSkinItem = skinItems[randomIndex];
-                Console.WriteLine(RandomSkinItem);
+                Logger.PlainLog(RandomSkinItem);
                 if (RandomSkinItem == null)
                 {
                     Logger.Error($"Shop generation will be canceled -> RandomSkinItem is null", "ItemShop");
@@ -97,7 +97,7 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
                             int price = 0;
                             if (Generator.categoryMap.ContainsKey(ItemTemplateId))
                             {
-                                Console.WriteLine("TEST!!");
+                                Logger.Log("TEST!!");
                                 price = Generator.categoryMap[ItemTemplateId](Item.rarity);
 
                                 if (price != 0)
@@ -347,12 +347,12 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
                 //
 
                 int price = 0;
-                Console.WriteLine(ChosenItemString);
-                Console.WriteLine(Generator.categoryMap.ContainsKey(ChosenItemString));
+                Logger.PlainLog(ChosenItemString);
+                Logger.PlainLog(Generator.categoryMap.ContainsKey(ChosenItemString));
                 if (Generator.categoryMap.ContainsKey(ChosenItemString))
                 {
                     price = Generator.categoryMap[ChosenItemString](RandomSkinItem.rarity);
-                    Console.WriteLine(price);
+                    Logger.PlainLog(price);
                     if (price != 0)
                     {
                         Price = price;

--- a/FortBackend/src/App/Utilities/Shop/Helpers/Generate.cs
+++ b/FortBackend/src/App/Utilities/Shop/Helpers/Generate.cs
@@ -2,6 +2,7 @@
 using FortLibrary;
 using FortLibrary.Shop;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace FortBackend.src.App.Utilities.Shop.Helpers
 {
@@ -10,20 +11,33 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
         public static int HowManyTurns = 0;
         public static async Task<bool> Bundles()
         {
-
             if (Generator.Attempts == 4)
             {
                 Logger.Error("Went pass too many attempts", "ItemShop");
                 return false;
             }
-            Random random = new Random();
 
-            List<ShopBundles> skinItems = Saved.Saved.BackendCachedData.ShopBundlesFiltered;
-            if (skinItems != null)
+            Random random = new Random();
+            List<ShopBundles> bundleItems = new();
+            var currentEvent = Generator.GetActiveEvent();
+            if (!string.IsNullOrEmpty(currentEvent))
             {
-                int randomIndex = random.Next(skinItems.Count);
+                var FestiveShop = Saved.Saved.BackendCachedData.ShopFestiveItems
+                       .FirstOrDefault(e => e.Key == currentEvent);
+
+                if (FestiveShop.Key != null && FestiveShop.Value != null)
+                {
+                    bundleItems = FestiveShop.Value.Bundles;
+                }
+            }
+            else 
+                bundleItems = Saved.Saved.BackendCachedData.ShopBundlesFiltered; 
+
+            if (bundleItems != null)
+            {
+                int randomIndex = random.Next(bundleItems.Count);
                 Logger.PlainLog(randomIndex);
-                ShopBundles RandomSkinItem = skinItems[randomIndex];
+                ShopBundles RandomSkinItem = bundleItems[randomIndex];
                 Logger.PlainLog(RandomSkinItem);
                 if (RandomSkinItem == null)
                 {
@@ -34,7 +48,7 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
                 DateTime lastShownDate;
                 if (DateTime.TryParse(RandomSkinItem.LastShownDate, out lastShownDate))
                 {
-                    if (lastShownDate.Month == DateTime.Now.Month && lastShownDate.Year == DateTime.Now.Year)
+                    if ((lastShownDate.Month == DateTime.Now.Month && lastShownDate.Year == DateTime.Now.Year) && !RandomSkinItem.AllowAgain)
                     {
                         Logger.Log("Item Already been this month", "ItemShop");
                         Generator.Attempts += 1;
@@ -56,7 +70,7 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
 
                     foreach (var Item in DailyArray)
                     {
-                        
+
                         if (!Item.categories.Any())
                         {
                             HowManyTurns += 1;
@@ -66,27 +80,8 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
                             Price = Item.singleprice;
                         }
                         else
-                        { 
-                            switch (Item.item.Split(":")[0])
-                            {
-                                case "AthenaCharacter":
-                                    ItemTemplateId = "skins";
-                                    break;
-                                case "AthenaDance":
-                                    ItemTemplateId = "emotes";
-                                    break;
-                                case "AthenaPickaxe":
-                                    ItemTemplateId = "pickaxes";
-                                    break;
-                                case "AthenaGlider":
-                                    ItemTemplateId = "gliders";
-                                    break;
-                                case "AthenaItemWrap":
-                                    ItemTemplateId = "wrap";
-                                    break;
-                                default:
-                                    break;
-                            }
+                        {
+                            ItemTemplateId = Generator.GetCategoryFromItem(Item.item)!;
 
                             if (string.IsNullOrEmpty(ItemTemplateId))
                             {
@@ -146,14 +141,17 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
                             items = Item.items,
                             price = Price,
                             singleprice = Price, // not done
+                            variants = Item.variants,
                             rarity = Item.rarity,
                             BundlePath = Item.BundlePath,
                             type = "Normal",
                             categories = Item.categories
                         });
                         Logger.Log($"Generated {ItemTemplateId}:{Item.name}", "ItemShop");
+
+                        Generator.DailyItems -= 1;
                     }
-                    Generator.DailyItems -= 1;
+                   
                 }
 
                 List<ShopBundlesItem> WeeklyArray = RandomSkinItem.Weekly;
@@ -164,40 +162,23 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
                     int Price = -1; // High As Broken
                     string ItemTemplateId = "";
 
-                  
+
                     foreach (var Item in WeeklyArray)
                     {
-                       
+
                         if (!Item.categories.Any())
                         {
                             HowManyTurns += 1;
                         }
 
-                        if(Item.singleprice != -1) {
+                        if (Item.singleprice != -1)
+                        {
                             Price = Item.singleprice;
                         }
                         else
                         {
-                            switch (Item.item.Split(":")[0])
-                            {
-                                case "AthenaCharacter":
-                                    ItemTemplateId = "skins";
-                                    break;
-                                case "AthenaDance":
-                                    ItemTemplateId = "emotes";
-                                    break;
-                                case "AthenaPickaxe":
-                                    ItemTemplateId = "pickaxes";
-                                    break;
-                                case "AthenaGlider":
-                                    ItemTemplateId = "gliders";
-                                    break;
-                                case "AthenaItemWrap":
-                                    ItemTemplateId = "wrap";
-                                    break;
-                                default:
-                                    break;
-                            }
+                            ItemTemplateId = Generator.GetCategoryFromItem(Item.item)!;
+
 
                             if (string.IsNullOrEmpty(ItemTemplateId))
                             {
@@ -277,12 +258,17 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
             return true;
         }
 
-        public static async Task RandomItems(int Items, List<ItemsSaved> Type, List<object> DiscordFields, string ItemType = "Small")
+        public static async Task RandomItems(int Items, List<ItemsSaved> Type, List<object> DiscordFields, List<ShopItems> EventItems, double RandomFest = 0, string ItemType = "Small")
         {
             Logger.Log("Generating useless stuff -> " + Items, "ItemShop");
+            Random RandomNumber = new Random();
+
             for (int i = 0; i < Items; i++)
             {
-                await SingleItem(Generator.savedData, Type, Generator.itemTypes, Generator.rarityProb1, DiscordFields, ItemType);
+                if(EventItems != null && EventItems.Count > 0 && RandomNumber.NextDouble() < RandomFest)
+                   await FestiveSingleItem(Generator.savedData, Type, Generator.itemTypes, EventItems, DiscordFields, ItemType);
+                else
+                   await SingleItem(Generator.savedData, Type, Generator.itemTypes, Generator.rarityProb1, DiscordFields, ItemType);
             }
         }
 
@@ -391,6 +377,71 @@ namespace FortBackend.src.App.Utilities.Shop.Helpers
             {
                 Logger.Error($"Failed To Generate Item: {ChosenItemString}:Unknown ofc", "ItemShop");
             }
+        }
+    
+
+        public static async Task FestiveSingleItem(SavedData savedData, List<ItemsSaved> ListItemSaved, List<string> itemType, List<ShopItems> shopItems, List<object> DiscordFields, string type = "Small")
+        {
+            Random random = new Random();
+            int Price = -1;
+            var rng = new Random();
+
+
+            var available = shopItems
+                .Where(item =>
+                {
+                    if (DateTime.TryParse(item.LastShownDate, out var d))
+                        return d.Date != DateTime.UtcNow.Date;
+
+                    return true;
+                })
+                .ToList();
+
+            if (available.Count == 0)
+            {
+                // no point at the point to continue doing this
+                await SingleItem(savedData, ListItemSaved, itemType, Generator.rarityProb1, DiscordFields, type);
+                return;
+            }
+
+            var RandomSkinItem = available[rng.Next(available.Count)];
+
+            RandomSkinItem.LastShownDate = DateTime.UtcNow.ToString("yyyy-MM-dd");
+
+            var ItemType = Generator.GetCategoryFromItem(RandomSkinItem.item);
+            int price = 0;
+            if (ItemType != null && Generator.categoryMap.ContainsKey(ItemType))
+            {
+                price = Generator.categoryMap[ItemType](RandomSkinItem.rarity);
+                Logger.PlainLog(price);
+                if (price != 0)
+                {
+                    Price = price;
+                }
+            }
+
+            DiscordFields.Add(new
+            {
+                name = RandomSkinItem.name,
+                value = Price
+            });
+
+            ListItemSaved.Add(new ItemsSaved
+            {
+                id = RandomSkinItem.id,
+                item = RandomSkinItem.item,
+                name = RandomSkinItem.name,
+                description = RandomSkinItem.description,
+                items = RandomSkinItem.items,
+                price = Price,
+                singleprice = Price,
+                variants = RandomSkinItem.variants,
+                BundlePath = RandomSkinItem.BundlePath,
+                type = type,
+                rarity = RandomSkinItem.rarity
+            });
+
+            Logger.Log($"Generated Item: {ItemType}:{RandomSkinItem.name}", "ItemShop:Festive");
         }
     }
 }

--- a/FortBackend/src/App/Utilities/Shop/LoadShopCache.cs
+++ b/FortBackend/src/App/Utilities/Shop/LoadShopCache.cs
@@ -33,7 +33,7 @@ namespace FortBackend.src.App.Utilities.Shop
                 Saved.Saved.BackendCachedData.ShopBundlesFiltered.Remove(bundle);
             }
 
-            Console.WriteLine($"ShopBundles Loaded: {Saved.Saved.BackendCachedData.ShopBundlesFiltered.Count()} / {Saved.Saved.BackendCachedData.ShopBundles.Count()}");
+            Logger.Log($"ShopBundles Loaded: {Saved.Saved.BackendCachedData.ShopBundlesFiltered.Count()} / {Saved.Saved.BackendCachedData.ShopBundles.Count()}");
         }
 
         // yaps
@@ -41,7 +41,7 @@ namespace FortBackend.src.App.Utilities.Shop
         {
             if (!File.Exists(filePath))
             {
-                Console.WriteLine($"File not found: {filePath}");
+                Logger.Error($"File not found: {filePath}");
                 return new List<ShopItems>();
             }
 

--- a/FortBackend/src/App/Utilities/Shop/LoadShopCache.cs
+++ b/FortBackend/src/App/Utilities/Shop/LoadShopCache.cs
@@ -8,7 +8,7 @@ namespace FortBackend.src.App.Utilities.Shop
 {
     public class LoadShopCache
     {
-        public static void LoadAndFilterShopBundles(int currentSeason)
+        public static void LoadAndFilterShopBundles(float currentSeason)
         {
             List<ShopBundles> bundlesToRemove = new List<ShopBundles>();
 
@@ -33,11 +33,49 @@ namespace FortBackend.src.App.Utilities.Shop
                 Saved.Saved.BackendCachedData.ShopBundlesFiltered.Remove(bundle);
             }
 
-            Logger.Log($"ShopBundles Loaded: {Saved.Saved.BackendCachedData.ShopBundlesFiltered.Count()} / {Saved.Saved.BackendCachedData.ShopBundles.Count()}");
+            Logger.Log($"ShopBundles Loaded: {Saved.Saved.BackendCachedData.ShopBundlesFiltered.Count()} / {Saved.Saved.BackendCachedData.ShopBundlesFiltered.Count()}");
+
+
+            // Filter festive items, or smth like that
+
+            var filteredFes = new Dictionary<string, FestiveShopItems>();
+
+            foreach (var (eventName, festive) in Saved.Saved.BackendCachedData.ShopFestiveItems)
+            {
+                foreach (var bundle in festive.Bundles)
+                {
+                    bundle.Daily = bundle.Daily
+                        .Where(i => i.season <= currentSeason)
+                        .ToList();
+
+                    bundle.Weekly = bundle.Weekly
+                        .Where(i => i.season <= currentSeason)
+                        .ToList();
+                }
+
+                var BundleCount = festive.Bundles.Count;
+                var NormalCount = festive.Normal.Count;
+
+                festive.Bundles = festive.Bundles
+                     .Where(b => b.Daily.Any() || b.Weekly.Any())
+                     .ToList();
+
+                festive.Normal = festive.Normal
+                    .Where(i => i.season <= currentSeason)
+                    .ToList();
+
+                if (festive.Bundles.Any() || festive.Normal.Any())
+                    filteredFes[eventName] = festive;
+
+                Logger.Log($"ShopFestive {eventName} Bundle Loaded: {festive.Bundles.Count()} / {BundleCount}");
+                Logger.Log($"ShopFestive {eventName} Items Loaded: {festive.Normal.Count()} / {NormalCount}");
+            }
+
+            Saved.Saved.BackendCachedData.ShopFestiveItems = filteredFes;
         }
 
         // yaps
-        public static List<ShopItems> LoadAndFilter(string filePath, int currentSeason, string ItemLoader = "skins")
+        public static List<ShopItems> LoadAndFilter(string filePath, float currentSeason, string ItemLoader = "skins")
         {
             if (!File.Exists(filePath))
             {
@@ -56,7 +94,7 @@ namespace FortBackend.src.App.Utilities.Shop
             return filteredSkins;
         }
 
-        public static void LoadItems(int currentSeason)
+        public static void LoadItems(float currentSeason)
         {
             Saved.Saved.BackendCachedData.ShopSkinItems = LoadAndFilter(PathConstants.ShopJson.ShopSkins, currentSeason);
             Saved.Saved.BackendCachedData.ShopEmotesItems = LoadAndFilter(PathConstants.ShopJson.ShopEmotes, currentSeason, "emotes");

--- a/FortBackend/src/App/Utilities/Shop/UpdateShopBundle.cs
+++ b/FortBackend/src/App/Utilities/Shop/UpdateShopBundle.cs
@@ -32,7 +32,7 @@ namespace FortBackend.src.App.Utilities.Shop
                                     originalBundle.LastShownDate = filteredBundle.LastShownDate;
                                     Logger.Log($"Bundle: {filteredBundle.BundleID} date been updated to {filteredBundle.LastShownDate}");
                                 }
-                                Console.WriteLine(Saved.Saved.BackendCachedData.ShopBundles.Count);
+                                Logger.PlainLog(Saved.Saved.BackendCachedData.ShopBundles.Count);
                             }
 
                             // Then update the json file!!

--- a/FortBackend/src/App/Utilities/Shop/UpdateShopBundle.cs
+++ b/FortBackend/src/App/Utilities/Shop/UpdateShopBundle.cs
@@ -27,7 +27,7 @@ namespace FortBackend.src.App.Utilities.Shop
                                 var originalBundle = Saved.Saved.BackendCachedData.ShopBundles
                                 .FirstOrDefault(bundle => bundle.BundleID == filteredBundle.BundleID && (filteredBundle.Weekly.Count > 1 || filteredBundle.Daily.Count > 1));
 
-                                if (originalBundle != null)
+                                if (originalBundle != null && originalBundle.LastShownDate != filteredBundle.LastShownDate)
                                 {
                                     originalBundle.LastShownDate = filteredBundle.LastShownDate;
                                     Logger.Log($"Bundle: {filteredBundle.BundleID} date been updated to {filteredBundle.LastShownDate}");

--- a/FortBackend/src/App/Utilities/Startup.cs
+++ b/FortBackend/src/App/Utilities/Startup.cs
@@ -76,7 +76,7 @@ namespace FortBackend.src.App.Utilities
                 app.UseDeveloperExceptionPage();
             }
 
-            if (Saved.Saved.DeserializeConfig.EnableLogs)
+            if (Saved.Saved.DeserializeConfig.LogLevel > 1)
             {
                 Logger.Log("Logs are enabled", "SETUP");
                 app.UseMiddleware<LoggingMiddleware>();

--- a/FortBackend/src/App/XMPP Server/TCP/TcpServer.cs
+++ b/FortBackend/src/App/XMPP Server/TCP/TcpServer.cs
@@ -47,7 +47,7 @@ namespace FortBackend.src.App.XMPP_Server.TCP
                 try
                 {
                     TcpClient client = tcpListener.AcceptTcpClient();
-                    Console.WriteLine("NEW CONNECTION!!");
+                    Logger.PlainLog("NEW CONNECTION!!");
                     string clientId = Guid.NewGuid().ToString(); // GENERATES A NEW CLIENTID
                     _ = Task.Run(() => HandleTcpClientAsync(client, clientId));
                 }
@@ -130,7 +130,7 @@ namespace FortBackend.src.App.XMPP_Server.TCP
                                 if (reader.NodeType == XmlNodeType.Element && reader.Name == "stream:stream")
                                 {
 
-                                    Console.WriteLine("chat");
+                                    Logger.PlainLog("chat");
                                     string responseXml1 = "<?xml version='1.0' encoding='UTF-8'?>" +
                                     "<stream:stream xmlns:stream='http://etherx.jabber.org/streams' " +
                                     $"xmlns='jabber:client' from='127.0.0.1'  id='{clientId}' " +
@@ -138,14 +138,14 @@ namespace FortBackend.src.App.XMPP_Server.TCP
 
                                     byte[] responseBytes2 = Encoding.UTF8.GetBytes(responseXml1.ToString());
                                     await stream.WriteAsync(responseBytes2, 0, responseBytes2.Length);
-                                    Console.WriteLine("Response sent");
+                                    Logger.PlainLog("Response sent");
                                     await Task.Delay(100);
                                     string responseXml3 = "<stream:features><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'><required/></starttls>" + 
                                     "<mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>PLAIN</mechanism></mechanisms></stream:features>";
 
                                     byte[] responseBytes3 = Encoding.UTF8.GetBytes(responseXml3.ToString());
                                     await stream.WriteAsync(responseBytes3, 0, responseBytes3.Length);
-                                    Console.WriteLine("Response sent");
+                                    Logger.PlainLog("Response sent");
                                     break;
                                 }
                                 //<starttls xmlns="urn:ietf:params:xml:ns:xmpp-tls"/>
@@ -154,7 +154,7 @@ namespace FortBackend.src.App.XMPP_Server.TCP
                                     string xmlString = "<proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>";
                                     byte[] responseBytes33 = Encoding.UTF8.GetBytes(xmlString.ToString());
                                     await stream.WriteAsync(responseBytes33, 0, responseBytes33.Length);
-                                    Console.WriteLine("StartTls");
+                                    Logger.PlainLog("StartTls");
 
                                     //stream.Close();
                                     //client.Close();
@@ -165,7 +165,7 @@ namespace FortBackend.src.App.XMPP_Server.TCP
 
                                         int bytesRead2 = await stream.ReadAsync(buffer, 0, buffer.Length);
                                         string initialMessage = Encoding.UTF8.GetString(buffer, 0, bytesRead2);
-                                        Console.WriteLine($"Received initial message: {initialMessage}");
+                                        Logger.PlainLog($"Received initial message: {initialMessage}");
 
 
                                     }

--- a/FortBackend/src/App/XMPP Server/XMPP/XmppServer.cs
+++ b/FortBackend/src/App/XMPP Server/XMPP/XmppServer.cs
@@ -83,7 +83,7 @@ namespace FortBackend.src.App.XMPP_Server.XMPP
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine("OH SUGAR :/ it crashed why -> " + ex.Message);
+                            Logger.Error("OH SUGAR :/ it crashed why -> " + ex.Message);
                         }
                     }
                     else

--- a/FortBackend/src/App/XMPP Server/Xmpp.cs
+++ b/FortBackend/src/App/XMPP Server/Xmpp.cs
@@ -19,11 +19,11 @@ namespace FortBackend.src.App.XMPP_V2
                 XmppServer.Intiliazation(args, cancellationToken);
             }).Start();
 
-            new Thread(() =>
-            {
-                TcpServer tcpServer = new TcpServer(Saved.DeserializeConfig.TCPXmppPort);
-                Task tcpServerTask = tcpServer.Start();
-            }).Start();
+            //new Thread(() =>
+            //{
+            //    TcpServer tcpServer = new TcpServer(Saved.DeserializeConfig.TCPXmppPort);
+            //    Task tcpServerTask = tcpServer.Start();
+            //}).Start();
 
         }
     }

--- a/FortBackend/src/XMPP/SERVER/Handle.cs
+++ b/FortBackend/src/XMPP/SERVER/Handle.cs
@@ -44,7 +44,7 @@ namespace FortBackend.src.App.SERVER
                             try
                             {
                                 test = JToken.Parse(receivedMessage);
-                                Console.WriteLine("DISCONNETING USER AS FAKE RESPONSE // JSON");
+                                Logger.Error("DISCONNETING USER AS FAKE RESPONSE // JSON", "[XMPP]");
                                 receivedMessage = "";
                                 return;
                             }
@@ -113,7 +113,7 @@ namespace FortBackend.src.App.SERVER
             }
             finally
             {
-                Console.WriteLine("XMPP CLOSE");
+                Logger.PlainLog("XMPP CLOSE");
                 try
                 {
                     if (!serverShutdownToken.IsCancellationRequested && webSocket.State == WebSocketState.Open || webSocket.State == WebSocketState.CloseReceived)

--- a/FortBackend/src/XMPP/SERVER/KillGame.cs
+++ b/FortBackend/src/XMPP/SERVER/KillGame.cs
@@ -71,7 +71,7 @@ namespace FortBackend.src.XMPP.SERVER
                                 var partyJoinInfoData = ParsedPresence.Properties[key];
 
                                 PartyId = partyJoinInfoData.partyId;
-                                Console.WriteLine($"Party ID: {PartyId}");
+                                Logger.PlainLog($"Party ID: {PartyId}");
 
                                 break;
                             }
@@ -81,14 +81,14 @@ namespace FortBackend.src.XMPP.SERVER
                         {
                            
                             if (Client.accountId == client.accountId) continue;
-                            Console.WriteLine(Client.accountId);
-                            Console.WriteLine(client.accountId);
+                            Logger.PlainLog(Client.accountId);
+                            Logger.PlainLog(client.accountId);
 
                             foreach(var test in Client.Rooms) {
-                                Console.Write("test" + Client.Rooms);
+                                Logger.PlainLog("test" + Client.Rooms);
                             }
                             // Check rooms so we dont tell everyone
-                            Console.Write("a " + Client.Rooms);
+                            Logger.PlainLog("a " + Client.Rooms);
 
                             byte[] buffer;
                             string xmlMessage;

--- a/FortBackend/src/XMPP/SERVER/Root/AuthHandler.cs
+++ b/FortBackend/src/XMPP/SERVER/Root/AuthHandler.cs
@@ -20,7 +20,7 @@ namespace FortBackend.src.App.SERVER.Root
         {
             try
             {
-                Console.WriteLine("CLIENTDI: " + clientId);
+                Logger.PlainLog("CLIENTDI: " + clientId);
                 string xmlMessage;
                 byte[] buffer;
                 if (clientId == null)
@@ -42,7 +42,7 @@ namespace FortBackend.src.App.SERVER.Root
                     if (splitContent.Length == 3)
                     {
                         var AccessToken = splitContent[2].Replace("eg1~", "");
-                        Console.WriteLine(AccessToken);
+                        Logger.PlainLog(AccessToken);
                         TokenData AccessTokenClient = GlobalData.AccessToken.FirstOrDefault(i => i.token == splitContent[2])!;
                         if (AccessTokenClient == null/* && string.IsNullOrEmpty(AccessTokenClient.accountId)*/)
                         {
@@ -73,7 +73,7 @@ namespace FortBackend.src.App.SERVER.Root
                                     if (decodedContent != "" && dataSaved.AccountId != "" && dataSaved.DisplayName != "" && dataSaved.Token != "" && splitContent.Length == 3)
                                     {
                                         dataSaved.DidUserLoginNotSure = true;
-                                        Console.WriteLine($"New Xmpp Client Logged In User Name Is As {dataSaved.DisplayName}");
+                                        Logger.Log($"New Xmpp Client Logged In User Name Is As {dataSaved.DisplayName}");
                                         XNamespace streamNs = "urn:ietf:params:xml:ns:xmpp-sasl";
                                         var featuresElement = new XElement(streamNs + "success",
                                                new XAttribute(XNamespace.None + "xmlns", "urn:ietf:params:xml:ns:xmpp-sasl")

--- a/FortBackend/src/XMPP/SERVER/Root/MessageHandler.cs
+++ b/FortBackend/src/XMPP/SERVER/Root/MessageHandler.cs
@@ -44,7 +44,6 @@ namespace FortBackend.src.App.SERVER.Root
                 switch (Type)
                 {
                     case "chat":
-                        Console.WriteLine("CGAT");
                         if (string.IsNullOrEmpty(xmlDoc.Root?.Attribute("to")?.Value)) break;
                         if (body.Length >= 300) break;
 

--- a/FortBackend/src/XMPP/SERVER/Root/PresenceHandler.cs
+++ b/FortBackend/src/XMPP/SERVER/Root/PresenceHandler.cs
@@ -38,7 +38,6 @@ namespace FortBackend.src.App.SERVER.Root
                 switch (Type)
                 {
                     case "unavailable":
-                        Console.WriteLine("UNNNNNNNNNNNNNN");
                         if (string.IsNullOrEmpty(xmlDoc.Root?.Attribute("to")?.Value))
                         {
                             break;
@@ -258,8 +257,7 @@ namespace FortBackend.src.App.SERVER.Root
                     }
                  
 
-                    Console.WriteLine("TEST + " + findStatus);
-                    Console.WriteLine(away);
+                    Logger.PlainLog("TEST + " + findStatus);
 
                     await XmppFriend.UpdatePresenceForFriends(webSocket, status, away, false);
                     await XmppFriend.GrabSomeonesPresence(Saved_Clients.accountId, Saved_Clients.accountId, false);

--- a/FortBackend/src/XMPP/SERVER/Send/XmppFriend.cs
+++ b/FortBackend/src/XMPP/SERVER/Send/XmppFriend.cs
@@ -85,7 +85,7 @@ namespace FortBackend.src.App.SERVER.Send
 
                 if (FromAccountIdData == null || ToAccountIdData == null)
                 {
-                    Console.WriteLine("NOT FOUND");
+                    Logger.PlainLog("NOT FOUND, frined?");
                     return; // invalid data not found?
                 }
 
@@ -150,13 +150,13 @@ namespace FortBackend.src.App.SERVER.Send
 
                     if(shittyXmppClass.type == "com.epicgames.party.data")
                     {
-                        Console.WriteLine(shittyXmppClass.payload.ToString());
+                        Logger.PlainLog(shittyXmppClass.payload.ToString());
                         PartyData partyData = JsonConvert.DeserializeObject<PartyData>(shittyXmppClass.payload.ToString());
                         if(partyData != null && !string.IsNullOrEmpty(partyData.partyId))
                         {
                             if(partyData.payload.Attrs.PartyState_s == "BattleRoyaleView")
                             {
-                                Console.WriteLine("I WAnt to shut down the matchmaker for everything in the party!");
+                                Logger.PlainLog("I WAnt to shut down the matchmaker for everything in the party!");
                                 if (string.IsNullOrEmpty(partyData.payload.Attrs.MatchmakingInfoString_s))
                                 {
                                     var PartyId = $"Party-{partyData.partyId}";
@@ -169,7 +169,7 @@ namespace FortBackend.src.App.SERVER.Send
                                         {
                                             using (HttpClient client = new HttpClient())
                                             {
-                                                Console.WriteLine($"{Saved.BackendCachedData.DefaultProtocol}{Saved.DeserializeConfig.MatchmakerIP}:{Saved.DeserializeConfig.MatchmakerPort}/fortmatchmaker/removeUser/{member.accountId}");
+                                                Logger.PlainLog($"{Saved.BackendCachedData.DefaultProtocol}{Saved.DeserializeConfig.MatchmakerIP}:{Saved.DeserializeConfig.MatchmakerPort}/fortmatchmaker/removeUser/{member.accountId}");
                                                 client.DefaultRequestHeaders.Add("Authorization", $"bearer {Saved.DeserializeConfig.JWTKEY}");
                                                 var response = await client.PostAsync($"{Saved.BackendCachedData.DefaultProtocol}{Saved.DeserializeConfig.MatchmakerIP}:{Saved.DeserializeConfig.MatchmakerPort}/fortmatchmaker/removeUser/{member.accountId}", null);
                                                 var responseContent = await response.Content.ReadAsStringAsync();
@@ -182,7 +182,7 @@ namespace FortBackend.src.App.SERVER.Send
                                         }
                                        
                                             //fortmatchmaker/removeUser
-                                            Console.WriteLine($"how many peopel in party -> {test.members.Count}");
+                                            Logger.PlainLog($"how many peopel in party -> {test.members.Count}");
                                     }
                                 }
                             }
@@ -194,7 +194,7 @@ namespace FortBackend.src.App.SERVER.Send
                 }
                 else
                 {
-                    Console.WriteLine("THIS IS NULLW HY!");
+                    Logger.PlainLog("THIS IS NULLW HY!");
                 }
             }
             catch (Exception ex)

--- a/FortBackend/src/XMPP/SERVER/Send/XmppGift.cs
+++ b/FortBackend/src/XMPP/SERVER/Send/XmppGift.cs
@@ -1,0 +1,54 @@
+﻿using FortBackend.src.XMPP.Data;
+using FortLibrary;
+using FortLibrary.XMPP;
+using Newtonsoft.Json;
+using System.Net.WebSockets;
+using System.Text;
+using System.Xml.Linq;
+
+namespace FortBackend.src.XMPP.SERVER.Send
+{
+    public class XmppGift
+    {
+        public static async Task NotifyUser(string SendMessageTo)
+        {
+            try
+            {
+                Clients Client = GlobalData.Clients.FirstOrDefault(client => client.accountId == SendMessageTo)!;
+
+                if (Client != null)
+                {
+                    string xmlMessage;
+                    byte[] buffer;
+                    WebSocket webSocket = Client.Game_Client;
+                    Logger.PlainLog(webSocket.State);
+                    if (webSocket != null && webSocket.State == WebSocketState.Open)
+                    {
+                        XNamespace clientNs = "jabber:client";
+
+                        var message = new XElement(clientNs + "message",
+                          new XAttribute("from", $"xmpp-admin@prod.ol.epicgames.com"),
+                          new XAttribute("to", SendMessageTo),
+                          new XElement(clientNs + "body", JsonConvert.SerializeObject(new
+                          {
+                              payload = new { },
+                              type = "com.epicgames.gift.received",
+                              timestamp = DateTime.UtcNow.ToString("o")
+                          }))
+                        );
+
+                        xmlMessage = message.ToString();
+                        buffer = Encoding.UTF8.GetBytes(xmlMessage);
+
+                        await webSocket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
+                    }
+
+                }
+            }
+            catch (Exception ex)
+            {
+            }
+        }
+
+    }
+}

--- a/FortDashboard/app/dashboard/content/management/page.tsx
+++ b/FortDashboard/app/dashboard/content/management/page.tsx
@@ -278,13 +278,13 @@ export default function DashboardBase() {
                                   onChange={(e) =>
                                     setSecondTabContent((prev) => ({
                                       ...prev,
-                                      Season: Number(e.target.value),
+                                      Season: parseFloat(e.target.value),
                                     }))
                                   }
                                   min="0"
                                 />
                                 <p className="text-xs text-muted-foreground">
-                                  Season to force for all players
+                                  Season to force for all players, e.g 12.41, 11.31
                                 </p>
                               </div>
 

--- a/FortDashboard/app/dashboard/sidebar.tsx
+++ b/FortDashboard/app/dashboard/sidebar.tsx
@@ -1,4 +1,4 @@
-import { Activity, LogOut, Settings, Users } from "lucide-react";
+import { Activity, LogOut, Server, Settings, Users } from "lucide-react";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useUserStore } from "@/hooks/useUserStore";
@@ -59,6 +59,18 @@ const Sidebar = () => {
             </Button>
             <Button
               variant={
+                pathname === "/dashboard/servers" ? "secondary" : "ghost"
+              }
+              className="flex justify-start gap-2 px-4 py-2"
+              asChild
+            >
+              <Link href="/dashboard/servers">
+                <Server className="h-4 w-4" />
+                Matchmaker
+              </Link>
+            </Button>
+            <Button
+              variant={
                 pathname === "/dashboard/admin-panel" ? "secondary" : "ghost"
               }
               className="flex justify-start gap-2 px-4 py-2"
@@ -80,24 +92,24 @@ const Sidebar = () => {
               <p className="text-sm font-medium">{user?.displayName}</p>
             </div>
             <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-8 w-8">
-                    <Settings className="h-4 w-4" />
-                    <span className="sr-only">Settings</span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem>
-                    <Settings className="mr-2 h-4 w-4" />
-                    <span>Settings</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem className="text-red-500" onClick={() => LogoutDashboard()}>
-                    <LogOut className="mr-2 h-4 w-4" />
-                    <span>Logout</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Settings className="h-4 w-4" />
+                  <span className="sr-only">Settings</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem>
+                  <Settings className="mr-2 h-4 w-4" />
+                  <span>Settings</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="text-red-500" onClick={() => LogoutDashboard()}>
+                  <LogOut className="mr-2 h-4 w-4" />
+                  <span>Logout</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/FortDashboard/package-lock.json
+++ b/FortDashboard/package-lock.json
@@ -3830,9 +3830,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.1.tgz",
+      "integrity": "sha512-L7BnWgRbMwzMAubQcS7sXdPdNLmKlucPlopgAzx7FtYbksWZgEWiuYM5x9T6UqS2Ne0rsgQTq5kY2SGqpzUkYA==",
       "license": "MIT",
       "peer": true
     },

--- a/FortLauncher/FortLauncherV2/src/backend/index.ts
+++ b/FortLauncher/FortLauncherV2/src/backend/index.ts
@@ -75,6 +75,10 @@ function createWindow(): void {
       return "am i the rizzler?";
     });
 
+    ipcMain.handle('open-link', (_, url) => {
+      shell.openExternal(url)
+    })
+
     ipcMain.handle("fortlauncher:login", async () => {
       return login(mainWindow!);
     });
@@ -196,7 +200,7 @@ function createWindow(): void {
         }
 
         mainWindow?.webContents.send("gameStatus", {
-          Launching: false,
+          Launching: true,
           Type: "Message",
           Message: "Launching",
         });

--- a/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Content/Settings.vue
+++ b/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Content/Settings.vue
@@ -1,16 +1,67 @@
+<script setup lang="ts">
+import About from '../Settings/About.vue';
+import Account from '../Settings/Account.vue';
+import Developer from '../Settings/Developer.vue';
+
+</script>
 <template>
-    <div class="CenterContent">
-        <a style="color: white; font-size: 22px; font-weight: bold; text-align: left;  width: 95%;">Settings, unfinished</a>
-        
-        <button class="open-appdata" @click="openAppData">Open AppData</button>
-        <button class="open-appdata" @click="LogoutLauncher">Logout</button>
+  <div class="CenterContent">
+    <a style="color: white; font-size: 22px; font-weight: bold; text-align: left;  width: 95%;">Settings, unfinished</a>
+
+    <div class="btn-grid">
+      <button class="btn" @click="setTab('account')" :class="{ active: currentTab === 'account' }">Account</button>
+      <button class="btn" @click="setTab('launcher')" :class="{ active: currentTab === 'launcher' }">Launcher</button>
+      <button class="btn" @click="setTab('developer')"
+        :class="{ active: currentTab === 'developer' }">Developer</button>
+      <button class="btn" @click="setTab('about')" :class="{ active: currentTab === 'about' }">About</button>
     </div>
+
+
+    <div v-if="currentTab === 'account'" class="tab-wrapper">
+      <Account :LoginResponse="user" />
+    </div>
+
+    <div v-if="currentTab === 'developer'" class="tab-wrapper">
+      <Developer />
+    </div>
+
+
+    <div v-if="currentTab === 'about'" class="tab-wrapper">
+      <About />
+    </div>
+
+
+  </div>
 
 </template>
 
-<script>
+<script lang="ts">
+
 export default {
+  data() {
+    return {
+      currentTab: 'account',
+      TabName: 'account',
+    }
+  },
+  props: {
+    LoginResponse: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  computed: {
+    user() {
+      return this.LoginResponse
+    }
+  },
   methods: {
+    setTab(tab: string) {
+      if (tab != this.TabName) {
+        this.TabName = tab
+        this.currentTab = tab
+      }
+    },
     async openAppData() {
       try {
         await window.ipcRenderer.invoke("fortlauncher:open-appdata");
@@ -30,132 +81,179 @@ export default {
 </script>
 
 <style scoped>
+.tab-wrapper {
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.btn-grid {
+  background-color: #1b1b1b;
+  width: 90%;
+  height: 45px;
+  border-radius: 10px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  padding: 0 6px;
+  gap: 6px;
+}
+
+.btn-grid .active {
+  background: #2a2a2a;
+}
+
+.btn {
+  width: 85%;
+  height: 32px;
+  border-radius: 8px;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.btn:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.btn:active {
+  outline: none;
+  box-shadow: none;
+  border: 0;
+}
+
 .open-appdata {
   margin-top: 8px;
 }
+
 .CenterContent {
-    margin-top: 15px;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    align-items: center;
-    gap: 15px;
+  margin-top: 15px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-items: center;
+  gap: 15px;
 }
 
 .SomeDivINthebuild {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    align-items: flex-start;
-    margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-items: flex-start;
+  margin-top: 5px;
 }
 
 .BuildImageHOlder .launchButton {
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
 }
 
 
 .BuildImageHOlder:hover {
-    background-color: #5f5f5ffb;
+  background-color: #5f5f5ffb;
 }
 
 
 .BuildImageHOlder:hover .launchButton {
-    opacity: 1;
-    visibility: visible;
+  opacity: 1;
+  visibility: visible;
 }
 
 .launchButton.running {
-    background-color: #27ae60;
+  background-color: #27ae60;
 }
 
 .launchButton:disabled {
-    background-color: #bdc3c7;
-    cursor: not-allowed;
+  background-color: #bdc3c7;
+  cursor: not-allowed;
 }
 
 .launchButton {
-    background-color: #1c1c1e;
-    color: white;
-    border: none;
-    padding: 8px 0px;
-    width: 90%;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 16px;
-    margin-top: auto;
-    margin-bottom: 10px;
+  background-color: #1c1c1e;
+  color: white;
+  border: none;
+  padding: 8px 0px;
+  width: 90%;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 16px;
+  margin-top: auto;
+  margin-bottom: 10px;
 }
 
 .GridContainer {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, 170px);
-    gap: 15px;
-    width: 90%;
-    height: 170px;
-    justify-content: start;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 170px);
+  gap: 15px;
+  width: 90%;
+  height: 170px;
+  justify-content: start;
 
 }
 
 .BuildTitle {
-    color: white;
-    font-size: 18px;
-    font-weight: bold;
-    margin-top: 0px;
-    margin-left: 10px;
+  color: white;
+  font-size: 18px;
+  font-weight: bold;
+  margin-top: 0px;
+  margin-left: 10px;
 }
 
 .BuildBody {
-    color: #9c9891;
-    font-size: 14px;
-    font-weight: normal;
-    margin-top: 0px;
-    margin-left: 10px;
+  color: #9c9891;
+  font-size: 14px;
+  font-weight: normal;
+  margin-top: 0px;
+  margin-left: 10px;
 }
 
 .BuildImageHOlder {
-    width: 170px;
-    background-color: #a5a5a5;
-    border-style: solid;
-    border-width: 1px;
-    border-color: #1e1e2d;
-    height: 225px;
-    border-radius: 10px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-    overflow: hidden;
-    transition: all 0.3s ease;
+  width: 170px;
+  background-color: #a5a5a5;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #1e1e2d;
+  height: 225px;
+  border-radius: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  transition: all 0.3s ease;
 }
 
 
 .AddBuildB {
-    width: 170px;
-    background-color: transparent;
-    border-style: dotted;
-    border-width: 2px;
-    border-color: #a0a0b8;
-    height: 225px;
-    border-radius: 10px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-    overflow: hidden;
-    transition: all 0.3s ease;
-    flex-direction: column;
+  width: 170px;
+  background-color: transparent;
+  border-style: dotted;
+  border-width: 2px;
+  border-color: #a0a0b8;
+  height: 225px;
+  border-radius: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  transition: all 0.3s ease;
+  flex-direction: column;
 }
 
 .GridThing {
-    display: flex;
-    flex-direction: column;
-    width: 170px;
-    height: 290x;
-    justify-content: flex-start;
-    border-radius: 10px;
-    align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  width: 170px;
+  height: 290x;
+  justify-content: flex-start;
+  border-radius: 10px;
+  align-items: flex-start;
 }
 </style>

--- a/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Dashboard.vue
+++ b/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Dashboard.vue
@@ -15,7 +15,7 @@ import Settings from './Content/Settings.vue';
         <Library ref="libraryTab" @buildpath="OpenBuildPopup" />
     </div>
     <div v-if="currentTab === 'settings'" style="margin-left: 270px;">
-        <Settings ref="libraryTab"  />
+        <Settings ref="libraryTab" :LoginResponse="getData"  />
     </div>
 
     <div @click="OpenBuildPopup(false)" v-if="LibraryPopup" class="AddBuildPopup">

--- a/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Settings/About.vue
+++ b/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Settings/About.vue
@@ -1,0 +1,78 @@
+<template>
+    <h3 class="title">About FortLauncher</h3>
+    <div class="box">
+        <div style="width: 90%;">
+            <h4>FortLauncher</h4>
+            <hr>
+            <h5 class="desc">FortBackend is a Universal Fortnite Private Server written in C#.</h5>
+            <hr>
+            <div class="actions">
+                <button @click="goGitHub()">View on GitHub</button>
+            </div>
+        </div>
+
+    </div>
+</template>
+
+<script>
+export default {
+    methods: {
+        goGitHub() {
+            window.ipcRenderer.invoke('open-link', "https://github.com/zinx28/FortServer")
+        }
+    }
+}
+</script>
+
+<style scoped>
+.title {
+    width: 100%;
+    text-align: left;
+}
+
+.box>div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.desc {
+    font-size: 15px;
+    color: #808080;
+    margin: 10px 0;
+}
+
+hr {
+    width: 100%;
+    height: 2px;
+    border: none;
+    background: #3a3a3a;
+    margin: 14px 0;
+}
+
+.box>div h4 {
+    margin-bottom: 4px;
+}
+
+button {
+    padding: 8px 16px;
+    border-radius: 6px;
+    background: #1a1a1a;
+    border: 1px solid #2d2d2d;
+}
+
+.box {
+    width: 100%;
+    height: 100%;
+    padding-bottom: 15px;
+    background-color: #1d1c1c;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #222020;
+    border-radius: 10px;
+    margin-left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+</style>

--- a/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Settings/Account.vue
+++ b/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Settings/Account.vue
@@ -1,0 +1,105 @@
+<template>
+    <h3 class="title">Account Information</h3>
+    <div class="box">
+        <div class="inner">
+            <div class="circle"></div>
+            <div class="links">
+                <p href="#">{{ user?.username || "User" }}</p>
+                <p href="#">{{ user?.DiscordId || "DiscordID" }}</p>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        LoginResponse: {
+            type: Object,
+            default: () => ({})
+        }
+    },
+    computed: {
+        user() {
+            return this.LoginResponse
+        }
+    },
+    methods: {
+        goGitHub() {
+            window.ipcRenderer.invoke('open-link', "https://github.com/zinx28/FortServer")
+        }
+    }
+}
+</script>
+
+<style scoped>
+.title {
+    width: 100%;
+    text-align: left;
+}
+
+.box {
+    width: 100%;
+    height: 100%;
+    padding-top: 15px;
+    padding-bottom: 15px;
+    background-color: #1d1c1c;
+    border: 1px solid #222020;
+    border-radius: 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+.inner {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    margin-left: 15px;
+}
+
+.circle {
+    width: 60px;
+    height: 60px;
+    background-color: rgb(43, 43, 54);
+    border-radius: 50%;
+}
+
+.links {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+}
+
+.links p {
+    margin: 0;
+    text-align: left;
+}
+
+.desc {
+    font-size: 15px;
+    color: #636363;
+    margin: 10px 0;
+}
+
+hr {
+    width: 100%;
+    height: 2px;
+    border: none;
+    background: #3a3a3a;
+    margin: 14px 0;
+}
+
+.box>div h3 {
+    margin-bottom: 4px;
+}
+
+button {
+    padding: 8px 16px;
+    border-radius: 6px;
+    background: #1a1a1a;
+    border: 1px solid #2d2d2d;
+}
+</style>

--- a/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Settings/Developer.vue
+++ b/FortLauncher/FortLauncherV2/src/renderer/src/components/Main/Settings/Developer.vue
@@ -1,0 +1,76 @@
+<template>
+    <h3 class="title">Storage</h3>
+    <div class="box">
+        <div style="width: 90%;">
+            <h4>Application Data</h4>
+            <h5 class="desc">Access launcher configuration and data files</h5>  
+            <div class="actions">
+                <button @click="goGitHub()">Open AppData</button>
+            </div>
+        </div>
+
+    </div>
+</template>
+
+<script>
+export default {
+    methods: {
+        goGitHub() {
+            window.ipcRenderer.invoke('fortlauncher:open-appdata');
+        }
+    }
+}
+</script>
+
+<style scoped>
+.title {
+    width: 100%;
+    text-align: left;
+}
+
+.box>div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.desc {
+    font-size: 15px;
+    color: #808080;
+    margin: 10px 0;
+}
+
+hr {
+    width: 100%;
+    height: 2px;
+    border: none;
+    background: #3a3a3a;
+    margin: 10px 0;
+}
+
+.box>div h4 {
+    margin-bottom: 1px;
+}
+
+button {
+    padding: 8px 16px;
+    border-radius: 6px;
+    background: #1a1a1a;
+    border: 1px solid #2d2d2d;
+}
+
+.box {
+    width: 100%;
+    height: 100%;
+    padding-bottom: 15px;
+    background-color: #1d1c1c;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #222020;
+    border-radius: 10px;
+    margin-left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+</style>

--- a/FortLauncher/FortLauncherV2/src/renderer/src/style.css
+++ b/FortLauncher/FortLauncherV2/src/renderer/src/style.css
@@ -42,13 +42,13 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
-button:hover {
+/*button:hover {
   border-color: #646cff;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
+}*/
 
 .card {
   padding: 2em;
@@ -67,9 +67,9 @@ button:focus-visible {
   a:hover {
     color: #747bff;
   }
-  button {
+  /*button {
     background-color: #f9f9f9;
-  }
+  }*/
 }
 
 

--- a/FortLibrary/ConfigHelpers/FortConfig.cs
+++ b/FortLibrary/ConfigHelpers/FortConfig.cs
@@ -94,7 +94,14 @@ namespace FortLibrary.ConfigHelpers
 
         // -- //
 
-        public bool EnableLogs { get; set; } = false; // http requests
+        /*
+         * Low: 0
+         * Medium: 1
+         * High: 2
+         * Medium~High: 3 (plain logs won't display but asp logs will)
+         * Any higher will be reverted back to (2)
+         */
+        public int LogLevel { get; set; } = 0; // Low (basic logging, medium crazy logging, high crazy with asp logging) 
 
         // - could be in game config in the future
         public bool FullLockerForEveryone { get; set; } = false; // full locker (should show all up to 29.10 - .20 i forgot)

--- a/FortLibrary/ConfigHelpers/FortGameConfig.cs
+++ b/FortLibrary/ConfigHelpers/FortGameConfig.cs
@@ -17,11 +17,13 @@ namespace FortLibrary.ConfigHelpers
         public string SeasonEndDate { get; set; } = "9999-12-31T23:59:59.999Z";
 
         public bool ForceSeason { get; set; } = false; // force season~ means that no matter version you login to will be that season
-        public int Season { get; set; } = 0;
+        public float Season { get; set; } = 0; // eg. 12.41, 11.30, 10.40.... get it?!?
         public int WeeklyQuest { get; set; } = 1; // This is the max weekly quests is added to the user profile if they have the battlepass
 
         public bool MfaClaim { get; set; } = false; // Change this to true for auto claim! -- idk how your going to claim without having it enabled!
 
         public bool ShopRotation { get; set; } = false; // THIS IS STILL WIP AND MIGHT GIVE WEIRD SHOPS
+
+        public bool SeasonalShopRotation { get; set; } = true;
     }
 }

--- a/FortLibrary/Default/DefaultAccount.cs
+++ b/FortLibrary/Default/DefaultAccount.cs
@@ -49,6 +49,10 @@ namespace FortLibrary.Default
                             }
                         }
                     },
+                    loadouts = new()
+                    {
+                        "sandbox_loadout"
+                    },
                     loadouts_data = new Dictionary<string, SandboxLoadout>()
                     {
                         ["sandbox_loadout"] = new SandboxLoadout() // dont need much just the default obj

--- a/FortLibrary/Dynamics/SeasonBPPurchase.cs
+++ b/FortLibrary/Dynamics/SeasonBPPurchase.cs
@@ -1,0 +1,33 @@
+﻿using FortLibrary.EpicResponses.Profile.Query.Items;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortLibrary.Dynamics
+{
+    public class SeasonBPPurchase
+    {
+        public bool bRequireBp { get; set; } = true;
+        public string OfferId { get; set; } = string.Empty;
+        public string templateId { get; set; } = string.Empty;
+        public List<NewAddedItemVariants_V2> new_variants { get; set; } = new List<NewAddedItemVariants_V2>();
+        public List<AthenaItemVariants> variants { get; set; } = new List<AthenaItemVariants>();
+
+        public int Price { get; set; } = -1;
+        public int Quantity { get; set;  } = -1;
+    }
+
+    public class NewAddedItemVariants_V2
+    {
+        [JsonProperty("connectedItem")]
+        public string connectedItem { get; set; } = string.Empty;
+        [JsonProperty("channel")]
+        public string channel { get; set; } = string.Empty;
+
+        [JsonProperty("added")]
+        public List<string> added { get; set; } = new List<string>();
+    }
+}

--- a/FortLibrary/EpicResponses/Profile/CopyCosmeticLoadoutReq.cs
+++ b/FortLibrary/EpicResponses/Profile/CopyCosmeticLoadoutReq.cs
@@ -1,0 +1,16 @@
+﻿namespace FortLibrary.EpicResponses.Profile
+{
+    public class CopyCosmeticLoadoutReq
+    {
+        public int sourceIndex { get; set; } = 0;
+        public int targetIndex { get; set; } = 1;
+        public string optNewNameForTarget { get; set; } = string.Empty;
+    }
+
+    public class DeleteCosmeticLoadoutReq
+    {
+        public int index { get; set; } = 0;
+        public int fallbackLoadoutIndex { get; set; } = -1;
+        public bool leaveNullSlot { get; set; } = true;
+    }
+}

--- a/FortLibrary/EpicResponses/Profile/CopyCosmeticLoadoutResponse.cs
+++ b/FortLibrary/EpicResponses/Profile/CopyCosmeticLoadoutResponse.cs
@@ -1,9 +1,0 @@
-﻿namespace FortLibrary.EpicResponses.Profile
-{
-    public class CopyCosmeticLoadoutResponse
-    {
-        public int sourceIndex { get; set; } = 0;
-        public int targetIndex { get; set; } = 1;
-        public string optNewNameForTarget { get; set; } = "Couldn't grab name!!";
-    }
-}

--- a/FortLibrary/EpicResponses/Profile/ExchangeGameCurrencyForBattlePassOffer.cs
+++ b/FortLibrary/EpicResponses/Profile/ExchangeGameCurrencyForBattlePassOffer.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortLibrary.EpicResponses.Profile
+{
+    public class ExchangeGameCurrencyForBattlePassOfferReq
+    {
+        public List<string> offerItemIdList { get; set; } = new();
+    }
+}

--- a/FortLibrary/EpicResponses/Profile/PurchaseMultipleCatalogEntriesReq.cs
+++ b/FortLibrary/EpicResponses/Profile/PurchaseMultipleCatalogEntriesReq.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortLibrary.EpicResponses.Profile
+{
+    public class PurchaseMultipleCatalogEntriesReq
+    {
+        public List<PurchaseInfoList> purchaseInfoList = new();
+    }
+
+    public class PurchaseInfoList
+    {
+        public string currency { get; set; } = "MtxCurrency";
+        public string currencySubType { get; set; } = string.Empty;
+        public int expectedTotalPrice { get; set; } = -1;
+        public string gameContext { get; set; } = string.Empty;
+        public string offerId { get; set; } = string.Empty;
+        public int purchaseQuantity { get; set; } = -1;
+    }
+}

--- a/FortLibrary/EpicResponses/Profile/Query/Attributes/AthenaAttributes.cs
+++ b/FortLibrary/EpicResponses/Profile/Query/Attributes/AthenaAttributes.cs
@@ -10,7 +10,7 @@
         public bool use_random_loadout { get; set; }
         public List<object> past_seasons { get; set; } = new List<object>();
         public int season_match_boost { get; set; }
-        public string[] loadouts { get; set; }
+        public List<string> loadouts { get; set; } = new();
         public bool mfa_reward_claimed { get; set; }
         public int rested_xp_overflow { get; set; }
         public string last_xp_interaction { get; set; } = string.Empty;
@@ -34,7 +34,7 @@
         public int xp { get; set; }
         public int season_friend_match_boost { get; set; }
         public int active_loadout_index { get; set; }
-        public List<object> purchased_bp_offers { get; set; } = new List<object>();
+        public List<PurchasedBpOffsers> purchased_bp_offers { get; set; } = new();
         public string last_applied_loadout { get; set; } = string.Empty;
         public string favorite_musicpack { get; set; } = string.Empty;
         public string banner_icon { get; set; } = string.Empty;

--- a/FortLibrary/EpicResponses/Profile/Query/PurchasedBpOffsers.cs
+++ b/FortLibrary/EpicResponses/Profile/Query/PurchasedBpOffsers.cs
@@ -1,0 +1,52 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortLibrary.EpicResponses.Profile.Query
+{
+    public class PurchasedBpOffsers
+    {
+        [BsonElement("offerId")]
+        [JsonProperty("offerId")]
+        public string offerId { get; set; } = string.Empty;
+        [BsonElement("bIsFreePassReward")]
+        [JsonProperty("bIsFreePassReward")]
+        public bool bIsFreePassReward { get; set; }
+        [BsonElement("purchaseDate")]
+        [JsonProperty("purchaseDate")]
+        public string purchaseDate { get; set; } = string.Empty;
+
+        [BsonElement("lootResult")]
+        [JsonProperty("lootResult")]
+        public List<LootResultMD> lootResult { get; set; } = new();
+
+        [BsonElement("currencyType")]
+        [JsonProperty("currencyType")]
+        public string currencyType { get; set; } = string.Empty;
+
+        [BsonElement("totalCurrencyPaid")]
+        [JsonProperty("totalCurrencyPaid")]
+        public int totalCurrencyPaid { get; set; } = -1;
+    }
+
+    public class LootResultMD
+    {
+        [BsonElement("itemType")]
+        [JsonProperty("itemType")]
+        public string itemType { get; set; } = string.Empty;
+        [BsonElement("itemGuid")]
+        [JsonProperty("itemGuid")]
+        public string itemGuid { get; set; } = string.Empty;
+        [BsonElement("itemProfile")]
+        [JsonProperty("itemProfile")]
+        public string itemProfile { get; set; } = string.Empty;
+        [BsonElement("quantity")]
+        [JsonProperty("quantity")]
+        public int quantity { get; set; } = -1;
+
+    }
+}

--- a/FortLibrary/EpicResponses/Profile/SetBattleRoyaleBannerReq.cs
+++ b/FortLibrary/EpicResponses/Profile/SetBattleRoyaleBannerReq.cs
@@ -5,4 +5,18 @@
         public string homebaseBannerIconId { get; set; } = string.Empty;
         public string homebaseBannerColorId { get; set; } = string.Empty;
     }
+
+    public class SetCosmeticLockerBannerReq
+    {
+        public string lockerItem { get; set; } = string.Empty;
+        public string bannerIconTemplateName { get; set; } = string.Empty;
+        public string bannerColorTemplateName { get; set; } = string.Empty;
+    }
+
+    public class SetCosmeticLockerNameReq
+    {
+        public string lockerItem { get; set; } = string.Empty;
+        public string name { get; set; } = string.Empty;
+    }
+
 }

--- a/FortLibrary/EpicResponses/Profile/SetCosmeticLockerSlotRequest.cs
+++ b/FortLibrary/EpicResponses/Profile/SetCosmeticLockerSlotRequest.cs
@@ -11,4 +11,9 @@ namespace FortLibrary.EpicResponses.Profile
         public List<AthenaItemVariants> variantUpdates { get; set; } = new List<AthenaItemVariants>();
         public int optLockerUseCountOverride { get; set; }
     }
+
+    public class SetRandomCosmeticLoadoutFlagReq
+    {
+        public bool random { get; set; }
+    }
 }

--- a/FortLibrary/EpicResponses/Profile/SetItemFavoriteStatusReq.cs
+++ b/FortLibrary/EpicResponses/Profile/SetItemFavoriteStatusReq.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortLibrary.EpicResponses.Profile
+{
+    public class SetItemFavoriteStatusReq
+    {
+        public string targetItemId { get; set; } = string.Empty;
+        public bool bFavorite { get; set; } = false;
+    }
+
+    public class SetItemFavoriteStatusBatchReq
+    {
+        public List<string> itemIds { get; set; } = new();
+        public List<bool> itemFavStatus { get; set; } = new();
+    }
+}

--- a/FortLibrary/Logger.cs
+++ b/FortLibrary/Logger.cs
@@ -13,6 +13,7 @@ namespace FortLibrary
 
         private static StreamWriter? writer;
         private static readonly object _lock = new();
+        private static int LogLevel = 1; // 1 for the start only
 
         static Logger()
         {
@@ -50,6 +51,15 @@ namespace FortLibrary
         }
 
         /// <summary>
+        /// Set log level
+        /// </summary>
+        /// <param name="level">log level: 0 basic logs</param>
+        public static void SetLogLevel(int level)
+        {
+            LogLevel = level;
+        }
+
+        /// <summary>
         /// Logs plain text
         /// </summary>
         /// <param name="message">Message that will be printed</param>
@@ -58,7 +68,21 @@ namespace FortLibrary
             if(writer != null)
                 writer.WriteLine(message);
 
-            Console.WriteLine(message);
+            if (LogLevel > 0 && LogLevel != 3)
+                Console.WriteLine(message);
+        }
+
+        /// <summary>
+        /// Logs plain text
+        /// </summary>
+        /// <param name="message">Message that will be printed</param>
+        public static void PlainLog(object message)
+        {
+            if (writer != null)
+                writer.WriteLine(message);
+
+            if (LogLevel > 0 && LogLevel != 3)
+                Console.WriteLine(message);
         }
 
         /// <summary>

--- a/FortLibrary/MongoDB/Extensions/ProfileRevisionExtensions.cs
+++ b/FortLibrary/MongoDB/Extensions/ProfileRevisionExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace FortBackend.src.App.Utilities.MongoDB.Extentions
+{
+    public interface IProfileRevisions
+    {
+        DateTime Updated { get; set; }
+        int RVN { get; set; }
+        int CommandRevision { get; set; }
+    }
+
+    public static class ProfileRevisionExtensions
+    {
+        public static void BumpRevisions(this IProfileRevisions profile)
+        {
+            profile.Updated = DateTime.UtcNow;
+            profile.RVN++;
+            profile.CommandRevision++;
+        }
+
+        public static int GetBaseRevision(this IProfileRevisions profile, int Season)
+        {
+            return Season >= 17
+                ? profile.CommandRevision
+                : profile.RVN;
+        }
+    }
+}

--- a/FortLibrary/MongoDB/Modules/Account.cs
+++ b/FortLibrary/MongoDB/Modules/Account.cs
@@ -311,6 +311,10 @@ namespace FortLibrary.MongoDB.Module
         [BsonElement("intro_game_played")]
         [JsonProperty("intro_game_played")]
         public bool intro_game_played { get; set; } = false;
+
+        [BsonElement("special_items")]
+        [JsonProperty("special_items")]
+        public Dictionary<string, AthenaItem> special_items { get; set; } = new();
     }
 
     public class Events

--- a/FortLibrary/MongoDB/Modules/Account.cs
+++ b/FortLibrary/MongoDB/Modules/Account.cs
@@ -1,4 +1,6 @@
-﻿using FortLibrary.EpicResponses.Profile.Query.Items;
+﻿using FortBackend.src.App.Utilities.MongoDB.Extentions;
+using FortLibrary.EpicResponses.Profile.Query;
+using FortLibrary.EpicResponses.Profile.Query.Items;
 using FortLibrary.EpicResponses.Profile.Quests;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -54,30 +56,30 @@ namespace FortLibrary.MongoDB.Module
         public bool item_seen { get; set; } = false;
     }
 
-    public class Athena
+    public class Athena : IProfileRevisions
     {
         [BsonElement("Updated")]
         public DateTime Updated { get; set; } = DateTime.UtcNow;
 
         [BsonElement("items")]
         //[BsonIgnoreIfNull]
-        public Dictionary<string, AthenaItem> Items { get; set; }
+        public Dictionary<string, AthenaItem>? Items { get; set; }
 
 
         [BsonElement("loadouts_data")]
         //[JsonProperty("loadouts_data")] // we will now use loadouts for this.. this will be 
-        public Dictionary<string, SandboxLoadout> loadouts_data { get; set; }
+        public Dictionary<string, SandboxLoadout>? loadouts_data { get; set; }
 
 
         [BsonElement("loadouts")]
-        public string[] loadouts { get; set; } = new string[]
-        {
-            "sandbox_loadout"
-        };
+        public List<string>? loadouts { get; set; }
 
 
         [BsonElement("last_applied_loadout")]
         public string last_applied_loadout { get; set; } = "sandbox_loadout";
+
+        [BsonElement("random_loadout")]
+        public bool random_loadout { get; set; } = false; // idk how this owrks
 
         [BsonElement("battlestars")]
         public int BattleStars { get; set; } = 0;
@@ -97,7 +99,7 @@ namespace FortLibrary.MongoDB.Module
 
 
 
-    public class CommonCore
+    public class CommonCore : IProfileRevisions
     {
         [BsonElement("Updated")]
         public DateTime Updated { get; set; } = DateTime.UtcNow;
@@ -315,9 +317,15 @@ namespace FortLibrary.MongoDB.Module
         [BsonElement("special_items")]
         [JsonProperty("special_items")]
         public Dictionary<string, AthenaItem> special_items { get; set; } = new();
+
+        [BsonElement("purchased_bp_offers")]
+        [JsonProperty("purchased_bp_offers")]
+
+        public List<PurchasedBpOffsers> season_offers { get; set; } = new();
     }
 
-    public class Events
+
+        public class Events
     {
         [BsonElement("persistentScores")]
         [JsonProperty("persistentScores")]

--- a/FortLibrary/Shop/SavedData.cs
+++ b/FortLibrary/Shop/SavedData.cs
@@ -11,7 +11,7 @@ namespace FortLibrary.Shop
         public List<object> WeeklyFields { get; set; } = new List<object>();
         public List<object> DailyFields { get; set; } = new List<object>();
 
-        public int Season = 15;
+        public float Season = 15;
         public int WeeklyItems;
         public int DailyItems;
     }

--- a/FortLibrary/Shop/ShopBundles.cs
+++ b/FortLibrary/Shop/ShopBundles.cs
@@ -7,9 +7,16 @@ namespace FortLibrary.Shop
         public int BundleID { get; set; } = 0;
         public List<ShopBundlesItem> Daily { get; set; } = new List<ShopBundlesItem>();
         public List<ShopBundlesItem> Weekly { get; set; } = new List<ShopBundlesItem>();
+        public bool AllowAgain { get; set; } = false;
         public string LastShownDate { get; set; } = string.Empty;
     }
-     
+
+    public class FestiveShopItems
+    {
+        public List<ShopBundles> Bundles { get; set; } = new List<ShopBundles>();
+        public List<ShopItems> Normal { get; set; } = new List<ShopItems>();
+    }
+
     public class ShopItems
     {
         public string id { get; set; } = string.Empty;
@@ -23,7 +30,7 @@ namespace FortLibrary.Shop
         public List<AthenaItemVariants> variants { get; set; } = new List<AthenaItemVariants>();
         public string rarity { get; set; } = string.Empty;
         public string LastShownDate { get; set; } = string.Empty;
-        public int season { get; set; } = -1;
+        public float season { get; set; } = -1;
     }
 
     public class ShopBundlesItem
@@ -40,10 +47,11 @@ namespace FortLibrary.Shop
 
         public List<AthenaItemVariants> variants { get; set; } = new List<AthenaItemVariants>();
         public int singleprice { get; set; } = -1;
+        public int original_price { get; set; } = -1;
         public int price { get; set; } = -1;
         public string[] categories { get; set; } = new string[0];
 
-        public int season { get; set; } = -1;
+        public float season { get; set; } = -1;
     }
 
     public class Item

--- a/FortMatchmaker/src/App/Utilities/MongoDB/Helpers/CreateBlank.cs
+++ b/FortMatchmaker/src/App/Utilities/MongoDB/Helpers/CreateBlank.cs
@@ -19,7 +19,7 @@ namespace FortMatchmaker.src.App.Utilities.MongoDB.Helpers
             }
             catch
             {
-                Console.WriteLine($"Failed to create blank collection -> {collectionName}");
+                Logger.Error($"Failed to create blank collection -> {collectionName}", "MongoDB");
             }
         }
 

--- a/FortMatchmaker/src/App/Utilities/MongoDB/Helpers/Handlers.cs
+++ b/FortMatchmaker/src/App/Utilities/MongoDB/Helpers/Handlers.cs
@@ -64,7 +64,6 @@ namespace FortMatchmaker.src.App.Utilities.MongoDB.Helpers
                 var regexPattern = (BsonRegularExpression)null!;
                 if (!string.IsNullOrEmpty(CustomRegex))
                 {
-                    Console.WriteLine("T");
                     regexPattern = new BsonRegularExpression(CustomRegex, "i");
                 }
                 else

--- a/FortMatchmaker/src/App/Utilities/Startup.cs
+++ b/FortMatchmaker/src/App/Utilities/Startup.cs
@@ -76,7 +76,7 @@ namespace FortMatchmaker.src.App.Utilities
 
                             using (webSocket)
                             {
-                                Console.WriteLine("User Connected!");
+                                Logger.PlainLog("User Connected!");
                                 await NewConnection.Init(webSocket, context.Request, clientId);
                             }
                         }

--- a/FortMatchmaker/src/App/WebSockets/Helpers/Breathe.cs
+++ b/FortMatchmaker/src/App/WebSockets/Helpers/Breathe.cs
@@ -65,14 +65,14 @@ namespace FortMatchmaker.src.App.WebSockets.Helpers
                     foreach (var item in Region)
                     {
                         // we find the hoster that is hosting for that playlist and region
-                        Console.WriteLine(item.Region);
-                        Console.WriteLine(item.Playlist);
+                        Logger.PlainLog(item.Region);
+                        Logger.PlainLog(item.Playlist);
                         var Data = MatchmakerData.matchmakerData.FirstOrDefault(e => e.Region == item.Region && e.Playlist == item.Playlist);
 
                         if(Data != null && Data?.webSocket != null)
                         {
-                            Console.WriteLine($"FortHoster is connected with {MatchmakerData.SavedData.Values.Select(e => e.Region).ToList().Count}");
-                            Console.WriteLine(Saved.serverHotFixes.max_servers);
+                            Logger.Log($"FortHoster is connected with {MatchmakerData.SavedData.Values.Select(e => e.Region).ToList().Count}");
+                            Logger.PlainLog(Saved.serverHotFixes.max_servers);
                             
                             var ServerToUpdate = Saved.CurrentServers.FindAll(e => e.bServersLaunching == true && e.CurrentPlayers < e.MaxPlayers);
 
@@ -94,7 +94,7 @@ namespace FortMatchmaker.src.App.WebSockets.Helpers
                                         if (!item1.Value.Queuing) continue;
                                         if (item1.Value.Playlist != item.Playlist) continue;
                                         if (item1.Value.Region != item.Region) continue;
-                                        Console.WriteLine(item1.Value.Ticket);
+                                        Logger.PlainLog(item1.Value.Ticket);
                                         if (!string.IsNullOrEmpty(item1.Value.Ticket)) continue;
 
                                         item1.Value.Ticket = e.Session;
@@ -110,7 +110,7 @@ namespace FortMatchmaker.src.App.WebSockets.Helpers
 
                             if (ServersToJoin != null && ServersToJoin.Count > 0)
                             {
-                                Console.WriteLine("JOIN ABLE");
+                                Logger.Log("JOIN ABLE");
                                 foreach (var e in ServersToJoin)
                                 {
                                     string joinPayload = JsonConvert.SerializeObject(new
@@ -124,7 +124,7 @@ namespace FortMatchmaker.src.App.WebSockets.Helpers
                                         name = "Play"
                                     });
 
-                                    Console.WriteLine("2");
+                                    Logger.Log("2");
                                     foreach (var item1 in MatchmakerData.SavedData)
                                     {
                                         if (!item1.Value.Queuing) continue;
@@ -154,7 +154,7 @@ namespace FortMatchmaker.src.App.WebSockets.Helpers
                                         }
                                         catch (Exception ex)
                                         {
-                                            Console.WriteLine(ex.Message);
+                                            Logger.Error(ex.Message, "[FortniteGamer]");
                                         }
 
                                         item1.Key.Dispose();

--- a/FortMatchmaker/src/App/WebSockets/NewConnection.cs
+++ b/FortMatchmaker/src/App/WebSockets/NewConnection.cs
@@ -71,7 +71,7 @@ namespace FortMatchmaker.src.App.Websockets
                     else if(matchmakerTicket.IsHoster)
                     {
                         var Sigma = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-                        Console.WriteLine("Sigma: " + Encoding.UTF8.GetString(buffer, 0, Sigma.Count));
+                        Logger.PlainLog("Sigma: " + Encoding.UTF8.GetString(buffer, 0, Sigma.Count));
 
                         HosterJ hosterJ = JsonConvert.DeserializeObject<HosterJ>(Encoding.UTF8.GetString(buffer, 0, Sigma.Count))!;
 
@@ -92,7 +92,7 @@ namespace FortMatchmaker.src.App.Websockets
                     {
                         // ready?!?!
                         var Sigma = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-                        Console.WriteLine("Sigma: " + Encoding.UTF8.GetString(buffer, 0, Sigma.Count));
+                        Logger.PlainLog("Sigma: " + Encoding.UTF8.GetString(buffer, 0, Sigma.Count));
                         IDThing iDThing = JsonConvert.DeserializeObject<IDThing>(Encoding.UTF8.GetString(buffer, 0, Sigma.Count))!;
 
                         if(iDThing != null)
@@ -104,19 +104,19 @@ namespace FortMatchmaker.src.App.Websockets
                                 {
                                     
                                     server.bServersLaunching = true;
-                                    Console.WriteLine("SERVERS LAUNCHING");
+                                    Logger.Log("SERVERS LAUNCHING");
                                 }
                                 // only if dll doesnt use console
                                 else if(iDThing.Message == "JOINABLE")
                                 {
                                     server.bServersLaunching = false;
                                     server.bJoinable = true;
-                                    Console.WriteLine("SERVERS JOINABLE");
+                                    Logger.Log("SERVERS JOINABLE");
                                 }
                                 else if(iDThing.Message == "CLOSED")
                                 {
                                     Saved.CurrentServers.Remove(server);
-                                    Console.WriteLine("SERVER CLOSED");
+                                    Logger.Log("SERVER CLOSED");
                                 }
                             }
                         }
@@ -125,7 +125,7 @@ namespace FortMatchmaker.src.App.Websockets
                 }
 
 
-                Console.WriteLine(webSocket.State);
+                Logger.PlainLog(webSocket.State);
                 if (webSocket.State == WebSocketState.CloseReceived)
                 {
                     await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed Websocket please try to reconnect", CancellationToken.None);

--- a/TestFiles/AuraPrices.json
+++ b/TestFiles/AuraPrices.json
@@ -1,0 +1,730 @@
+{
+    "Outfit_Sm": {
+        "Cost": 9,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Outfit_Med": {
+        "Cost": 9,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Outfit_Lrg": {
+        "Cost": 9,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Style_Sm": {
+        "Cost": 8,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Style_Med": {
+        "Cost": 8,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Style_Lrg": {
+        "Cost": 8,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Spray_Sm": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Spray_Med": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Spray_Lrg": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Emoticon_Sm": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Emoticon_Med": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Emoticon_Lrg": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Banner_Sm": {
+        "Cost": 2,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Banner_Med": {
+        "Cost": 2,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Banner_Lrg": {
+        "Cost": 2,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "LoadingScreen_Sm": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "LoadingScreen_Med": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "LoadingScreen_Lrg": {
+        "Cost": 3,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Wrap_Sm": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Wrap_Med": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Wrap_Lrg": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Contrail_Sm": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Contrail_Med": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Contrail_Lrg": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Music_Sm": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Music_Med": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Music_Lrg": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "PickAxe_Sm": {
+        "Cost": 7,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "PickAxe_Med": {
+        "Cost": 7,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "PickAxe_Lrg": {
+        "Cost": 7,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Glider_Sm": {
+        "Cost": 6,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Glider_Med": {
+        "Cost": 6,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Glider_Lrg": {
+        "Cost": 6,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BackBling_Sm": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BackBling_Med": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BackBling_Lrg": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Emote_Sm": {
+        "Cost": 7,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Emote_Med": {
+        "Cost": 7,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Emote_Lrg": {
+        "Cost": 7,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Vbucks_Sm": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Vbucks_Med": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Vbucks_Lrg": {
+        "Cost": 5,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "SuperLevelStyles_T1": {
+        "Cost": 20,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "SuperLevelStyles_T2": {
+        "Cost": 20,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "SuperLevelStyles_T3": {
+        "Cost": 20,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "CustomizableStyle": {
+        "Cost": 10,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "InkStylePoint"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/Blueprints/Blutilities/ForArtists/TextureTools/PlaceholderTextureGenerator/Placeholder_Icon_Template.Placeholder_Icon_Template",
+            "SubPathString": ""
+        }
+    },
+    "Outfit_Included": {
+        "Cost": -1,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Variant_Pickaxe": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Variant_Glider": {
+        "Cost": 6,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "Variant_Backbling": {
+        "Cost": 4,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BonusReward_T1": {
+        "Cost": 10,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BonusReward_T2": {
+        "Cost": 15,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BonusReward_T3": {
+        "Cost": 20,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BonusReward_T4": {
+        "Cost": 25,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "BonusReward_T5": {
+        "Cost": 30,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "AthenaBattleStar"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/UI/Foundation/Textures/Icons/Items/T-FNBR-BattlePoints.T-FNBR-BattlePoints",
+            "SubPathString": ""
+        }
+    },
+    "CustomizableStyle_More": {
+        "Cost": 15,
+        "CurrencyItemTemplate": {
+            "PrimaryAssetType": {
+                "Name": "AccountResource"
+            },
+            "PrimaryAssetName": "InkStylePoint"
+        },
+        "CurrencyItem_IconPath": {
+            "AssetPathName": "/Game/Blueprints/Blutilities/ForArtists/TextureTools/PlaceholderTextureGenerator/Placeholder_Icon_Template.Placeholder_Icon_Template",
+            "SubPathString": ""
+        }
+    }
+}

--- a/TestFiles/Bat3l.js
+++ b/TestFiles/Bat3l.js
@@ -1,0 +1,117 @@
+const Battlepass = require("./Ch3Battlepass.json");
+const Prices = require("./AuraPrices.json")
+let ConvertedBP = [];
+Battlepass.forEach(element => {
+    if (element.Name.includes("AthenaSeasonItemEntryReward") && element.Properties != null) {
+        console.log(element.Properties.bIsFreePassReward)
+
+
+        if (element.Properties.BattlePassOffer != null) {
+
+            var RewardItem = element.Properties.BattlePassOffer.RewardItem
+            var templatePush = "";
+            let Variants = [];
+            if (RewardItem.ItemDefinition.AssetPathName
+                && RewardItem.ItemDefinition.AssetPathName.includes(".")) {
+                var test = RewardItem.ItemDefinition.AssetPathName.split(".")[1].toLowerCase();
+                console.log(RewardItem.ItemDefinition.AssetPathName);
+                //console.log(test);
+                //if(test.includes(""))
+                if (
+                    test.includes("eid") ||
+                    test.includes("emoji") ||
+                    test.includes("spid") ||
+                    test.includes("toy")
+                ) {
+                    templatePush = `AthenaDance:${test}`;
+                } else if (test.includes("vtid")) {
+                    templatePush = `CosmeticVariantToken:${test}`;
+                    //
+                    //
+                    if (element.Properties.BattlePassPreviewInfoList != null) {
+                        element.Properties.BattlePassPreviewInfoList.forEach(element2 => {
+                            if (element2.PreviewParams.VariantsToApply) {
+                                element2.PreviewParams.VariantsToApply.forEach(e => {
+                                    var SoMuchAura = e.VariantChannelTag.TagName.split(".");
+                                    var ChannelType = "";
+                                    if (SoMuchAura.length > 2)
+                                        ChannelType = SoMuchAura[3];
+
+                                    var ItemDef = "";
+                                    var LazyRipped = e.ItemVariantIsUsedFor.ObjectName;
+                                    var FirstPartii = LazyRipped.split("ItemDef")[0];
+                                    if (FirstPartii)
+                                        ItemDef = FirstPartii + ":" + LazyRipped.split("'")[1];
+
+                                    Variants.push({
+                                        connectedItem: ItemDef,
+                                        channel: ChannelType,
+                                        added: [
+                                            e.ActiveVariantTag.TagName.split(".")[3]
+                                        ],
+                                    })
+                                })
+                            }
+                        });
+                    }
+
+                    //Variants
+                    //
+                } else if (test.includes("athenabattlestar")) {
+                    templatePush = `FortPersistentResourceItem:AthenaBattleStar`;
+                } else if (test.includes("mtxgiveaway")) {
+                    templatePush = `Currency:${test}`;
+                } else if (test.includes("athenaseasonalxp")) {
+                    templatePush = `AccountResource:${test}`;
+                } else if (test.includes("glider")) {
+                    templatePush = `AthenaGlider:${test}`;
+                } else if (test.includes("cid")) {
+                    templatePush = `AthenaCharacter:${test}`;
+                } else if (
+                    test.includes("athenaseason") ||
+                    test.includes("athenanextseason")
+                ) {
+                    // idk
+                    templatePush = `Token:${test}`;
+                } else if (test.includes("wrap")) {
+                    templatePush = `AthenaItemWrap:${test}`;
+                } else if (test.includes("pickaxe")) {
+                    templatePush = `AthenaPickaxe:${test}`;
+                } else if (test.includes("lsid")) {
+                    templatePush = `AthenaLoadingScreen:${test}`;
+                } else if (test.includes("trails")) {
+                    templatePush = `AthenaSkyDiveContrail:${test}`;
+                } else if (test.includes("musicpack")) {
+                    templatePush = `AthenaMusicPack:${test}`;
+                } else if (test.includes("bid") || test.includes("petcarrier")) {
+                    templatePush = `AthenaBackpack:${test}`;
+                }
+                else if (RewardItem.ItemDefinition.AssetPathName.includes("BannerIcons")) {
+                    templatePush = `HomebaseBannerIcon:${test}`;
+                }
+                //QuestSchedules
+                //HomebaseBannerIcon
+                //else if(test.includes("")){
+                //  templatePush = `HomebaseBannerIcon:${test}`
+                //}
+
+                console.log(templatePush);
+            }
+
+            var StuffToPush = {
+                bRequireBp: element.Properties.bIsFreePassReward ? false : true,
+                OfferId: element.Properties.BattlePassOffer.OfferId,
+                templateId: templatePush,
+                Price: Prices[element.Properties.BattlePassOffer.OfferPriceRowHandle.RowName].Cost,
+                Quantity: RewardItem.Quantity != null ? RewardItem.Quantity : 1
+            }
+
+            if(Variants.length > 0)
+                StuffToPush.new_variants = Variants
+
+            ConvertedBP.push(StuffToPush)
+        }
+    }
+});
+
+console.log(JSON.stringify(ConvertedBP));

--- a/TestFiles/BattlePass.json
+++ b/TestFiles/BattlePass.json
@@ -1,723 +1,23984 @@
 [
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_068_S14EndEvent.MusicPack_068_S14EndEvent",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 100,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_266_Cosmos.LSID_266_Cosmos",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_310_SpaceFighter.Wrap_310_SpaceFighter",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S15_SpaceFighter.Emoji_S15_SpaceFighter",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_236_S15_SpaceFighter.SPID_236_S15_SpaceFighter",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Items/BannerIcons/BRS15_SpaceFighter.BRS15_SpaceFighter",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_506_FlapjackWranglerMale.Pickaxe_ID_506_FlapjackWranglerMale",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_255_FlapjackWranglerMale.Glider_ID_255_FlapjackWranglerMale",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_264_Flapjack.LSID_264_Flapjack",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_232_S15_Shapeshifter.SPID_232_S15_Shapeshifter",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 100,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_105_FutureSamurai.Trails_ID_105_FutureSamurai",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S15_FutureSamurai.Emoji_S15_FutureSamurai",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_070_StarPowerRemix.MusicPack_070_StarPowerRemix",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_110_Lexa.Trails_ID_110_Lexa",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/BattlepassS15/Items/Tokens/Athena_S15_NoBattleBundleOption_Token.Athena_S15_NoBattleBundleOption_Token",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::GiftboxHiddenReward",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_657_LexaFemale.BID_657_LexaFemale",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Items/BannerIcons/BRS15_AncientGladiator.BRS15_AncientGladiator",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_305_AncientGladiator.Wrap_305_AncientGladiator",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/EID_AncientGladiator.EID_AncientGladiator",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 1,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": []
-  },
-  {
-    "Rewards": [
-      {
-        "ItemDefinition": {
-          "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
-          "SubPathString": ""
-        },
-        "TemplateId": "",
-        "Quantity": 100,
-        "RewardGiftBox": {
-          "GiftBoxToUse": {
-            "AssetPathName": "None",
-            "SubPathString": ""
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
           },
-          "GiftBoxFormatData": []
-        },
-        "IsChaseReward": false,
-        "RewardType": "EAthenaRewardItemType::Normal",
-        "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal"
-      }
-    ]
-  },
-  {
-    "Rewards": []
-  }
-]
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": []
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 5,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": [
+              {
+                "ItemDefinition": {
+                  "AssetPathName": "None",
+                  "SubPathString": ""
+                },
+                "TemplateId": "",
+                "Quantity": 0,
+                "RewardGiftBox": {
+                  "GiftBoxToUse": {
+                    "AssetPathName": "None",
+                    "SubPathString": ""
+                  },
+                  "GiftBoxFormatData": []
+                },
+                "IsChaseReward": false,
+                "RewardType": "EAthenaRewardItemType::Normal",
+                "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+                "PreviewVariantSets": [],
+                "AdditionalPreviewVariants": []
+              }
+            ]
+          },
+          {
+            "Rewards": []
+          }
+        ]

--- a/TestFiles/Ch3Battlepass.json
+++ b/TestFiles/Ch3Battlepass.json
@@ -1,0 +1,11930 @@
+[
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_0",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "9CC86E4644EC0926E8671889EB4A1B61",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_130_ExoSuit.Trails_ID_130_ExoSuit",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Contrail_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Trails_ID_Exosuit.MI_Trails_ID_Exosuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_130_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_130_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_130_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_130_ExoSuit.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_1",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "2E4B9D3E411F2CA6F7F7E8BAAD9348FF",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.BID_915_ExoSuitFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BackBling_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_ExoSuit.MI_BID_ExoSuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.ProfileLoadout"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ProfileLoadout"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.ProfileLoadout"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_10",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "0A1304E4407F355DD8E4859563AB92B4",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_100",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "C8661B5147016C2D9905D9911589975C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_364_BuffLlama_ColorB.VTID_A_364_BuffLlama_ColorB",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_386_BuffLlama_Pickaxe_StyleB.VTID_A_386_BuffLlama_Pickaxe_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_344_BuffLlama_Backbling_ColorB.VTID_A_344_BuffLlama_Backbling_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T4"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_BuffLlama_ColorC.MI_CID_BuffLlama_ColorC",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_364_BuffLlama_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_364_BuffLlama_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_665_BuffLlamaMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_386_BuffLlama_Pickaxe_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_386_BuffLlama_Pickaxe_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_665_BuffLlamaMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_848_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_344_BuffLlama_Backbling_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_344_BuffLlama_Backbling_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_848_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_101",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "EAA7870D4ECD8DEB6DDB92A9E5472A7D",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/BannerIcons/BRS19_Parallel.BRS19_Parallel",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T1"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Banner_Parallel.MI_Banner_Parallel",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_Parallel'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_Parallel.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_Parallel'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_Parallel.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_102",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 4,
+      "BattlePassOffer": {
+        "OfferId": "8EF0946F4194DBB34DAA10A8BB482B61",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_362_LoneWolf_ColorC.VTID_A_362_LoneWolf_ColorC",
+            "SubPathString": ""
+          },
+          "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+          "PreviewVariantSets": [
+            {
+              "VariantsToApply": [
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Parts"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Stage5"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Progressive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Stage3"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_347_LoneWolf_Backbling_ColorC.VTID_A_347_LoneWolf_Backbling_ColorC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_392_LoneWolf_Pickaxe_StyleC.VTID_A_392_LoneWolf_Pickaxe_StyleC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_399_LoneWolf_Glider_StyleC.VTID_A_399_LoneWolf_Glider_StyleC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T5"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_3",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf_ColorC.MI_CID_LoneWolf_ColorC",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_362_LoneWolf_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_362_LoneWolf_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_362_LoneWolf_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_362_LoneWolf_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1",
+                  "Cosmetics.Variant.Property.Stage3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4",
+                  "Cosmetics.Variant.Property.Stage5"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage5"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_911_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_347_LoneWolf_Backbling_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_347_LoneWolf_Backbling_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_911_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_715_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_392_LoneWolf_Pickaxe_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_392_LoneWolf_Pickaxe_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_715_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_330_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_399_LoneWolf_Glider_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_399_LoneWolf_Glider_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_330_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_103",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "08EA19EF4E2DEEA5C81765A4BC1817D3",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_423_Motorcyclist.Wrap_423_Motorcyclist",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T2"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Wrap_Motorcyclist.MI_Wrap_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_423_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_423_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_423_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_423_Motorcyclist.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_104",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "B803AF59482FBEDA39EF1B99369BC814",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_368_Motorcyclist_ColorB.VTID_A_368_Motorcyclist_ColorB",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_350_Motorcyclist_Backbling_ColorB.VTID_A_350_Motorcyclist_Backbling_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_393_Motorcyclist_Pickaxe_StyleB.VTID_A_393_Motorcyclist_Pickaxe_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_400_Motorcyclist_Glider_StyleB.VTID_A_400_Motorcyclist_Glider_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T3"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Motorcyclist_ColorB.MI_CID_Motorcyclist_ColorB",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_368_Motorcyclist_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_368_Motorcyclist_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat4"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_350_Motorcyclist_Backbling_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_350_Motorcyclist_Backbling_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1",
+                  "Cosmetics.Variant.Property.Emissive3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_393_Motorcyclist_Pickaxe_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_393_Motorcyclist_Pickaxe_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_400_Motorcyclist_Glider_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_400_Motorcyclist_Glider_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_105",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "4D6851DE4CA806629378D19DB2AE436F",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_378_Exosuit_StyleB.VTID_A_378_Exosuit_StyleB",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T2"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Exosuit_Head.MI_CID_Exosuit_Head",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_378_Exosuit_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_378_Exosuit_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.000"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_106",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "8DBA118B43BB459870B6B79EB8FDA110",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_367_Gumball_ColorC.VTID_A_367_Gumball_ColorC",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_349_Gumball_Backbling_ColorC.VTID_A_349_Gumball_Backbling_ColorC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_389_Gumball_Pickaxe_StyleC.VTID_A_389_Gumball_Pickaxe_StyleC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_397_Gumball_Glider_StyleC.VTID_A_397_Gumball_Glider_StyleC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T4"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Gumball_ColorC.MI_CID_Gumball_ColorC",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_367_Gumball_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_367_Gumball_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_912_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_349_Gumball_Backbling_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_349_Gumball_Backbling_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_912_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_713_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_389_Gumball_Pickaxe_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_389_Gumball_Pickaxe_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_713_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_329_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_397_Gumball_Glider_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_397_Gumball_Glider_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_329_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_107",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 4,
+      "BattlePassOffer": {
+        "OfferId": "E1E695AD45EF4763E1AF23A7558B3883",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_385_ParallelComic_StyleC.VTID_A_385_ParallelComic_StyleC",
+            "SubPathString": ""
+          },
+          "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot"
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_353_ParallelComic_Backbling_ColorC.VTID_A_353_ParallelComic_Backbling_ColorC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T5"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_3",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_ParallelComic_StyleC.MI_CID_ParallelComic_StyleC",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_385_ParallelComic_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_385_ParallelComic_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_916_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_353_ParallelComic_Backbling_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_353_ParallelComic_Backbling_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_916_ParallelComicMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_108",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "0197AF634360EE4CCF7DFAB6B491DFDB",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_376_IslandNomad_ColorB.VTID_A_376_IslandNomad_ColorB",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_390_IslandNomad_Pickaxe_StyleB.VTID_A_390_IslandNomad_Pickaxe_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_351_IslandNomad_Backbling_ColorB.VTID_A_351_IslandNomad_Backbling_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T3"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_IslandNomad_ColorB.MI_CID_IslandNomad_ColorB",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_376_IslandNomad_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_376_IslandNomad_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_714_IslandNomadFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_714_IslandNomadFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_390_IslandNomad_Pickaxe_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_390_IslandNomad_Pickaxe_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_714_IslandNomadFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_714_IslandNomadFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_914_IslandNomadFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_914_IslandNomadFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_351_IslandNomad_Backbling_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_351_IslandNomad_Backbling_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_914_IslandNomadFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_914_IslandNomadFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_109",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "864A43D94612F2E8A8C55CA420235E9A",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_369_Motorcyclist_StyleB.VTID_A_369_Motorcyclist_StyleB",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_419_Motorcyclist_Backbling_EmissiveD.VTID_A_419_Motorcyclist_Backbling_EmissiveD",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_407_Motorcyclist_Pickaxe_ColorD.VTID_A_407_Motorcyclist_Pickaxe_ColorD",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_410_Motorcyclist_Glider_ColorD.VTID_A_410_Motorcyclist_Glider_ColorD",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BonusReward_T1"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Motorcyclist_Helmet.MI_CID_Motorcyclist_Helmet",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_369_Motorcyclist_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_369_Motorcyclist_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_419_Motorcyclist_Backbling_EmissiveD'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_419_Motorcyclist_Backbling_EmissiveD.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_407_Motorcyclist_Pickaxe_ColorD'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_407_Motorcyclist_Pickaxe_ColorD.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_410_Motorcyclist_Glider_ColorD'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_410_Motorcyclist_Glider_ColorD.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_11",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "6F1D037A4C27BA30FEF184848F19B590",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.Pickaxe_ID_715_LoneWolfMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "PickAxe_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Pickaxe_ID_LoneWolf.MI_Pickaxe_ID_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_715_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_715_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_715_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_110",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 4,
+      "BattlePassOffer": {
+        "OfferId": "F6FC91854069B4C346AAB0977DE9EB28",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_438_LoneWolf_SuperLevelT1.VTID_A_438_LoneWolf_SuperLevelT1",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T1"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_3",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf_SuperLevelT1.MI_CID_LoneWolf_SuperLevelT1",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_438_LoneWolf_SuperLevelT1'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_438_LoneWolf_SuperLevelT1.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat4"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage5"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_111",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "3F66C13A4CED5F6956A39A89C04DDA85",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_432_ParallelComic_SuperLevelT1.VTID_A_432_ParallelComic_SuperLevelT1",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T1"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_ParallelComic_SuperLevelT1.MI_CID_ParallelComic_SuperLevelT1",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_432_ParallelComic_SuperLevelT1'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_432_ParallelComic_SuperLevelT1.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_112",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "6D72B9DD4673AFD1438F27AB731481F0",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_426_BuffLlama_SuperLevelT1.VTID_A_426_BuffLlama_SuperLevelT1",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T1"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_BuffLlama_SuperLevelT1.MI_CID_BuffLlama_SuperLevelT1",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_426_BuffLlama_SuperLevelT1'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_426_BuffLlama_SuperLevelT1.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_113",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "0D96CB8A4A0374063D1BFF8F47718256",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_435_Motorcyclist_SuperLevelT1.VTID_A_435_Motorcyclist_SuperLevelT1",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T1"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Motorcyclist_SuperLevelT1.MI_CID_Motorcyclist_SuperLevelT1",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_435_Motorcyclist_SuperLevelT1'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_435_Motorcyclist_SuperLevelT1.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat5"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_114",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "623289C14BF47F81DCDF00B2EC6E179B",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_429_Exosuit_SuperLevelT1.VTID_A_429_Exosuit_SuperLevelT1",
+            "SubPathString": ""
+          },
+          "PreviewVariantSets": [
+            {
+              "VariantsToApply": [
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Progressive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Stage3"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Material"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Emissive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Emissive2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Particle"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Particle2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Mesh"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat4"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T1"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Exosuit_SuperLevelT1.MI_CID_Exosuit_SuperLevelT1",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_429_Exosuit_SuperLevelT1'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_429_Exosuit_SuperLevelT1.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.001"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_429_Exosuit_SuperLevelT1'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_429_Exosuit_SuperLevelT1.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.001"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1",
+                  "Cosmetics.Variant.Property.Stage3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1",
+                  "Cosmetics.Variant.Property.Mat2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1",
+                  "Cosmetics.Variant.Property.Emissive2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3",
+                  "Cosmetics.Variant.Property.Mat4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_115",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "237C2D8A43BB74D00C0D5AA9011ADE5D",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_433_ParallelComic_SuperLevelT2.VTID_A_433_ParallelComic_SuperLevelT2",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T2"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_ParallelComic_SuperLevelT2.MI_CID_ParallelComic_SuperLevelT2",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_433_ParallelComic_SuperLevelT2'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_433_ParallelComic_SuperLevelT2.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage5"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_116",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "B2DCC1D34EDCC42B1D2D13869CE5F687",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_436_Motorcyclist_SuperLevelT2.VTID_A_436_Motorcyclist_SuperLevelT2",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T2"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Motorcyclist_SuperLevelT2.MI_CID_Motorcyclist_SuperLevelT2",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_436_Motorcyclist_SuperLevelT2'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_436_Motorcyclist_SuperLevelT2.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat6"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_117",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 4,
+      "BattlePassOffer": {
+        "OfferId": "D3B596ED459EAA81B71EB2959F950E4B",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_430_Exosuit_SuperLevelT2.VTID_A_430_Exosuit_SuperLevelT2",
+            "SubPathString": ""
+          },
+          "PreviewVariantSets": [
+            {
+              "VariantsToApply": [
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Progressive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Stage3"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Material"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Emissive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Emissive2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Particle"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Particle2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Mesh"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat4"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T2"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_3",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Exosuit_SuperLevelT2.MI_CID_Exosuit_SuperLevelT2",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_430_Exosuit_SuperLevelT2'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_430_Exosuit_SuperLevelT2.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.002"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_430_Exosuit_SuperLevelT2'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_430_Exosuit_SuperLevelT2.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.002"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1",
+                  "Cosmetics.Variant.Property.Stage3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1",
+                  "Cosmetics.Variant.Property.Mat2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1",
+                  "Cosmetics.Variant.Property.Emissive2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3",
+                  "Cosmetics.Variant.Property.Mat4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_118",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "57C1C46047BD2B9D81DE8E8A29FDF0C8",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_427_BuffLlama_SuperLevelT2.VTID_A_427_BuffLlama_SuperLevelT2",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T2"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_BuffLlama_SuperLevelT2.MI_CID_BuffLlama_SuperLevelT2",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_427_BuffLlama_SuperLevelT2'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_427_BuffLlama_SuperLevelT2.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat5"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_119",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "13C2FE524CD9C59EEFD845910135567A",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_439_LoneWolf_SuperLevelT2.VTID_A_439_LoneWolf_SuperLevelT2",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T2"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf_SuperLevelT2.MI_CID_LoneWolf_SuperLevelT2",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_439_LoneWolf_SuperLevelT2'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_439_LoneWolf_SuperLevelT2.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat5"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage5"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_12",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "7914F7C14D69F18142D78B93847DD8BB",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_395_ExoSuitAlt.LSID_395_ExoSuitAlt",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_Exosuit.MI_LSID_Exosuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_395_ExoSuitAlt'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_395_ExoSuitAlt.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_395_ExoSuitAlt'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_395_ExoSuitAlt.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_120",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "65233FD3452CD5984AFCED83539F2860",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_440_LoneWolf_SuperLevelT3.VTID_A_440_LoneWolf_SuperLevelT3",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T3"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf_SuperLevelT3.MI_CID_LoneWolf_SuperLevelT3",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_440_LoneWolf_SuperLevelT3'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_440_LoneWolf_SuperLevelT3.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat6"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage5"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_121",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "FE2E755449F1D4A497C3088A93D0D8AF",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_428_BuffLlama_SuperLevelT3.VTID_A_428_BuffLlama_SuperLevelT3",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T3"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_BuffLlama_SuperLevelT3.MI_CID_BuffLlama_SuperLevelT3",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_428_BuffLlama_SuperLevelT3'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_428_BuffLlama_SuperLevelT3.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat6"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_122",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "48C4A38B4FEA269C2FCF7AAE679D4622",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_437_Motorcyclist_SuperLevelT3.VTID_A_437_Motorcyclist_SuperLevelT3",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T3"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Motorcyclist_SuperLevelT3.MI_CID_Motorcyclist_SuperLevelT3",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_437_Motorcyclist_SuperLevelT3'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_437_Motorcyclist_SuperLevelT3.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat7"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_123",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "98AC795D4F7EF3CE0A6991AF5CCADCFA",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_431_Exosuit_SuperLevelT3.VTID_A_431_Exosuit_SuperLevelT3",
+            "SubPathString": ""
+          },
+          "PreviewVariantSets": [
+            {
+              "VariantsToApply": [
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Progressive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Stage3"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Material"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Emissive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Emissive2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Particle"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Particle2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Mesh"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat4"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T3"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Exosuit_SuperLevelT3.MI_CID_Exosuit_SuperLevelT3",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_431_Exosuit_SuperLevelT3'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_431_Exosuit_SuperLevelT3.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.003"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_431_Exosuit_SuperLevelT3'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_431_Exosuit_SuperLevelT3.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.003"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1",
+                  "Cosmetics.Variant.Property.Stage3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1",
+                  "Cosmetics.Variant.Property.Mat2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1",
+                  "Cosmetics.Variant.Property.Emissive2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3",
+                  "Cosmetics.Variant.Property.Mat4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_124",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 4,
+      "BattlePassOffer": {
+        "OfferId": "E1A6CB5741D41E9CDD2ADCBA52DFFB09",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_434_ParallelComic_SuperLevelT3.VTID_A_434_ParallelComic_SuperLevelT3",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "SuperLevelStyles_T3"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_3",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_ParallelComic_SuperLevelT3.MI_CID_ParallelComic_SuperLevelT3",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_434_ParallelComic_SuperLevelT3'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_434_ParallelComic_SuperLevelT3.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage6"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_13",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "207BC6AB4A8722EAFA07CFB0C1D00104",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/EID_LoneWolf.EID_LoneWolf",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emote_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_EID_LoneWolf.MI_EID_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_LoneWolf.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_14",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "F5D4D5F9444A6A13A0EB6C9D38741A6E",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_425_Exosuit.Wrap_425_Exosuit",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Wrap_Exosuit.MI_Wrap_Exosuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_425_Exosuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_425_Exosuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_425_Exosuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_425_Exosuit.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_15",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "E7CD6E6041B64E5594F01A82F7791F9C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.Glider_ID_330_LoneWolfMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Glider_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Glider_LoneWolf.MI_Glider_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_330_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_330_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_330_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_16",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "870EEBFD4D067D8337979B94B7FE6E96",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_17",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "E6C86D3E465820600CF4F99D089E85AB",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_342_LoneWolfHero.SPID_342_LoneWolfHero",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Spray_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_SPID_LoneWolf.MI_SPID_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_342_LoneWolfHero'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_342_LoneWolfHero.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_342_LoneWolfHero'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_342_LoneWolfHero.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_18",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.CID_A_287_Athena_Commando_M_LoneWolf",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "83BEC81846AA1F6456B76A821E891E58",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_361_LoneWolf_ColorB.VTID_A_361_LoneWolf_ColorB",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_346_LoneWolf_Backbling_ColorB.VTID_A_346_LoneWolf_Backbling_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_391_LoneWolf_Pickaxe_StyleB.VTID_A_391_LoneWolf_Pickaxe_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_398_LoneWolf_Glider_StyleB.VTID_A_398_LoneWolf_Glider_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Style_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf_ColorB.MI_CID_LoneWolf_ColorB",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "loneWolfStyle",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_361_LoneWolf_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_361_LoneWolf_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_911_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_346_LoneWolf_Backbling_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_346_LoneWolf_Backbling_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_911_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_715_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_391_LoneWolf_Pickaxe_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_391_LoneWolf_Pickaxe_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_715_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_715_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_330_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_398_LoneWolf_Glider_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_398_LoneWolf_Glider_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_330_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_330_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_19",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "7981F39E493BDD05D0E53D904C05BC87",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.BID_911_LoneWolfMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BackBling_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_LoneWolf.MI_BID_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_911_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_911_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_911_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_911_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_2",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "8566D265454FFB78F09DA4BEA72898AF",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_336_ExoSuit.SPID_336_ExoSuit",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Spray_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_SPID_Exosuit.MI_SPID_Exosuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_336_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_336_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_336_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_336_ExoSuit.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_20",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "F7BBEDB644E157FC303A778E66ACEDBE",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_420_LoneWolf.Wrap_420_LoneWolf",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Wrap_LoneWolf.MI_Wrap_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_420_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_420_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_420_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_420_LoneWolf.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_21",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.BID_915_ExoSuitFemale",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "3F2FCBBF4B693141C79C00AE3100F5F5",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_402_Exosuit_Backbling_StyleB.VTID_A_402_Exosuit_Backbling_StyleB",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_403_Exosuit_Backbling_StyleC.VTID_A_403_Exosuit_Backbling_StyleC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Med"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_ExoSuit_StyleB.MI_BID_ExoSuit_StyleB",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_402_Exosuit_Backbling_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_402_Exosuit_Backbling_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.ProfileLoadout"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ProfileLoadout"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.ProfileLoadout"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_403_Exosuit_Backbling_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_403_Exosuit_Backbling_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.ProfileLoadout"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_915_ExoSuitFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_915_ExoSuitFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ProfileLoadout"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.ProfileLoadout"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_22",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "2FC9E0184C541CDBE21947806CE9617D",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_LoneWolf.Emoji_S19_LoneWolf",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emoticon_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Emoji_S19_Lonewolf.MI_Emoji_S19_Lonewolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_LoneWolf.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_23",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "112EA58C415D5D8F64B658B14663B5DB",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/EID_Lifted.EID_Lifted",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emote_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_EID_Lifted.MI_EID_Lifted",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_Lifted'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_Lifted.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_Lifted'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_Lifted.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_24",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "4AF68E2A48949BFED69195BF6D4A98D7",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.Trails_ID_133_LoneWolfMale",
+            "SubPathString": ""
+          },
+          "AdditionalPreviewVariants": [
+            {
+              "OwnedVariantTags": [],
+              "ItemVariantIsUsedFor": null,
+              "CustomData": "",
+              "VariantChannelTag": {
+                "TagName": "Cosmetics.Variant.Channel.Particle"
+              },
+              "ActiveVariantTag": {
+                "TagName": "Cosmetics.Variant.Property.Particle2"
+              }
+            },
+            {
+              "OwnedVariantTags": [],
+              "ItemVariantIsUsedFor": null,
+              "CustomData": "",
+              "VariantChannelTag": {
+                "TagName": "Cosmetics.Variant.Channel.Particle"
+              },
+              "ActiveVariantTag": {
+                "TagName": "Cosmetics.Variant.Property.Particle3"
+              }
+            }
+          ]
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Contrail_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Trails_ID_LoneWolf.MI_Trails_ID_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle2",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle2",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle2",
+                  "Cosmetics.Variant.Property.Particle3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_133_LoneWolfMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_133_LoneWolfMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_25",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "4C46F35C41C713C95F00AF8214513056",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.BID_848_BuffLlama",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BackBling_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_BuffLlama.MI_BID_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_848_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_848_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_848_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_26",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "BattlePassOffer": {
+        "OfferId": "943BA1894DB4BA8F0A85EB9EEA58D241",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.CID_A_288_Athena_Commando_M_BuffLlama",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Outfit_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_BuffLlama.MI_CID_BuffLlama",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "buffLlama",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_27",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "FA94555648326BFC23FF8D91A66EB420",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_381_BuffLlama.LSID_381_BuffLlama",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_BuffLlama.MI_LSID_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_381_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_381_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_381_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_381_BuffLlama.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_28",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "257483914A4857BA03CC728C0E0095B4",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_29",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "2EB6F58041F2F98EB181F492B8CDFC2B",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/BannerIcons/BRS19_BuffLlama.BRS19_BuffLlama",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Banner_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Banner_BuffLlama.MI_Banner_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_BuffLlama'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_BuffLlama'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_BuffLlama.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_3",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "D998ABBC499B6A297B42859565134FF7",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.CID_A_292_Athena_Commando_F_ExoSuit",
+            "SubPathString": ""
+          },
+          "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+          "PreviewVariantSets": [
+            {
+              "VariantsToApply": [
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Progressive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Stage3"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Material"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Emissive"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Emissive2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Particle"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Particle2"
+                  }
+                },
+                {
+                  "VariantChannelTag": {
+                    "TagName": "Cosmetics.Variant.Channel.Mesh"
+                  },
+                  "ActiveVariantTag": {
+                    "TagName": "Cosmetics.Variant.Property.Mat4"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Outfit_Included"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Exosuit.MI_CID_Exosuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.000"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Color.000"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Color.000"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_292_Athena_Commando_F_ExoSuit'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_292_Athena_Commando_F_ExoSuit.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Mesh"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_30",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "28726E814E6CD3ACB9904FA436E3708C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_BuffLlama.Emoji_S19_BuffLlama",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emoticon_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Emoji_S19_BuffLlama.MI_Emoji_S19_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_BuffLlama.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_31",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "045F2D144F78FE4597ADEE95831362A6",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/EID_Doodling.EID_Doodling",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emote_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_EID_Doodling.MI_EID_Doodling",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_Doodling'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_Doodling.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_Doodling'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_Doodling.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_32",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "E67CE0544376384C6BEE9292B90E1C1F",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_335_BuffLlama.SPID_335_BuffLlama",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Spray_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_SPID_BuffLlama.MI_SPID_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_335_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_335_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_335_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_335_BuffLlama.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_33",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "548109944808033E2ECCB590B4B1C0C6",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_34",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "E69CBF7E459A47E16612EF9266927717",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_310_BuffLlamaMale.Glider_ID_310_BuffLlamaMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Glider_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Glider_BuffLlama.MI_Glider_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_310_BuffLlamaMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_310_BuffLlamaMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_310_BuffLlamaMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_310_BuffLlamaMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_35",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "4652125E4D5F0BC1C15267BF061E9D40",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_389_Collage.LSID_389_Collage",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_Collage.MI_LSID_Collage",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_389_Collage'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_389_Collage.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_389_Collage'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_389_Collage.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_36",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "2C3EEFEE46054D1339BAE2887D6074F2",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_37",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "4CF915F74258575FA434DABBBBD0B5B8",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.Pickaxe_ID_665_BuffLlamaMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "PickAxe_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Pickaxe_ID_BuffLlama.MI_Pickaxe_ID_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_665_BuffLlamaMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_665_BuffLlamaMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_665_BuffLlamaMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_38",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.CID_A_288_Athena_Commando_M_BuffLlama",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "637BC2EF4A9BC64DB9E620AABD3643C9",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_365_BuffLlama_ColorC.VTID_A_365_BuffLlama_ColorC",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_345_BuffLlama_Backbling_ColorC.VTID_A_345_BuffLlama_Backbling_ColorC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_387_BuffLlama_Pickaxe_StyleC.VTID_A_387_BuffLlama_Pickaxe_StyleC",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Style_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_BuffLlama_ColorB.MI_CID_BuffLlama_ColorB",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "buffLlamaStyle",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_365_BuffLlama_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_365_BuffLlama_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_288_Athena_Commando_M_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_288_Athena_Commando_M_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_848_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_345_BuffLlama_Backbling_ColorC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_345_BuffLlama_Backbling_ColorC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_848_BuffLlama'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_848_BuffLlama.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_665_BuffLlamaMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_387_BuffLlama_Pickaxe_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_387_BuffLlama_Pickaxe_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_665_BuffLlamaMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_665_BuffLlamaMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_39",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "10B651E54CA86FB1B20757AE5315FB46",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_421_BuffLlama.Wrap_421_BuffLlama",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Wrap_BuffLlama.MI_Wrap_BuffLlama",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_421_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_421_BuffLlama.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_421_BuffLlama'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_421_BuffLlama.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_4",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "1882CE704594B349EEB2B28433548CE6",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_328_ExoSuitFemale.Glider_ID_328_ExoSuitFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Glider_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Glider_ExoSuit.MI_Glider_ExoSuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_328_ExoSuitFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_328_ExoSuitFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_328_ExoSuitFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_328_ExoSuitFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_40",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "FE141A8A4A77AB6C8175F4814AE88FDD",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_114_IslandNomad.MusicPack_114_IslandNomad",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Music_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_MusicPack_IslandNomad.MI_MusicPack_IslandNomad",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaMusicPackItemDefinition'MusicPack_114_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_114_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaMusicPackItemDefinition'MusicPack_114_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_114_IslandNomad.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_41",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "F992FD4546ED5ABA2D8E898E4C80C50A",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_714_IslandNomadFemale.Pickaxe_ID_714_IslandNomadFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "PickAxe_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Pickaxe_ID_IslandNomad.MI_Pickaxe_ID_IslandNomad",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_714_IslandNomadFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_714_IslandNomadFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_714_IslandNomadFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_714_IslandNomadFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_714_IslandNomadFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_714_IslandNomadFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_42",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "BattlePassOffer": {
+        "OfferId": "FF0083734612D2F9049F0D85EA5DA52C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.CID_A_291_Athena_Commando_F_IslandNomad",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_403_IslandNomad_MaskB.VTID_A_403_IslandNomad_MaskB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Outfit_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_IslandNomad.MI_CID_IslandNomad",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "islandNomad",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_403_IslandNomad_MaskB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_403_IslandNomad_MaskB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_43",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "4DB64617486D4506C7934D9591EFCE22",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_44",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "42B2FD134AC584553D7EE78C6EEDFE73",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_383_IslandNomad.LSID_383_IslandNomad",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_IslandNomad.MI_LSID_IslandNomad",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_383_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_383_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_383_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_383_IslandNomad.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_45",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "B9027AF446324C58982CEF820E03BCCC",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_424_IslandNomad.Wrap_424_IslandNomad",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Wrap_IslandNomad.MI_Wrap_IslandNomad",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_424_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_424_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_424_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_424_IslandNomad.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_46",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "729F3B93433F92E2F56555A2B1761FD7",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_338_IslandNomad.SPID_338_IslandNomad",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Spray_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_SPID_IslandNomad.MI_SPID_IslandNomad",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_338_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_338_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_338_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_338_IslandNomad.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_47",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.CID_A_287_Athena_Commando_M_LoneWolf",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "5523CB104A1400D1AFE841AECF09F532",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_359_LoneWolf_StyleB.VTID_A_359_LoneWolf_StyleB",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Style_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf_StyleB.MI_CID_LoneWolf_StyleB",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_359_LoneWolf_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_359_LoneWolf_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat11"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_48",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "15805A7841705341DCDBF5822B8AFAC4",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/BannerIcons/BRS19_IslandNomad.BRS19_IslandNomad",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Banner_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Banner_IslandNomad.MI_Banner_IslandNomad",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_IslandNomad'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_IslandNomad'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_IslandNomad.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_49",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "65AAE67D49738B6A35074794219D5BE8",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_914_IslandNomadFemale.BID_914_IslandNomadFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BackBling_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_IslandNomad.MI_BID_IslandNomad",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_914_IslandNomadFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_914_IslandNomadFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_914_IslandNomadFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_914_IslandNomadFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_914_IslandNomadFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_914_IslandNomadFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_5",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "68DFF99B43FAF85BEF46C59A36A01F66",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_712_ExoSuitFemale1H.Pickaxe_ID_712_ExoSuitFemale1H",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "PickAxe_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Pickaxe_ID_Exosuit.MI_Pickaxe_ID_Exosuit",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_712_ExoSuitFemale1H'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_712_ExoSuitFemale1H.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_712_ExoSuitFemale1H'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_712_ExoSuitFemale1H.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_50",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "02DFA4B2465BB21F49A996A44838D9E4",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_51",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "40FB45804C52DA3B55C807B3003CC838",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_52",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "66846AB842510F91328DEFA125DBAB8E",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_131_Gumball.Trails_ID_131_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Contrail_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Trails_ID_Gumball.MI_Trails_ID_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_131_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_131_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_131_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_131_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_53",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "CDE35D824959E744326DF08C24333F0B",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/EID_Chuckle.EID_Chuckle",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emote_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_EID_Chuckle.MI_EID_Chuckle",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_Chuckle'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_Chuckle.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_Chuckle'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_Chuckle.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_54",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "A6C966A04833C8A8208AE1A651A606F4",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_337_Gumball.SPID_337_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Spray_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_SPID_Gumball.MI_SPID_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_337_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_337_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_337_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_337_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_55",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "F144441E459E4A49F02DB1A29270430F",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.BID_912_GumballMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BackBling_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_Gumball.MI_BID_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_912_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_912_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_912_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_56",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "BattlePassOffer": {
+        "OfferId": "C431B5BF418AE90D18C091B646F57B01",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.CID_A_289_Athena_Commando_M_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Outfit_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Gumball.MI_CID_Gumball",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "gumball",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_57",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.CID_A_291_Athena_Commando_F_IslandNomad",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "5BD80C3641AB3E766181A59253BB00AE",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_377_IslandNomad_StyleB.VTID_A_377_IslandNomad_StyleB",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Sm"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_IslandNomad_StyleB.MI_CID_IslandNomad_StyleB",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_377_IslandNomad_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_377_IslandNomad_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_291_Athena_Commando_F_IslandNomad'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_291_Athena_Commando_F_IslandNomad.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_58",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "B7A440CF4C5D219204015DAB088090E7",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_392_IceLegends.LSID_392_IceLegends",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_IceLegends.MI_LSID_IceLegends",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_392_IceLegends'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_392_IceLegends.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_392_IceLegends'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_392_IceLegends.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_59",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "1230AA744A4E49655CA022AC827A38B1",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.Pickaxe_ID_713_GumballMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "PickAxe_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Pickaxe_ID_Gumball.MI_Pickaxe_ID_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_713_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_713_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_713_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_6",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "D554258C41E2FEA456840BB0AD433FF8",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.CID_A_287_Athena_Commando_M_LoneWolf",
+            "SubPathString": ""
+          },
+          "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot"
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Outfit_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf.MI_CID_LoneWolf",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "loneWolf",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat11"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_60",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "9367F1E44A21D4762E5B20B71125AA10",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/BannerIcons/BRS19_Gumball.BRS19_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Banner_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Banner_Gumball.MI_Banner_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_Gumball'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_Gumball'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_61",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "80F957CF47D54198BE5DA1A1E7DE453C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_116_Gumball.MusicPack_116_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Music_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_MusicPack_Gumball.MI_MusicPack_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaMusicPackItemDefinition'MusicPack_116_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_116_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaMusicPackItemDefinition'MusicPack_116_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_116_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_62",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.CID_A_289_Athena_Commando_M_Gumball",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "769CFCE54E11EF60163F67AED3F2EFF7",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_366_Gumball_ColorB.VTID_A_366_Gumball_ColorB",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_348_Gumball_Backbling_ColorB.VTID_A_348_Gumball_Backbling_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_388_Gumball_Pickaxe_StyleB.VTID_A_388_Gumball_Pickaxe_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_396_Gumball_Glider_StyleB.VTID_A_396_Gumball_Glider_StyleB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Style_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Gumball_ColorB.MI_CID_Gumball_ColorB",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "gumballStyle",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_366_Gumball_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_366_Gumball_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_912_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_348_Gumball_Backbling_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_348_Gumball_Backbling_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_912_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_912_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_713_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_388_Gumball_Pickaxe_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_388_Gumball_Pickaxe_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_713_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_713_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_329_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_396_Gumball_Glider_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_396_Gumball_Glider_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_329_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_63",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "572518784C2384114452319C1FFCFD47",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_Gumball.Emoji_S19_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emoticon_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Emoji_S19_Gumball.MI_Emoji_S19_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_64",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "401E03904C0E52552C82B5B9B003F8D8",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_65",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "593EE46D4ABAD09E2BC453856B5460A6",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_422_Gumball.Wrap_422_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Wrap_Gumball.MI_Wrap_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_422_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_422_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_422_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_422_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_66",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "631F83424B737BEF3E6FBD943BC288FE",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_382_Gumball.LSID_382_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_Gumball.MI_LSID_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_382_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_382_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_382_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_382_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_67",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.CID_A_289_Athena_Commando_M_Gumball",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "E80E39C1477CCEC9D01EB491C49D876D",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/ItemAccessTokens/IATID_023_Emote_Gumball.IATID_023_Emote_Gumball",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emote_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_EID_Gumball.MI_EID_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_Gumball.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortItemAccessTokenType'IATID_023_Emote_Gumball'",
+              "ObjectPath": "/Game/Athena/Items/ItemAccessTokens/IATID_023_Emote_Gumball.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_289_Athena_Commando_M_Gumball'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_289_Athena_Commando_M_Gumball.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_68",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "7D4286354E58AA589C70A3AE3D83501B",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_340_Motorcyclist.SPID_340_Motorcyclist",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Spray_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_SPID_Motorcyclist.MI_SPID_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_340_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_340_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_340_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_340_Motorcyclist.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_69",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "0FF97127417CE4B32F3B6596BA6BAB4C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.Glider_ID_329_GumballMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Glider_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Glider_Gumball.MI_Glider_Gumball",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_329_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_329_GumballMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_329_GumballMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_329_GumballMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_7",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "C060D0C946D827401F97CD99F6E8E305",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_70",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "7F2D6276447A7B009C7D88A688D9338A",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_Motorcyclist.Emoji_S19_Motorcyclist",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emoticon_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Emoji_S19_Motorcyclist.MI_Emoji_S19_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_Motorcyclist.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_71",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "C2F784054C575B82CCB458BF6C276CC4",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_72",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.CID_A_287_Athena_Commando_M_LoneWolf",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "F4363D5341645A18539D48AEDEDF0EF9",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_360_LoneWolf_StyleC.VTID_A_360_LoneWolf_StyleC",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_363_LoneWolf_StyleD.VTID_A_363_LoneWolf_StyleD",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Style_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_LoneWolf_StyleC.MI_CID_LoneWolf_StyleC",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_360_LoneWolf_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_360_LoneWolf_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat11"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage4"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_363_LoneWolf_StyleD'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_363_LoneWolf_StyleD.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat11"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat11"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage4"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_287_Athena_Commando_M_LoneWolf'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_287_Athena_Commando_M_LoneWolf.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage5"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_73",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "6B3D785B4C782A24BA4FF2B7F72FBAF5",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_74",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "0F449EE0499652B3A6B2DFB86CED618C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.BID_913_MotorcyclistFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BackBling_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_Motorcyclist.MI_BID_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_75",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "701E619A40B6A10B130C5A9B274DDDF3",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.Pickaxe_ID_716_MotorcyclistFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "PickAxe_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Pickaxe_ID_Motorcyclist.MI_Pickaxe_ID_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_76",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "F10B23E8461C8B0F657CFFB0E4DABA3C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.Glider_ID_331_MotorcyclistFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Glider_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Glider_Motorcyclist.MI_Glider_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_77",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "BattlePassOffer": {
+        "OfferId": "58512666416FE30709D78096BA1D743C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.CID_A_290_Athena_Commando_F_Motorcyclist",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Outfit_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Motorcyclist.MI_CID_Motorcyclist",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "motorcyclist",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_78",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "6D860AB64A03DF71C5249AAA3FAF8812",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_385_Motorcyclist.LSID_385_Motorcyclist",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_Motorcyclist.MI_LSID_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_385_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_385_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_385_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_385_Motorcyclist.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_79",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "C4F313444C04F0C47F9FA08176E57998",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_134_MotorcyclistFemale.Trails_ID_134_MotorcyclistFemale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Contrail_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Trails_ID_Motorcyclist.MI_Trails_ID_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_134_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_134_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_134_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_134_MotorcyclistFemale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_8",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "F31428EB45229CB488D247AB24F5886A",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/BannerIcons/BRS19_LoneWolf.BRS19_LoneWolf",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Banner_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Banner_LoneWolf.MI_Banner_LoneWolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_LoneWolf'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_LoneWolf'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_LoneWolf.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_80",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "028CD65848E068A96207A9AC937162D6",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/BannerIcons/BRS19_ParallelSymbol.BRS19_ParallelSymbol",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Banner_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Banner_ParallelComic.MI_Banner_ParallelComic",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_ParallelSymbol'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_ParallelSymbol.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortHomebaseBannerIconItemDefinition'BRS19_ParallelSymbol'",
+              "ObjectPath": "/Game/Items/BannerIcons/BRS19_ParallelSymbol.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_81",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.CID_A_290_Athena_Commando_F_Motorcyclist",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "0E089CE246353E666499209D75284167",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_370_Motorcyclist_StyleC.VTID_A_370_Motorcyclist_StyleC",
+            "SubPathString": ""
+          }
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_417_Motorcyclist_Backbling_EmissiveB.VTID_A_417_Motorcyclist_Backbling_EmissiveB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_405_Motorcyclist_Pickaxe_ColorB.VTID_A_405_Motorcyclist_Pickaxe_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          },
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_408_Motorcyclist_Glider_ColorB.VTID_A_408_Motorcyclist_Glider_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Style_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_Motorcyclist_StyleB.MI_CID_Motorcyclist_StyleB",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_370_Motorcyclist_StyleC'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_370_Motorcyclist_StyleC.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat3"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.ClothingColor"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat3"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Parts"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1",
+                  "Cosmetics.Variant.Property.Mat2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1",
+                  "Cosmetics.Variant.Property.Emissive2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive2"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1",
+                  "Cosmetics.Variant.Property.Particle2"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_290_Athena_Commando_F_Motorcyclist'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_290_Athena_Commando_F_Motorcyclist.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_417_Motorcyclist_Backbling_EmissiveB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_417_Motorcyclist_Backbling_EmissiveB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Emissive1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_913_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_913_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Emissive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Emissive2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_405_Motorcyclist_Pickaxe_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_405_Motorcyclist_Pickaxe_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_716_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_716_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_408_Motorcyclist_Glider_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_408_Motorcyclist_Glider_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Mat1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Material"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Mat1"
+                }
+              },
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Particle1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaGliderItemDefinition'Glider_ID_331_MotorcyclistFemale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_331_MotorcyclistFemale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Particle"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Particle2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_82",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "0C362396435CF988FD1FBE98B0D6FBA5",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_115_Motorcyclist.MusicPack_115_Motorcyclist",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Music_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_MusicPack_Motorcyclist.MI_MusicPack_Motorcyclist",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaMusicPackItemDefinition'MusicPack_115_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_115_Motorcyclist.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaMusicPackItemDefinition'MusicPack_115_Motorcyclist'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/MusicPacks/MusicPack_115_Motorcyclist.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_83",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "833BBC5849F742838A848DBBD5AACFE3",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_135_ParallelComic.Trails_ID_135_ParallelComic",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Contrail_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Trails_ID_ParallelComic.MI_Trails_ID_ParallelComic",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_135_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_135_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSkyDiveContrailItemDefinition'Trails_ID_135_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Contrails/Trails_ID_135_ParallelComic.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_84",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "BattlePassOffer": {
+        "OfferId": "647229A941580CF26C9617B74C4D385C",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.CID_A_293_Athena_Commando_M_ParallelComic",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Outfit_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_ParallelComic.MI_CID_ParallelComic",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "spiderman",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_85",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "AB20EBB14288B5D698C1B3B98AAE5C29",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.BID_916_ParallelComicMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "BackBling_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_BID_ParallelComic.MI_BID_ParallelComic",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_916_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_916_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_916_ParallelComicMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_86",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "F65D3C044E7487AD4A12D481A3BC1792",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_87",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "DB72AADE421385606A8C0AA12AD250E9",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_ParallelSling.Emoji_S19_ParallelSling",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emoticon_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Emoji_S19_ParallelSwing.MI_Emoji_S19_ParallelSwing",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_ParallelSling'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_ParallelSling.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_ParallelSling'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_ParallelSling.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_88",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "B837DA8B4263BE49924B29A9B1D83B91",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/EID_YouThere.EID_YouThere",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emote_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_EID_YouThere.MI_EID_YouThere",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_YouThere'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_YouThere.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_YouThere'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_YouThere.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_89",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "48FF873642F1379749B59BA10001A05F",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_387_Island.LSID_387_Island",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_Island.MI_LSID_Island",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_387_Island'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_387_Island.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_387_Island'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_387_Island.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_9",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "BC5FF1BB4183D236EB7725A5E35C67D9",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_384_LoneWolf.LSID_384_LoneWolf",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_Lonewolf.MI_LSID_Lonewolf",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_384_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_384_LoneWolf.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_384_LoneWolf'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_384_LoneWolf.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_90",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "822AEB7F442C8550C3AF259E749DF0C7",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_ParallelSenses.Emoji_S19_ParallelSenses",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emoticon_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Emoji_S19_ParallelSenses.MI_Emoji_S19_ParallelSenses",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_ParallelSenses'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_ParallelSenses.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaEmojiItemDefinition'Emoji_S19_ParallelSenses'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/Emoji/Emoji_S19_ParallelSenses.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_91",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "64F9DE4B4510BDDD664099A14DB5E65B",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_92",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "3F5FFD0348E0076EF9B41FB3155B97BE",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_386_Parallel.LSID_386_Parallel",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "LoadingScreen_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_LSID_Parallel.MI_LSID_Parallel",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_386_Parallel'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_386_Parallel.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaLoadingScreenItemDefinition'LSID_386_Parallel'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/LoadingScreens/LSID_386_Parallel.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_93",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RewardsNeededForUnlock": 9,
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.CID_A_293_Athena_Commando_M_ParallelComic",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "74BEBC604629EBA7F86A38842B549295",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_384_ParallelComic_StyleB.VTID_A_384_ParallelComic_StyleB",
+            "SubPathString": ""
+          },
+          "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot"
+        },
+        "ChainedRewardItemList": [
+          {
+            "ItemDefinition": {
+              "AssetPathName": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_352_ParallelComic_Backbling_ColorB.VTID_A_352_ParallelComic_Backbling_ColorB",
+              "SubPathString": ""
+            },
+            "TemplateId": "",
+            "Quantity": 1,
+            "RewardGiftBox": {
+              "GiftBoxToUse": {
+                "AssetPathName": "None",
+                "SubPathString": ""
+              },
+              "GiftBoxFormatData": []
+            },
+            "IsChaseReward": false,
+            "RewardType": "EAthenaRewardItemType::Normal",
+            "RewardVisualImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "PreviewVariantSets": [],
+            "AdditionalPreviewVariants": []
+          }
+        ],
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Style_Lrg"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_3_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_CID_ParallelComic_StyleB.MI_CID_ParallelComic_StyleB",
+        "SubPathString": ""
+      },
+      "bIsPrmTracked": true,
+      "PRMOwnedParamName": "spidermanStyle",
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_384_ParallelComic_StyleB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_384_ParallelComic_StyleB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::CrazyHot",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        },
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaBackpackItemDefinition'BID_916_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortVariantTokenType'VTID_A_352_ParallelComic_Backbling_ColorB'",
+              "ObjectPath": "/Game/Athena/Items/CosmeticVariantTokens/VTID_A_352_ParallelComic_Backbling_ColorB.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaBackpackItemDefinition'BID_916_ParallelComicMale'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Backpacks/BID_916_ParallelComicMale.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage2"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_94",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "57FF9FD446B8B23667DC9D9B04A5DA03",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Items/Currency/MtxGiveaway.MtxGiveaway",
+            "SubPathString": ""
+          },
+          "Quantity": 100
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Vbucks_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassBase/UI/BP_ItemTile/M_Ui_BPItemTile_VBucks.M_Ui_BPItemTile_VBucks",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortCurrencyItemDefinition'MtxGiveaway'",
+              "ObjectPath": "/Game/Items/Currency/MtxGiveaway.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 100,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_95",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "6D9C1EBE46704F3CCF79AFB5928906FC",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Sprays/SPID_341_Parallel.SPID_341_Parallel",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Spray_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_SPID_ParallelComic.MI_SPID_ParallelComic",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_341_Parallel'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_341_Parallel.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaSprayItemDefinition'SPID_341_Parallel'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Sprays/SPID_341_Parallel.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_96",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "A027912E446D790B4439C797EFA90F3F",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_718_ParallelComicMale.Pickaxe_ID_718_ParallelComicMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "PickAxe_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Pickaxe_ID_ParallelComic.MI_Pickaxe_ID_ParallelComic",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_718_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_718_ParallelComicMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaPickaxeItemDefinition'Pickaxe_ID_718_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Pickaxes/Pickaxe_ID_718_ParallelComicMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_97",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "BattlePassOffer": {
+        "OfferId": "55948AF6469BB0833B3F7CB9F20E7E5E",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_332_ParallelComicMale.Glider_ID_332_ParallelComicMale",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Glider_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_1",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Glider_ParallelComic.MI_Glider_ParallelComic",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_332_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_332_ParallelComicMale.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaGliderItemDefinition'Glider_ID_332_ParallelComicMale'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Gliders/Glider_ID_332_ParallelComicMale.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_98",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "RequiredItems": [
+        {
+          "AssetPathName": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.CID_A_293_Athena_Commando_M_ParallelComic",
+          "SubPathString": ""
+        }
+      ],
+      "BattlePassOffer": {
+        "OfferId": "0B16464F4137F7D41006BA9DE59B28CD",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/ItemAccessTokens/IATID_024_Emote_ParallelComic.IATID_024_Emote_ParallelComic",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Emote_Med"
+        }
+      },
+      "TileSize": "EPageItemTileSize::Size_2_x_2",
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_EID_ParallelComic.MI_EID_ParallelComic",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaDanceItemDefinition'EID_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/Dances/EID_ParallelComic.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "FortItemAccessTokenType'IATID_024_Emote_ParallelComic'",
+              "ObjectPath": "/Game/Athena/Items/ItemAccessTokens/IATID_024_Emote_ParallelComic.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": [
+              {
+                "OwnedVariantTags": [
+                  "Cosmetics.Variant.Property.Stage1"
+                ],
+                "ItemVariantIsUsedFor": {
+                  "ObjectName": "AthenaCharacterItemDefinition'CID_A_293_Athena_Commando_M_ParallelComic'",
+                  "ObjectPath": "/Game/Athena/Items/Cosmetics/Characters/CID_A_293_Athena_Commando_M_ParallelComic.0"
+                },
+                "CustomData": "",
+                "VariantChannelTag": {
+                  "TagName": "Cosmetics.Variant.Channel.Progressive"
+                },
+                "ActiveVariantTag": {
+                  "TagName": "Cosmetics.Variant.Property.Stage1"
+                }
+              }
+            ]
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "Type": "AthenaSeasonItemEntryReward",
+    "Name": "AthenaSeasonItemEntryReward_99",
+    "Outer": "AthenaSeasonItemData_BattleStar_0",
+    "Class": "UScriptClass'AthenaSeasonItemEntryReward'",
+    "Flags": "RF_Public | RF_Transactional | RF_WasLoaded | RF_LoadCompleted",
+    "Properties": {
+      "bIsFreePassReward": true,
+      "BattlePassOffer": {
+        "OfferId": "8D3640624141C86E4BA80C915FC02436",
+        "RewardItem": {
+          "ItemDefinition": {
+            "AssetPathName": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_426_Parallel.Wrap_426_Parallel",
+            "SubPathString": ""
+          }
+        },
+        "OfferPriceRowHandle": {
+          "DataTable": {
+            "ObjectName": "DataTable'S19_BattlePassOffer_Prices'",
+            "ObjectPath": "/BattlePassS19/DataTables/S19_BattlePassOffer_Prices.0"
+          },
+          "RowName": "Wrap_Sm"
+        }
+      },
+      "CustomButtonIcon": {
+        "AssetPathName": "/BattlePassS19/UI/UI_Art/MI_BPTile/MI_Wrap_Parallel.MI_Wrap_Parallel",
+        "SubPathString": ""
+      },
+      "BattlePassPreviewInfoList": [
+        {
+          "PreviewParams": {
+            "ItemDefWeWishToView": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_426_Parallel'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_426_Parallel.0"
+            },
+            "OriginalItemDef": {
+              "ObjectName": "AthenaItemWrapDefinition'Wrap_426_Parallel'",
+              "ObjectPath": "/Game/Athena/Items/Cosmetics/ItemWraps/Wrap_426_Parallel.0"
+            },
+            "RewardImportanceType": "EAthenaRewardVisualImportanceType::Normal",
+            "Quantity": 1,
+            "VariantsToApply": []
+          },
+          "PreviewIcon": {
+            "AssetPathName": "None",
+            "SubPathString": ""
+          },
+          "CycleTimeOverride": 0.0
+        }
+      ]
+    }
+  }
+]

--- a/TestFiles/Data.json
+++ b/TestFiles/Data.json
@@ -1,3602 +1,8102 @@
 {
   "100": {
-    "XpPerLevel": 50000,
-    "UntilLevel": 101
+    "XpPerLevel": 75000,
+    "UntilLevel": 101,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "101": {
-    "XpPerLevel": 50250,
-    "UntilLevel": 102
+    "XpPerLevel": 75000,
+    "UntilLevel": 102,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "102": {
-    "XpPerLevel": 50500,
-    "UntilLevel": 103
+    "XpPerLevel": 75000,
+    "UntilLevel": 103,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "103": {
-    "XpPerLevel": 50500,
-    "UntilLevel": 104
+    "XpPerLevel": 75000,
+    "UntilLevel": 104,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "104": {
-    "XpPerLevel": 50750,
-    "UntilLevel": 105
+    "XpPerLevel": 75000,
+    "UntilLevel": 105,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "105": {
-    "XpPerLevel": 51000,
-    "UntilLevel": 106
+    "XpPerLevel": 75000,
+    "UntilLevel": 106,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "106": {
-    "XpPerLevel": 51250,
-    "UntilLevel": 107
+    "XpPerLevel": 75000,
+    "UntilLevel": 107,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "107": {
-    "XpPerLevel": 51500,
-    "UntilLevel": 108
+    "XpPerLevel": 75000,
+    "UntilLevel": 108,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "108": {
-    "XpPerLevel": 51750,
-    "UntilLevel": 109
+    "XpPerLevel": 75000,
+    "UntilLevel": 109,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "109": {
-    "XpPerLevel": 52000,
-    "UntilLevel": 110
+    "XpPerLevel": 75000,
+    "UntilLevel": 110,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "110": {
-    "XpPerLevel": 52000,
-    "UntilLevel": 111
+    "XpPerLevel": 75000,
+    "UntilLevel": 111,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "111": {
-    "XpPerLevel": 52250,
-    "UntilLevel": 112
+    "XpPerLevel": 75000,
+    "UntilLevel": 112,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "112": {
-    "XpPerLevel": 52500,
-    "UntilLevel": 113
+    "XpPerLevel": 75000,
+    "UntilLevel": 113,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "113": {
-    "XpPerLevel": 52750,
-    "UntilLevel": 114
+    "XpPerLevel": 75000,
+    "UntilLevel": 114,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "114": {
-    "XpPerLevel": 53000,
-    "UntilLevel": 115
+    "XpPerLevel": 75000,
+    "UntilLevel": 115,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "115": {
-    "XpPerLevel": 53250,
-    "UntilLevel": 116
+    "XpPerLevel": 75000,
+    "UntilLevel": 116,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "116": {
-    "XpPerLevel": 53500,
-    "UntilLevel": 117
+    "XpPerLevel": 75000,
+    "UntilLevel": 117,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "117": {
-    "XpPerLevel": 53500,
-    "UntilLevel": 118
+    "XpPerLevel": 75000,
+    "UntilLevel": 118,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "118": {
-    "XpPerLevel": 53750,
-    "UntilLevel": 119
+    "XpPerLevel": 75000,
+    "UntilLevel": 119,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "119": {
-    "XpPerLevel": 54000,
-    "UntilLevel": 120
+    "XpPerLevel": 75000,
+    "UntilLevel": 120,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "120": {
-    "XpPerLevel": 54250,
-    "UntilLevel": 121
+    "XpPerLevel": 75000,
+    "UntilLevel": 121,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "121": {
-    "XpPerLevel": 54500,
-    "UntilLevel": 122
+    "XpPerLevel": 75000,
+    "UntilLevel": 122,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "122": {
-    "XpPerLevel": 54750,
-    "UntilLevel": 123
+    "XpPerLevel": 75000,
+    "UntilLevel": 123,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "123": {
-    "XpPerLevel": 55000,
-    "UntilLevel": 124
+    "XpPerLevel": 75000,
+    "UntilLevel": 124,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "124": {
-    "XpPerLevel": 55250,
-    "UntilLevel": 125
+    "XpPerLevel": 75000,
+    "UntilLevel": 125,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "125": {
-    "XpPerLevel": 55500,
-    "UntilLevel": 126
+    "XpPerLevel": 75000,
+    "UntilLevel": 126,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "126": {
-    "XpPerLevel": 55750,
-    "UntilLevel": 127
+    "XpPerLevel": 75000,
+    "UntilLevel": 127,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "127": {
-    "XpPerLevel": 55750,
-    "UntilLevel": 128
+    "XpPerLevel": 75000,
+    "UntilLevel": 128,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "128": {
-    "XpPerLevel": 56000,
-    "UntilLevel": 129
+    "XpPerLevel": 75000,
+    "UntilLevel": 129,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "129": {
-    "XpPerLevel": 56250,
-    "UntilLevel": 130
+    "XpPerLevel": 75000,
+    "UntilLevel": 130,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "130": {
-    "XpPerLevel": 56500,
-    "UntilLevel": 131
+    "XpPerLevel": 75000,
+    "UntilLevel": 131,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "131": {
-    "XpPerLevel": 56750,
-    "UntilLevel": 132
+    "XpPerLevel": 75000,
+    "UntilLevel": 132,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "132": {
-    "XpPerLevel": 57000,
-    "UntilLevel": 133
+    "XpPerLevel": 75000,
+    "UntilLevel": 133,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "133": {
-    "XpPerLevel": 57250,
-    "UntilLevel": 134
+    "XpPerLevel": 75000,
+    "UntilLevel": 134,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "134": {
-    "XpPerLevel": 57500,
-    "UntilLevel": 135
+    "XpPerLevel": 75000,
+    "UntilLevel": 135,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "135": {
-    "XpPerLevel": 57750,
-    "UntilLevel": 136
+    "XpPerLevel": 75000,
+    "UntilLevel": 136,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "136": {
-    "XpPerLevel": 58000,
-    "UntilLevel": 137
+    "XpPerLevel": 75000,
+    "UntilLevel": 137,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "137": {
-    "XpPerLevel": 58250,
-    "UntilLevel": 138
+    "XpPerLevel": 75000,
+    "UntilLevel": 138,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "138": {
-    "XpPerLevel": 58500,
-    "UntilLevel": 139
+    "XpPerLevel": 75000,
+    "UntilLevel": 139,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "139": {
-    "XpPerLevel": 58750,
-    "UntilLevel": 140
+    "XpPerLevel": 75000,
+    "UntilLevel": 140,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "140": {
-    "XpPerLevel": 59000,
-    "UntilLevel": 141
+    "XpPerLevel": 75000,
+    "UntilLevel": 141,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "141": {
-    "XpPerLevel": 59250,
-    "UntilLevel": 142
+    "XpPerLevel": 75000,
+    "UntilLevel": 142,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "142": {
-    "XpPerLevel": 59500,
-    "UntilLevel": 143
+    "XpPerLevel": 75000,
+    "UntilLevel": 143,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "143": {
-    "XpPerLevel": 59750,
-    "UntilLevel": 144
+    "XpPerLevel": 75000,
+    "UntilLevel": 144,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "144": {
-    "XpPerLevel": 60000,
-    "UntilLevel": 145
+    "XpPerLevel": 75000,
+    "UntilLevel": 145,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "145": {
-    "XpPerLevel": 60250,
-    "UntilLevel": 146
+    "XpPerLevel": 75000,
+    "UntilLevel": 146,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "146": {
-    "XpPerLevel": 60500,
-    "UntilLevel": 147
+    "XpPerLevel": 75000,
+    "UntilLevel": 147,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "147": {
-    "XpPerLevel": 60750,
-    "UntilLevel": 148
+    "XpPerLevel": 75000,
+    "UntilLevel": 148,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "148": {
-    "XpPerLevel": 61000,
-    "UntilLevel": 149
+    "XpPerLevel": 75000,
+    "UntilLevel": 149,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "149": {
-    "XpPerLevel": 61250,
-    "UntilLevel": 150
+    "XpPerLevel": 75000,
+    "UntilLevel": 150,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "150": {
-    "XpPerLevel": 61500,
-    "UntilLevel": 151
+    "XpPerLevel": 75000,
+    "UntilLevel": 151,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "151": {
-    "XpPerLevel": 61750,
-    "UntilLevel": 152
+    "XpPerLevel": 75000,
+    "UntilLevel": 152,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "152": {
-    "XpPerLevel": 62000,
-    "UntilLevel": 153
+    "XpPerLevel": 75000,
+    "UntilLevel": 153,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "153": {
-    "XpPerLevel": 62250,
-    "UntilLevel": 154
+    "XpPerLevel": 75000,
+    "UntilLevel": 154,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "154": {
-    "XpPerLevel": 62500,
-    "UntilLevel": 155
+    "XpPerLevel": 75000,
+    "UntilLevel": 155,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "155": {
-    "XpPerLevel": 62750,
-    "UntilLevel": 156
+    "XpPerLevel": 75000,
+    "UntilLevel": 156,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "156": {
-    "XpPerLevel": 63000,
-    "UntilLevel": 157
+    "XpPerLevel": 75000,
+    "UntilLevel": 157,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "157": {
-    "XpPerLevel": 63250,
-    "UntilLevel": 158
+    "XpPerLevel": 75000,
+    "UntilLevel": 158,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "158": {
-    "XpPerLevel": 63500,
-    "UntilLevel": 159
+    "XpPerLevel": 75000,
+    "UntilLevel": 159,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "159": {
-    "XpPerLevel": 63750,
-    "UntilLevel": 160
+    "XpPerLevel": 75000,
+    "UntilLevel": 160,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "160": {
-    "XpPerLevel": 64000,
-    "UntilLevel": 161
+    "XpPerLevel": 75000,
+    "UntilLevel": 161,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "161": {
-    "XpPerLevel": 64250,
-    "UntilLevel": 162
+    "XpPerLevel": 75000,
+    "UntilLevel": 162,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "162": {
-    "XpPerLevel": 64500,
-    "UntilLevel": 163
+    "XpPerLevel": 75000,
+    "UntilLevel": 163,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "163": {
-    "XpPerLevel": 64750,
-    "UntilLevel": 164
+    "XpPerLevel": 75000,
+    "UntilLevel": 164,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "164": {
-    "XpPerLevel": 65000,
-    "UntilLevel": 165
+    "XpPerLevel": 75000,
+    "UntilLevel": 165,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "165": {
-    "XpPerLevel": 65250,
-    "UntilLevel": 166
+    "XpPerLevel": 75000,
+    "UntilLevel": 166,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "166": {
-    "XpPerLevel": 65500,
-    "UntilLevel": 167
+    "XpPerLevel": 75000,
+    "UntilLevel": 167,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "167": {
-    "XpPerLevel": 65750,
-    "UntilLevel": 168
+    "XpPerLevel": 75000,
+    "UntilLevel": 168,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "168": {
-    "XpPerLevel": 66000,
-    "UntilLevel": 169
+    "XpPerLevel": 75000,
+    "UntilLevel": 169,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "169": {
-    "XpPerLevel": 66250,
-    "UntilLevel": 170
+    "XpPerLevel": 75000,
+    "UntilLevel": 170,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "170": {
-    "XpPerLevel": 66750,
-    "UntilLevel": 171
+    "XpPerLevel": 75000,
+    "UntilLevel": 171,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "171": {
-    "XpPerLevel": 67000,
-    "UntilLevel": 172
+    "XpPerLevel": 75000,
+    "UntilLevel": 172,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "172": {
-    "XpPerLevel": 67250,
-    "UntilLevel": 173
+    "XpPerLevel": 75000,
+    "UntilLevel": 173,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "173": {
-    "XpPerLevel": 67500,
-    "UntilLevel": 174
+    "XpPerLevel": 75000,
+    "UntilLevel": 174,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "174": {
-    "XpPerLevel": 67750,
-    "UntilLevel": 175
+    "XpPerLevel": 75000,
+    "UntilLevel": 175,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "175": {
-    "XpPerLevel": 68000,
-    "UntilLevel": 176
+    "XpPerLevel": 75000,
+    "UntilLevel": 176,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "176": {
-    "XpPerLevel": 68250,
-    "UntilLevel": 177
+    "XpPerLevel": 75000,
+    "UntilLevel": 177,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "177": {
-    "XpPerLevel": 68500,
-    "UntilLevel": 178
+    "XpPerLevel": 75000,
+    "UntilLevel": 178,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "178": {
-    "XpPerLevel": 68750,
-    "UntilLevel": 179
+    "XpPerLevel": 75000,
+    "UntilLevel": 179,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "179": {
-    "XpPerLevel": 69250,
-    "UntilLevel": 180
+    "XpPerLevel": 75000,
+    "UntilLevel": 180,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "180": {
-    "XpPerLevel": 69500,
-    "UntilLevel": 181
+    "XpPerLevel": 75000,
+    "UntilLevel": 181,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "181": {
-    "XpPerLevel": 69750,
-    "UntilLevel": 182
+    "XpPerLevel": 75000,
+    "UntilLevel": 182,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "182": {
-    "XpPerLevel": 70000,
-    "UntilLevel": 183
+    "XpPerLevel": 75000,
+    "UntilLevel": 183,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "183": {
-    "XpPerLevel": 70250,
-    "UntilLevel": 184
+    "XpPerLevel": 75000,
+    "UntilLevel": 184,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "184": {
-    "XpPerLevel": 70500,
-    "UntilLevel": 185
+    "XpPerLevel": 75000,
+    "UntilLevel": 185,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "185": {
-    "XpPerLevel": 70750,
-    "UntilLevel": 186
+    "XpPerLevel": 75000,
+    "UntilLevel": 186,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "186": {
-    "XpPerLevel": 71250,
-    "UntilLevel": 187
+    "XpPerLevel": 75000,
+    "UntilLevel": 187,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "187": {
-    "XpPerLevel": 71500,
-    "UntilLevel": 188
+    "XpPerLevel": 75000,
+    "UntilLevel": 188,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "188": {
-    "XpPerLevel": 71750,
-    "UntilLevel": 189
+    "XpPerLevel": 75000,
+    "UntilLevel": 189,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "189": {
-    "XpPerLevel": 72000,
-    "UntilLevel": 190
+    "XpPerLevel": 75000,
+    "UntilLevel": 190,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "190": {
-    "XpPerLevel": 72250,
-    "UntilLevel": 191
+    "XpPerLevel": 75000,
+    "UntilLevel": 191,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "191": {
-    "XpPerLevel": 72750,
-    "UntilLevel": 192
+    "XpPerLevel": 75000,
+    "UntilLevel": 192,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "192": {
-    "XpPerLevel": 73000,
-    "UntilLevel": 193
+    "XpPerLevel": 75000,
+    "UntilLevel": 193,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "193": {
-    "XpPerLevel": 73250,
-    "UntilLevel": 194
+    "XpPerLevel": 75000,
+    "UntilLevel": 194,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "194": {
-    "XpPerLevel": 73500,
-    "UntilLevel": 195
+    "XpPerLevel": 75000,
+    "UntilLevel": 195,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "195": {
-    "XpPerLevel": 73750,
-    "UntilLevel": 196
+    "XpPerLevel": 75000,
+    "UntilLevel": 196,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "196": {
-    "XpPerLevel": 74250,
-    "UntilLevel": 197
+    "XpPerLevel": 75000,
+    "UntilLevel": 197,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "197": {
-    "XpPerLevel": 74500,
-    "UntilLevel": 198
+    "XpPerLevel": 75000,
+    "UntilLevel": 198,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "198": {
-    "XpPerLevel": 74750,
-    "UntilLevel": 199
+    "XpPerLevel": 75000,
+    "UntilLevel": 199,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "199": {
     "XpPerLevel": 75000,
-    "UntilLevel": 200
+    "UntilLevel": 200,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "200": {
-    "XpPerLevel": 75250,
-    "UntilLevel": 201
+    "XpPerLevel": 75000,
+    "UntilLevel": 201,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "/Game/Items/PersistentResources/AthenaBattleStar.AthenaBattleStar",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 5
   },
   "201": {
-    "XpPerLevel": 75750,
-    "UntilLevel": 202
+    "XpPerLevel": 75250,
+    "UntilLevel": 202,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "202": {
-    "XpPerLevel": 76000,
-    "UntilLevel": 203
+    "XpPerLevel": 75750,
+    "UntilLevel": 203,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "203": {
-    "XpPerLevel": 76250,
-    "UntilLevel": 204
+    "XpPerLevel": 76000,
+    "UntilLevel": 204,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "204": {
     "XpPerLevel": 76500,
-    "UntilLevel": 205
+    "UntilLevel": 205,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "205": {
-    "XpPerLevel": 77000,
-    "UntilLevel": 206
+    "XpPerLevel": 76750,
+    "UntilLevel": 206,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "206": {
-    "XpPerLevel": 77250,
-    "UntilLevel": 207
+    "XpPerLevel": 77000,
+    "UntilLevel": 207,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "207": {
     "XpPerLevel": 77500,
-    "UntilLevel": 208
+    "UntilLevel": 208,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "208": {
-    "XpPerLevel": 78000,
-    "UntilLevel": 209
+    "XpPerLevel": 77750,
+    "UntilLevel": 209,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "209": {
     "XpPerLevel": 78250,
-    "UntilLevel": 210
+    "UntilLevel": 210,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "210": {
     "XpPerLevel": 78500,
-    "UntilLevel": 211
+    "UntilLevel": 211,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "211": {
-    "XpPerLevel": 78750,
-    "UntilLevel": 212
+    "XpPerLevel": 79000,
+    "UntilLevel": 212,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "212": {
     "XpPerLevel": 79250,
-    "UntilLevel": 213
+    "UntilLevel": 213,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "213": {
-    "XpPerLevel": 79500,
-    "UntilLevel": 214
+    "XpPerLevel": 79750,
+    "UntilLevel": 214,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "214": {
-    "XpPerLevel": 79750,
-    "UntilLevel": 215
+    "XpPerLevel": 80000,
+    "UntilLevel": 215,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "215": {
-    "XpPerLevel": 80250,
-    "UntilLevel": 216
+    "XpPerLevel": 80500,
+    "UntilLevel": 216,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "216": {
-    "XpPerLevel": 80500,
-    "UntilLevel": 217
+    "XpPerLevel": 80750,
+    "UntilLevel": 217,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "217": {
-    "XpPerLevel": 80750,
-    "UntilLevel": 218
+    "XpPerLevel": 81000,
+    "UntilLevel": 218,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "218": {
-    "XpPerLevel": 81250,
-    "UntilLevel": 219
+    "XpPerLevel": 81500,
+    "UntilLevel": 219,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "219": {
-    "XpPerLevel": 81500,
-    "UntilLevel": 220
+    "XpPerLevel": 82000,
+    "UntilLevel": 220,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "220": {
-    "XpPerLevel": 81750,
-    "UntilLevel": 221
+    "XpPerLevel": 82250,
+    "UntilLevel": 221,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "221": {
-    "XpPerLevel": 82250,
-    "UntilLevel": 222
+    "XpPerLevel": 82750,
+    "UntilLevel": 222,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "222": {
-    "XpPerLevel": 82500,
-    "UntilLevel": 223
+    "XpPerLevel": 83000,
+    "UntilLevel": 223,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "223": {
-    "XpPerLevel": 82750,
-    "UntilLevel": 224
+    "XpPerLevel": 83500,
+    "UntilLevel": 224,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "224": {
-    "XpPerLevel": 83250,
-    "UntilLevel": 225
+    "XpPerLevel": 83750,
+    "UntilLevel": 225,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "225": {
-    "XpPerLevel": 83500,
-    "UntilLevel": 226
+    "XpPerLevel": 84250,
+    "UntilLevel": 226,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "226": {
-    "XpPerLevel": 83750,
-    "UntilLevel": 227
+    "XpPerLevel": 84500,
+    "UntilLevel": 227,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "227": {
-    "XpPerLevel": 84250,
-    "UntilLevel": 228
+    "XpPerLevel": 85000,
+    "UntilLevel": 228,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "228": {
-    "XpPerLevel": 84500,
-    "UntilLevel": 229
+    "XpPerLevel": 85250,
+    "UntilLevel": 229,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "229": {
-    "XpPerLevel": 85000,
-    "UntilLevel": 230
+    "XpPerLevel": 85750,
+    "UntilLevel": 230,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "230": {
-    "XpPerLevel": 85250,
-    "UntilLevel": 231
+    "XpPerLevel": 86250,
+    "UntilLevel": 231,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "231": {
-    "XpPerLevel": 85500,
-    "UntilLevel": 232
+    "XpPerLevel": 86500,
+    "UntilLevel": 232,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "232": {
-    "XpPerLevel": 86000,
-    "UntilLevel": 233
+    "XpPerLevel": 87000,
+    "UntilLevel": 233,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "233": {
-    "XpPerLevel": 86250,
-    "UntilLevel": 234
+    "XpPerLevel": 87250,
+    "UntilLevel": 234,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "234": {
-    "XpPerLevel": 86750,
-    "UntilLevel": 235
+    "XpPerLevel": 87750,
+    "UntilLevel": 235,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "235": {
-    "XpPerLevel": 87000,
-    "UntilLevel": 236
+    "XpPerLevel": 88250,
+    "UntilLevel": 236,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "236": {
-    "XpPerLevel": 87250,
-    "UntilLevel": 237
+    "XpPerLevel": 88500,
+    "UntilLevel": 237,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "237": {
-    "XpPerLevel": 87750,
-    "UntilLevel": 238
+    "XpPerLevel": 89000,
+    "UntilLevel": 238,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "238": {
-    "XpPerLevel": 88000,
-    "UntilLevel": 239
+    "XpPerLevel": 89500,
+    "UntilLevel": 239,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "239": {
-    "XpPerLevel": 88500,
-    "UntilLevel": 240
+    "XpPerLevel": 89750,
+    "UntilLevel": 240,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "240": {
-    "XpPerLevel": 88750,
-    "UntilLevel": 241
+    "XpPerLevel": 90250,
+    "UntilLevel": 241,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "241": {
-    "XpPerLevel": 89250,
-    "UntilLevel": 242
+    "XpPerLevel": 90750,
+    "UntilLevel": 242,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "242": {
-    "XpPerLevel": 89500,
-    "UntilLevel": 243
+    "XpPerLevel": 91000,
+    "UntilLevel": 243,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "243": {
-    "XpPerLevel": 90000,
-    "UntilLevel": 244
+    "XpPerLevel": 91500,
+    "UntilLevel": 244,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "244": {
-    "XpPerLevel": 90250,
-    "UntilLevel": 245
+    "XpPerLevel": 92000,
+    "UntilLevel": 245,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "245": {
-    "XpPerLevel": 90750,
-    "UntilLevel": 246
+    "XpPerLevel": 92250,
+    "UntilLevel": 246,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "246": {
-    "XpPerLevel": 91000,
-    "UntilLevel": 247
+    "XpPerLevel": 92750,
+    "UntilLevel": 247,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "247": {
-    "XpPerLevel": 91500,
-    "UntilLevel": 248
+    "XpPerLevel": 93250,
+    "UntilLevel": 248,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "248": {
-    "XpPerLevel": 91750,
-    "UntilLevel": 249
+    "XpPerLevel": 93500,
+    "UntilLevel": 249,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "249": {
-    "XpPerLevel": 92250,
-    "UntilLevel": 250
+    "XpPerLevel": 94000,
+    "UntilLevel": 250,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "250": {
-    "XpPerLevel": 92500,
-    "UntilLevel": 251
+    "XpPerLevel": 94500,
+    "UntilLevel": 251,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "251": {
-    "XpPerLevel": 93000,
-    "UntilLevel": 252
+    "XpPerLevel": 95000,
+    "UntilLevel": 252,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "252": {
-    "XpPerLevel": 93250,
-    "UntilLevel": 253
+    "XpPerLevel": 95250,
+    "UntilLevel": 253,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "253": {
-    "XpPerLevel": 93750,
-    "UntilLevel": 254
+    "XpPerLevel": 95750,
+    "UntilLevel": 254,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "254": {
-    "XpPerLevel": 94000,
-    "UntilLevel": 255
+    "XpPerLevel": 96250,
+    "UntilLevel": 255,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "255": {
-    "XpPerLevel": 94500,
-    "UntilLevel": 256
+    "XpPerLevel": 96750,
+    "UntilLevel": 256,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "256": {
-    "XpPerLevel": 94750,
-    "UntilLevel": 257
+    "XpPerLevel": 97250,
+    "UntilLevel": 257,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "257": {
-    "XpPerLevel": 95250,
-    "UntilLevel": 258
+    "XpPerLevel": 97500,
+    "UntilLevel": 258,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "258": {
-    "XpPerLevel": 95500,
-    "UntilLevel": 259
+    "XpPerLevel": 98000,
+    "UntilLevel": 259,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "259": {
-    "XpPerLevel": 96000,
-    "UntilLevel": 260
+    "XpPerLevel": 98500,
+    "UntilLevel": 260,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "260": {
-    "XpPerLevel": 96500,
-    "UntilLevel": 261
+    "XpPerLevel": 99000,
+    "UntilLevel": 261,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "261": {
-    "XpPerLevel": 96750,
-    "UntilLevel": 262
+    "XpPerLevel": 99500,
+    "UntilLevel": 262,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "262": {
-    "XpPerLevel": 97250,
-    "UntilLevel": 263
+    "XpPerLevel": 99750,
+    "UntilLevel": 263,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "263": {
-    "XpPerLevel": 97500,
-    "UntilLevel": 264
+    "XpPerLevel": 100250,
+    "UntilLevel": 264,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "264": {
-    "XpPerLevel": 98000,
-    "UntilLevel": 265
+    "XpPerLevel": 100750,
+    "UntilLevel": 265,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "265": {
-    "XpPerLevel": 98500,
-    "UntilLevel": 266
+    "XpPerLevel": 101250,
+    "UntilLevel": 266,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "266": {
-    "XpPerLevel": 98750,
-    "UntilLevel": 267
+    "XpPerLevel": 101750,
+    "UntilLevel": 267,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "267": {
-    "XpPerLevel": 99250,
-    "UntilLevel": 268
+    "XpPerLevel": 102250,
+    "UntilLevel": 268,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "268": {
-    "XpPerLevel": 99500,
-    "UntilLevel": 269
+    "XpPerLevel": 102750,
+    "UntilLevel": 269,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "269": {
-    "XpPerLevel": 100000,
-    "UntilLevel": 270
+    "XpPerLevel": 103250,
+    "UntilLevel": 270,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "270": {
-    "XpPerLevel": 100500,
-    "UntilLevel": 271
+    "XpPerLevel": 103500,
+    "UntilLevel": 271,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "271": {
-    "XpPerLevel": 100750,
-    "UntilLevel": 272
+    "XpPerLevel": 104000,
+    "UntilLevel": 272,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "272": {
-    "XpPerLevel": 101250,
-    "UntilLevel": 273
+    "XpPerLevel": 104500,
+    "UntilLevel": 273,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "273": {
-    "XpPerLevel": 101750,
-    "UntilLevel": 274
+    "XpPerLevel": 105000,
+    "UntilLevel": 274,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "274": {
-    "XpPerLevel": 102000,
-    "UntilLevel": 275
+    "XpPerLevel": 105500,
+    "UntilLevel": 275,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "275": {
-    "XpPerLevel": 102500,
-    "UntilLevel": 276
+    "XpPerLevel": 106000,
+    "UntilLevel": 276,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "276": {
-    "XpPerLevel": 103000,
-    "UntilLevel": 277
+    "XpPerLevel": 106500,
+    "UntilLevel": 277,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "277": {
-    "XpPerLevel": 103250,
-    "UntilLevel": 278
+    "XpPerLevel": 107000,
+    "UntilLevel": 278,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "278": {
-    "XpPerLevel": 103750,
-    "UntilLevel": 279
+    "XpPerLevel": 107500,
+    "UntilLevel": 279,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "279": {
-    "XpPerLevel": 104250,
-    "UntilLevel": 280
+    "XpPerLevel": 108000,
+    "UntilLevel": 280,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "280": {
-    "XpPerLevel": 104750,
-    "UntilLevel": 281
+    "XpPerLevel": 108500,
+    "UntilLevel": 281,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "281": {
-    "XpPerLevel": 105000,
-    "UntilLevel": 282
+    "XpPerLevel": 109000,
+    "UntilLevel": 282,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "282": {
-    "XpPerLevel": 105500,
-    "UntilLevel": 283
+    "XpPerLevel": 109500,
+    "UntilLevel": 283,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "283": {
-    "XpPerLevel": 106000,
-    "UntilLevel": 284
+    "XpPerLevel": 110000,
+    "UntilLevel": 284,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "284": {
-    "XpPerLevel": 106500,
-    "UntilLevel": 285
+    "XpPerLevel": 110500,
+    "UntilLevel": 285,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "285": {
-    "XpPerLevel": 106750,
-    "UntilLevel": 286
+    "XpPerLevel": 111000,
+    "UntilLevel": 286,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "286": {
-    "XpPerLevel": 107250,
-    "UntilLevel": 287
+    "XpPerLevel": 111500,
+    "UntilLevel": 287,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "287": {
-    "XpPerLevel": 107750,
-    "UntilLevel": 288
+    "XpPerLevel": 112000,
+    "UntilLevel": 288,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "288": {
-    "XpPerLevel": 108250,
-    "UntilLevel": 289
+    "XpPerLevel": 112500,
+    "UntilLevel": 289,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "289": {
-    "XpPerLevel": 108500,
-    "UntilLevel": 290
+    "XpPerLevel": 113000,
+    "UntilLevel": 290,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "290": {
-    "XpPerLevel": 109000,
-    "UntilLevel": 291
+    "XpPerLevel": 113750,
+    "UntilLevel": 291,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "291": {
-    "XpPerLevel": 109500,
-    "UntilLevel": 292
+    "XpPerLevel": 114250,
+    "UntilLevel": 292,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "292": {
-    "XpPerLevel": 110000,
-    "UntilLevel": 293
+    "XpPerLevel": 114750,
+    "UntilLevel": 293,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "293": {
-    "XpPerLevel": 110500,
-    "UntilLevel": 294
+    "XpPerLevel": 115250,
+    "UntilLevel": 294,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "294": {
-    "XpPerLevel": 110750,
-    "UntilLevel": 295
+    "XpPerLevel": 115750,
+    "UntilLevel": 295,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "295": {
-    "XpPerLevel": 111250,
-    "UntilLevel": 296
+    "XpPerLevel": 116250,
+    "UntilLevel": 296,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "296": {
-    "XpPerLevel": 111750,
-    "UntilLevel": 297
+    "XpPerLevel": 116750,
+    "UntilLevel": 297,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "297": {
-    "XpPerLevel": 112250,
-    "UntilLevel": 298
+    "XpPerLevel": 117250,
+    "UntilLevel": 298,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "298": {
-    "XpPerLevel": 112750,
-    "UntilLevel": 299
+    "XpPerLevel": 118000,
+    "UntilLevel": 299,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "299": {
-    "XpPerLevel": 113250,
-    "UntilLevel": 300
+    "XpPerLevel": 118500,
+    "UntilLevel": 300,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "300": {
-    "XpPerLevel": 113500,
-    "UntilLevel": 301
+    "XpPerLevel": 119000,
+    "UntilLevel": 301,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "301": {
-    "XpPerLevel": 114000,
-    "UntilLevel": 302
+    "XpPerLevel": 119500,
+    "UntilLevel": 302,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "302": {
-    "XpPerLevel": 114500,
-    "UntilLevel": 303
+    "XpPerLevel": 120000,
+    "UntilLevel": 303,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "303": {
-    "XpPerLevel": 115000,
-    "UntilLevel": 304
+    "XpPerLevel": 120750,
+    "UntilLevel": 304,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "304": {
-    "XpPerLevel": 115500,
-    "UntilLevel": 305
+    "XpPerLevel": 121250,
+    "UntilLevel": 305,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "305": {
-    "XpPerLevel": 116000,
-    "UntilLevel": 306
+    "XpPerLevel": 121750,
+    "UntilLevel": 306,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "306": {
-    "XpPerLevel": 116500,
-    "UntilLevel": 307
+    "XpPerLevel": 122250,
+    "UntilLevel": 307,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "307": {
-    "XpPerLevel": 117000,
-    "UntilLevel": 308
+    "XpPerLevel": 123000,
+    "UntilLevel": 308,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "308": {
-    "XpPerLevel": 117500,
-    "UntilLevel": 309
+    "XpPerLevel": 123500,
+    "UntilLevel": 309,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "309": {
-    "XpPerLevel": 117750,
-    "UntilLevel": 310
+    "XpPerLevel": 124000,
+    "UntilLevel": 310,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "310": {
-    "XpPerLevel": 118250,
-    "UntilLevel": 311
+    "XpPerLevel": 124750,
+    "UntilLevel": 311,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "311": {
-    "XpPerLevel": 118750,
-    "UntilLevel": 312
+    "XpPerLevel": 125250,
+    "UntilLevel": 312,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "312": {
-    "XpPerLevel": 119250,
-    "UntilLevel": 313
+    "XpPerLevel": 125750,
+    "UntilLevel": 313,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "313": {
-    "XpPerLevel": 119750,
-    "UntilLevel": 314
+    "XpPerLevel": 126250,
+    "UntilLevel": 314,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "314": {
-    "XpPerLevel": 120250,
-    "UntilLevel": 315
+    "XpPerLevel": 127000,
+    "UntilLevel": 315,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "315": {
-    "XpPerLevel": 120750,
-    "UntilLevel": 316
+    "XpPerLevel": 127500,
+    "UntilLevel": 316,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "316": {
-    "XpPerLevel": 121250,
-    "UntilLevel": 317
+    "XpPerLevel": 128250,
+    "UntilLevel": 317,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "317": {
-    "XpPerLevel": 121750,
-    "UntilLevel": 318
+    "XpPerLevel": 128750,
+    "UntilLevel": 318,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "318": {
-    "XpPerLevel": 122250,
-    "UntilLevel": 319
+    "XpPerLevel": 129250,
+    "UntilLevel": 319,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "319": {
-    "XpPerLevel": 122750,
-    "UntilLevel": 320
+    "XpPerLevel": 130000,
+    "UntilLevel": 320,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "320": {
-    "XpPerLevel": 123250,
-    "UntilLevel": 321
+    "XpPerLevel": 130500,
+    "UntilLevel": 321,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "321": {
-    "XpPerLevel": 123750,
-    "UntilLevel": 322
+    "XpPerLevel": 131000,
+    "UntilLevel": 322,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "322": {
-    "XpPerLevel": 124250,
-    "UntilLevel": 323
+    "XpPerLevel": 131750,
+    "UntilLevel": 323,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "323": {
-    "XpPerLevel": 124750,
-    "UntilLevel": 324
+    "XpPerLevel": 132250,
+    "UntilLevel": 324,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "324": {
-    "XpPerLevel": 125250,
-    "UntilLevel": 325
+    "XpPerLevel": 133000,
+    "UntilLevel": 325,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "325": {
-    "XpPerLevel": 125750,
-    "UntilLevel": 326
+    "XpPerLevel": 133500,
+    "UntilLevel": 326,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "326": {
-    "XpPerLevel": 126500,
-    "UntilLevel": 327
+    "XpPerLevel": 134250,
+    "UntilLevel": 327,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "327": {
-    "XpPerLevel": 127000,
-    "UntilLevel": 328
+    "XpPerLevel": 134750,
+    "UntilLevel": 328,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "328": {
-    "XpPerLevel": 127500,
-    "UntilLevel": 329
+    "XpPerLevel": 135500,
+    "UntilLevel": 329,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "329": {
-    "XpPerLevel": 128000,
-    "UntilLevel": 330
+    "XpPerLevel": 136000,
+    "UntilLevel": 330,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "330": {
-    "XpPerLevel": 128500,
-    "UntilLevel": 331
+    "XpPerLevel": 136750,
+    "UntilLevel": 331,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "331": {
-    "XpPerLevel": 129000,
-    "UntilLevel": 332
+    "XpPerLevel": 137250,
+    "UntilLevel": 332,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "332": {
-    "XpPerLevel": 129500,
-    "UntilLevel": 333
+    "XpPerLevel": 138000,
+    "UntilLevel": 333,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "333": {
-    "XpPerLevel": 130000,
-    "UntilLevel": 334
+    "XpPerLevel": 138500,
+    "UntilLevel": 334,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "334": {
-    "XpPerLevel": 130500,
-    "UntilLevel": 335
+    "XpPerLevel": 139250,
+    "UntilLevel": 335,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "335": {
-    "XpPerLevel": 131250,
-    "UntilLevel": 336
+    "XpPerLevel": 140000,
+    "UntilLevel": 336,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "336": {
-    "XpPerLevel": 131750,
-    "UntilLevel": 337
+    "XpPerLevel": 140500,
+    "UntilLevel": 337,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "337": {
-    "XpPerLevel": 132250,
-    "UntilLevel": 338
+    "XpPerLevel": 141250,
+    "UntilLevel": 338,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "338": {
-    "XpPerLevel": 132750,
-    "UntilLevel": 339
+    "XpPerLevel": 141750,
+    "UntilLevel": 339,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "339": {
-    "XpPerLevel": 133250,
-    "UntilLevel": 340
+    "XpPerLevel": 142500,
+    "UntilLevel": 340,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "340": {
-    "XpPerLevel": 133750,
-    "UntilLevel": 341
+    "XpPerLevel": 143250,
+    "UntilLevel": 341,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "341": {
-    "XpPerLevel": 134500,
-    "UntilLevel": 342
+    "XpPerLevel": 143750,
+    "UntilLevel": 342,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "342": {
-    "XpPerLevel": 135000,
-    "UntilLevel": 343
+    "XpPerLevel": 144500,
+    "UntilLevel": 343,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "343": {
-    "XpPerLevel": 135500,
-    "UntilLevel": 344
+    "XpPerLevel": 145250,
+    "UntilLevel": 344,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "344": {
-    "XpPerLevel": 136000,
-    "UntilLevel": 345
+    "XpPerLevel": 145750,
+    "UntilLevel": 345,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "345": {
-    "XpPerLevel": 136750,
-    "UntilLevel": 346
+    "XpPerLevel": 146500,
+    "UntilLevel": 346,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "346": {
-    "XpPerLevel": 137250,
-    "UntilLevel": 347
+    "XpPerLevel": 147250,
+    "UntilLevel": 347,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "347": {
-    "XpPerLevel": 137750,
-    "UntilLevel": 348
+    "XpPerLevel": 147750,
+    "UntilLevel": 348,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "348": {
-    "XpPerLevel": 138250,
-    "UntilLevel": 349
+    "XpPerLevel": 148500,
+    "UntilLevel": 349,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "349": {
-    "XpPerLevel": 139000,
-    "UntilLevel": 350
+    "XpPerLevel": 149250,
+    "UntilLevel": 350,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "350": {
-    "XpPerLevel": 139500,
-    "UntilLevel": 351
+    "XpPerLevel": 150000,
+    "UntilLevel": 351,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "351": {
-    "XpPerLevel": 140000,
-    "UntilLevel": 352
+    "XpPerLevel": 150500,
+    "UntilLevel": 352,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "352": {
-    "XpPerLevel": 140500,
-    "UntilLevel": 353
+    "XpPerLevel": 151250,
+    "UntilLevel": 353,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "353": {
-    "XpPerLevel": 141250,
-    "UntilLevel": 354
+    "XpPerLevel": 152000,
+    "UntilLevel": 354,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "354": {
-    "XpPerLevel": 141750,
-    "UntilLevel": 355
+    "XpPerLevel": 152750,
+    "UntilLevel": 355,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "355": {
-    "XpPerLevel": 142250,
-    "UntilLevel": 356
+    "XpPerLevel": 153500,
+    "UntilLevel": 356,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "356": {
-    "XpPerLevel": 143000,
-    "UntilLevel": 357
+    "XpPerLevel": 154000,
+    "UntilLevel": 357,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "357": {
-    "XpPerLevel": 143500,
-    "UntilLevel": 358
+    "XpPerLevel": 154750,
+    "UntilLevel": 358,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "358": {
-    "XpPerLevel": 144000,
-    "UntilLevel": 359
+    "XpPerLevel": 155500,
+    "UntilLevel": 359,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "359": {
-    "XpPerLevel": 144750,
-    "UntilLevel": 360
+    "XpPerLevel": 156250,
+    "UntilLevel": 360,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "360": {
-    "XpPerLevel": 145250,
-    "UntilLevel": 361
+    "XpPerLevel": 157000,
+    "UntilLevel": 361,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "361": {
-    "XpPerLevel": 146000,
-    "UntilLevel": 362
+    "XpPerLevel": 157750,
+    "UntilLevel": 362,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "362": {
-    "XpPerLevel": 146500,
-    "UntilLevel": 363
+    "XpPerLevel": 158500,
+    "UntilLevel": 363,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "363": {
-    "XpPerLevel": 147000,
-    "UntilLevel": 364
+    "XpPerLevel": 159250,
+    "UntilLevel": 364,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "364": {
-    "XpPerLevel": 147750,
-    "UntilLevel": 365
+    "XpPerLevel": 160000,
+    "UntilLevel": 365,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "365": {
-    "XpPerLevel": 148250,
-    "UntilLevel": 366
+    "XpPerLevel": 160750,
+    "UntilLevel": 366,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "366": {
-    "XpPerLevel": 149000,
-    "UntilLevel": 367
+    "XpPerLevel": 161500,
+    "UntilLevel": 367,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "367": {
-    "XpPerLevel": 149500,
-    "UntilLevel": 368
+    "XpPerLevel": 162250,
+    "UntilLevel": 368,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "368": {
-    "XpPerLevel": 150250,
-    "UntilLevel": 369
+    "XpPerLevel": 163000,
+    "UntilLevel": 369,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "369": {
-    "XpPerLevel": 150750,
-    "UntilLevel": 370
+    "XpPerLevel": 163750,
+    "UntilLevel": 370,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "370": {
-    "XpPerLevel": 151500,
-    "UntilLevel": 371
+    "XpPerLevel": 164500,
+    "UntilLevel": 371,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "371": {
-    "XpPerLevel": 152000,
-    "UntilLevel": 372
+    "XpPerLevel": 165250,
+    "UntilLevel": 372,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "372": {
-    "XpPerLevel": 152750,
-    "UntilLevel": 373
+    "XpPerLevel": 166000,
+    "UntilLevel": 373,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "373": {
-    "XpPerLevel": 153250,
-    "UntilLevel": 374
+    "XpPerLevel": 166750,
+    "UntilLevel": 374,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "374": {
-    "XpPerLevel": 154000,
-    "UntilLevel": 375
+    "XpPerLevel": 167500,
+    "UntilLevel": 375,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "375": {
-    "XpPerLevel": 154500,
-    "UntilLevel": 376
+    "XpPerLevel": 168250,
+    "UntilLevel": 376,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "376": {
-    "XpPerLevel": 155250,
-    "UntilLevel": 377
+    "XpPerLevel": 169000,
+    "UntilLevel": 377,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "377": {
-    "XpPerLevel": 155750,
-    "UntilLevel": 378
+    "XpPerLevel": 169750,
+    "UntilLevel": 378,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "378": {
-    "XpPerLevel": 156500,
-    "UntilLevel": 379
+    "XpPerLevel": 170500,
+    "UntilLevel": 379,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "379": {
-    "XpPerLevel": 157000,
-    "UntilLevel": 380
+    "XpPerLevel": 171500,
+    "UntilLevel": 380,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "380": {
-    "XpPerLevel": 157750,
-    "UntilLevel": 381
+    "XpPerLevel": 172250,
+    "UntilLevel": 381,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "381": {
-    "XpPerLevel": 158500,
-    "UntilLevel": 382
+    "XpPerLevel": 173000,
+    "UntilLevel": 382,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "382": {
-    "XpPerLevel": 159000,
-    "UntilLevel": 383
+    "XpPerLevel": 173750,
+    "UntilLevel": 383,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "383": {
-    "XpPerLevel": 159750,
-    "UntilLevel": 384
+    "XpPerLevel": 174500,
+    "UntilLevel": 384,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "384": {
-    "XpPerLevel": 160250,
-    "UntilLevel": 385
+    "XpPerLevel": 175500,
+    "UntilLevel": 385,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "385": {
-    "XpPerLevel": 161000,
-    "UntilLevel": 386
+    "XpPerLevel": 176250,
+    "UntilLevel": 386,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "386": {
-    "XpPerLevel": 161750,
-    "UntilLevel": 387
+    "XpPerLevel": 177000,
+    "UntilLevel": 387,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "387": {
-    "XpPerLevel": 162250,
-    "UntilLevel": 388
+    "XpPerLevel": 177750,
+    "UntilLevel": 388,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "388": {
-    "XpPerLevel": 163000,
-    "UntilLevel": 389
+    "XpPerLevel": 178750,
+    "UntilLevel": 389,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "389": {
-    "XpPerLevel": 163750,
-    "UntilLevel": 390
+    "XpPerLevel": 179500,
+    "UntilLevel": 390,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "390": {
-    "XpPerLevel": 164250,
-    "UntilLevel": 391
+    "XpPerLevel": 180250,
+    "UntilLevel": 391,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "391": {
-    "XpPerLevel": 165000,
-    "UntilLevel": 392
+    "XpPerLevel": 181250,
+    "UntilLevel": 392,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "392": {
-    "XpPerLevel": 165750,
-    "UntilLevel": 393
+    "XpPerLevel": 182000,
+    "UntilLevel": 393,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "393": {
-    "XpPerLevel": 166500,
-    "UntilLevel": 394
+    "XpPerLevel": 182750,
+    "UntilLevel": 394,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "394": {
-    "XpPerLevel": 167000,
-    "UntilLevel": 395
+    "XpPerLevel": 183750,
+    "UntilLevel": 395,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "395": {
-    "XpPerLevel": 167750,
-    "UntilLevel": 396
+    "XpPerLevel": 184500,
+    "UntilLevel": 396,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "396": {
-    "XpPerLevel": 168500,
-    "UntilLevel": 397
+    "XpPerLevel": 185500,
+    "UntilLevel": 397,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "397": {
-    "XpPerLevel": 169250,
-    "UntilLevel": 398
+    "XpPerLevel": 186250,
+    "UntilLevel": 398,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "398": {
-    "XpPerLevel": 169750,
-    "UntilLevel": 399
+    "XpPerLevel": 187000,
+    "UntilLevel": 399,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "399": {
-    "XpPerLevel": 170500,
-    "UntilLevel": 400
+    "XpPerLevel": 188000,
+    "UntilLevel": 400,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "400": {
-    "XpPerLevel": 171250,
-    "UntilLevel": 401
+    "XpPerLevel": 188750,
+    "UntilLevel": 401,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "401": {
-    "XpPerLevel": 172000,
-    "UntilLevel": 402
+    "XpPerLevel": 189750,
+    "UntilLevel": 402,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "402": {
-    "XpPerLevel": 172750,
-    "UntilLevel": 403
+    "XpPerLevel": 190500,
+    "UntilLevel": 403,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "403": {
-    "XpPerLevel": 173250,
-    "UntilLevel": 404
+    "XpPerLevel": 191500,
+    "UntilLevel": 404,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "404": {
-    "XpPerLevel": 174000,
-    "UntilLevel": 405
+    "XpPerLevel": 192250,
+    "UntilLevel": 405,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "405": {
-    "XpPerLevel": 174750,
-    "UntilLevel": 406
+    "XpPerLevel": 193250,
+    "UntilLevel": 406,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "406": {
-    "XpPerLevel": 175500,
-    "UntilLevel": 407
+    "XpPerLevel": 194250,
+    "UntilLevel": 407,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "407": {
-    "XpPerLevel": 176250,
-    "UntilLevel": 408
+    "XpPerLevel": 195000,
+    "UntilLevel": 408,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "408": {
-    "XpPerLevel": 177000,
-    "UntilLevel": 409
+    "XpPerLevel": 196000,
+    "UntilLevel": 409,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "409": {
-    "XpPerLevel": 177750,
-    "UntilLevel": 410
+    "XpPerLevel": 196750,
+    "UntilLevel": 410,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "410": {
-    "XpPerLevel": 178500,
-    "UntilLevel": 411
+    "XpPerLevel": 197750,
+    "UntilLevel": 411,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "411": {
-    "XpPerLevel": 179250,
-    "UntilLevel": 412
+    "XpPerLevel": 198750,
+    "UntilLevel": 412,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "412": {
-    "XpPerLevel": 179750,
-    "UntilLevel": 413
+    "XpPerLevel": 199500,
+    "UntilLevel": 413,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "413": {
-    "XpPerLevel": 180500,
-    "UntilLevel": 414
+    "XpPerLevel": 200500,
+    "UntilLevel": 414,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "414": {
-    "XpPerLevel": 181250,
-    "UntilLevel": 415
+    "XpPerLevel": 201500,
+    "UntilLevel": 415,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "415": {
-    "XpPerLevel": 182000,
-    "UntilLevel": 416
+    "XpPerLevel": 202250,
+    "UntilLevel": 416,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "416": {
-    "XpPerLevel": 182750,
-    "UntilLevel": 417
+    "XpPerLevel": 203250,
+    "UntilLevel": 417,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "417": {
-    "XpPerLevel": 183500,
-    "UntilLevel": 418
+    "XpPerLevel": 204250,
+    "UntilLevel": 418,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "418": {
-    "XpPerLevel": 184250,
-    "UntilLevel": 419
+    "XpPerLevel": 205250,
+    "UntilLevel": 419,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "419": {
-    "XpPerLevel": 185000,
-    "UntilLevel": 420
+    "XpPerLevel": 206250,
+    "UntilLevel": 420,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "420": {
-    "XpPerLevel": 186000,
-    "UntilLevel": 421
+    "XpPerLevel": 207000,
+    "UntilLevel": 421,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "421": {
-    "XpPerLevel": 186750,
-    "UntilLevel": 422
+    "XpPerLevel": 208000,
+    "UntilLevel": 422,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "422": {
-    "XpPerLevel": 187500,
-    "UntilLevel": 423
+    "XpPerLevel": 209000,
+    "UntilLevel": 423,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "423": {
-    "XpPerLevel": 188250,
-    "UntilLevel": 424
+    "XpPerLevel": 210000,
+    "UntilLevel": 424,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "424": {
-    "XpPerLevel": 189000,
-    "UntilLevel": 425
+    "XpPerLevel": 211000,
+    "UntilLevel": 425,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "425": {
-    "XpPerLevel": 189750,
-    "UntilLevel": 426
+    "XpPerLevel": 212000,
+    "UntilLevel": 426,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "426": {
-    "XpPerLevel": 190500,
-    "UntilLevel": 427
+    "XpPerLevel": 213000,
+    "UntilLevel": 427,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "427": {
-    "XpPerLevel": 191250,
-    "UntilLevel": 428
+    "XpPerLevel": 214000,
+    "UntilLevel": 428,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "428": {
-    "XpPerLevel": 192000,
-    "UntilLevel": 429
+    "XpPerLevel": 215000,
+    "UntilLevel": 429,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "429": {
-    "XpPerLevel": 192750,
-    "UntilLevel": 430
+    "XpPerLevel": 216000,
+    "UntilLevel": 430,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "430": {
-    "XpPerLevel": 193750,
-    "UntilLevel": 431
+    "XpPerLevel": 217000,
+    "UntilLevel": 431,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "431": {
-    "XpPerLevel": 194500,
-    "UntilLevel": 432
+    "XpPerLevel": 218000,
+    "UntilLevel": 432,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "432": {
-    "XpPerLevel": 195250,
-    "UntilLevel": 433
+    "XpPerLevel": 219000,
+    "UntilLevel": 433,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "433": {
-    "XpPerLevel": 196000,
-    "UntilLevel": 434
+    "XpPerLevel": 220000,
+    "UntilLevel": 434,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "434": {
-    "XpPerLevel": 196750,
-    "UntilLevel": 435
+    "XpPerLevel": 221000,
+    "UntilLevel": 435,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "435": {
-    "XpPerLevel": 197750,
-    "UntilLevel": 436
+    "XpPerLevel": 222000,
+    "UntilLevel": 436,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "436": {
-    "XpPerLevel": 198500,
-    "UntilLevel": 437
+    "XpPerLevel": 223000,
+    "UntilLevel": 437,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "437": {
-    "XpPerLevel": 199250,
-    "UntilLevel": 438
+    "XpPerLevel": 224000,
+    "UntilLevel": 438,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "438": {
-    "XpPerLevel": 200250,
-    "UntilLevel": 439
+    "XpPerLevel": 225000,
+    "UntilLevel": 439,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "439": {
-    "XpPerLevel": 201000,
-    "UntilLevel": 440
+    "XpPerLevel": 226000,
+    "UntilLevel": 440,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "440": {
-    "XpPerLevel": 201750,
-    "UntilLevel": 441
+    "XpPerLevel": 227250,
+    "UntilLevel": 441,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "441": {
-    "XpPerLevel": 202500,
-    "UntilLevel": 442
+    "XpPerLevel": 228250,
+    "UntilLevel": 442,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "442": {
-    "XpPerLevel": 203500,
-    "UntilLevel": 443
+    "XpPerLevel": 229250,
+    "UntilLevel": 443,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "443": {
-    "XpPerLevel": 204250,
-    "UntilLevel": 444
+    "XpPerLevel": 230250,
+    "UntilLevel": 444,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "444": {
-    "XpPerLevel": 205000,
-    "UntilLevel": 445
+    "XpPerLevel": 231250,
+    "UntilLevel": 445,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "445": {
-    "XpPerLevel": 206000,
-    "UntilLevel": 446
+    "XpPerLevel": 232500,
+    "UntilLevel": 446,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "446": {
-    "XpPerLevel": 206750,
-    "UntilLevel": 447
+    "XpPerLevel": 233500,
+    "UntilLevel": 447,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "447": {
-    "XpPerLevel": 207750,
-    "UntilLevel": 448
+    "XpPerLevel": 234500,
+    "UntilLevel": 448,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "448": {
-    "XpPerLevel": 208500,
-    "UntilLevel": 449
+    "XpPerLevel": 235750,
+    "UntilLevel": 449,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "449": {
-    "XpPerLevel": 209250,
-    "UntilLevel": 450
+    "XpPerLevel": 236750,
+    "UntilLevel": 450,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "450": {
-    "XpPerLevel": 210250,
-    "UntilLevel": 451
+    "XpPerLevel": 237750,
+    "UntilLevel": 451,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "451": {
-    "XpPerLevel": 211000,
-    "UntilLevel": 452
+    "XpPerLevel": 239000,
+    "UntilLevel": 452,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "452": {
-    "XpPerLevel": 212000,
-    "UntilLevel": 453
+    "XpPerLevel": 240000,
+    "UntilLevel": 453,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "453": {
-    "XpPerLevel": 212750,
-    "UntilLevel": 454
+    "XpPerLevel": 241250,
+    "UntilLevel": 454,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "454": {
-    "XpPerLevel": 213750,
-    "UntilLevel": 455
+    "XpPerLevel": 242250,
+    "UntilLevel": 455,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "455": {
-    "XpPerLevel": 214500,
-    "UntilLevel": 456
+    "XpPerLevel": 243500,
+    "UntilLevel": 456,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "456": {
-    "XpPerLevel": 215500,
-    "UntilLevel": 457
+    "XpPerLevel": 244500,
+    "UntilLevel": 457,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "457": {
-    "XpPerLevel": 216250,
-    "UntilLevel": 458
+    "XpPerLevel": 245750,
+    "UntilLevel": 458,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "458": {
-    "XpPerLevel": 217250,
-    "UntilLevel": 459
+    "XpPerLevel": 246750,
+    "UntilLevel": 459,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "459": {
-    "XpPerLevel": 218250,
-    "UntilLevel": 460
+    "XpPerLevel": 248000,
+    "UntilLevel": 460,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "460": {
-    "XpPerLevel": 219000,
-    "UntilLevel": 461
+    "XpPerLevel": 249000,
+    "UntilLevel": 461,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "461": {
-    "XpPerLevel": 220000,
-    "UntilLevel": 462
+    "XpPerLevel": 250250,
+    "UntilLevel": 462,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "462": {
-    "XpPerLevel": 220750,
-    "UntilLevel": 463
+    "XpPerLevel": 251500,
+    "UntilLevel": 463,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "463": {
-    "XpPerLevel": 221750,
-    "UntilLevel": 464
+    "XpPerLevel": 252500,
+    "UntilLevel": 464,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "464": {
-    "XpPerLevel": 222750,
-    "UntilLevel": 465
+    "XpPerLevel": 253750,
+    "UntilLevel": 465,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "465": {
-    "XpPerLevel": 223500,
-    "UntilLevel": 466
+    "XpPerLevel": 255000,
+    "UntilLevel": 466,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "466": {
-    "XpPerLevel": 224500,
-    "UntilLevel": 467
+    "XpPerLevel": 256000,
+    "UntilLevel": 467,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "467": {
-    "XpPerLevel": 225500,
-    "UntilLevel": 468
+    "XpPerLevel": 257250,
+    "UntilLevel": 468,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "468": {
-    "XpPerLevel": 226250,
-    "UntilLevel": 469
+    "XpPerLevel": 258500,
+    "UntilLevel": 469,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "469": {
-    "XpPerLevel": 227250,
-    "UntilLevel": 470
+    "XpPerLevel": 259750,
+    "UntilLevel": 470,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "470": {
-    "XpPerLevel": 228250,
-    "UntilLevel": 471
+    "XpPerLevel": 261000,
+    "UntilLevel": 471,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "471": {
-    "XpPerLevel": 229250,
-    "UntilLevel": 472
+    "XpPerLevel": 262000,
+    "UntilLevel": 472,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "472": {
-    "XpPerLevel": 230000,
-    "UntilLevel": 473
+    "XpPerLevel": 263250,
+    "UntilLevel": 473,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "473": {
-    "XpPerLevel": 231000,
-    "UntilLevel": 474
+    "XpPerLevel": 264500,
+    "UntilLevel": 474,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "474": {
-    "XpPerLevel": 232000,
-    "UntilLevel": 475
+    "XpPerLevel": 265750,
+    "UntilLevel": 475,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "475": {
-    "XpPerLevel": 233000,
-    "UntilLevel": 476
+    "XpPerLevel": 267000,
+    "UntilLevel": 476,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "476": {
-    "XpPerLevel": 234000,
-    "UntilLevel": 477
+    "XpPerLevel": 268250,
+    "UntilLevel": 477,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "477": {
-    "XpPerLevel": 234750,
-    "UntilLevel": 478
+    "XpPerLevel": 269500,
+    "UntilLevel": 478,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "478": {
-    "XpPerLevel": 235750,
-    "UntilLevel": 479
+    "XpPerLevel": 270750,
+    "UntilLevel": 479,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "479": {
-    "XpPerLevel": 236750,
-    "UntilLevel": 480
+    "XpPerLevel": 272000,
+    "UntilLevel": 480,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "480": {
-    "XpPerLevel": 237750,
-    "UntilLevel": 481
+    "XpPerLevel": 273250,
+    "UntilLevel": 481,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "481": {
-    "XpPerLevel": 238750,
-    "UntilLevel": 482
+    "XpPerLevel": 274500,
+    "UntilLevel": 482,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "482": {
-    "XpPerLevel": 239750,
-    "UntilLevel": 483
+    "XpPerLevel": 275750,
+    "UntilLevel": 483,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "483": {
-    "XpPerLevel": 240750,
-    "UntilLevel": 484
+    "XpPerLevel": 277000,
+    "UntilLevel": 484,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "484": {
-    "XpPerLevel": 241750,
-    "UntilLevel": 485
+    "XpPerLevel": 278250,
+    "UntilLevel": 485,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "485": {
-    "XpPerLevel": 242750,
-    "UntilLevel": 486
+    "XpPerLevel": 279500,
+    "UntilLevel": 486,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "486": {
-    "XpPerLevel": 243750,
-    "UntilLevel": 487
+    "XpPerLevel": 281000,
+    "UntilLevel": 487,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "487": {
-    "XpPerLevel": 244750,
-    "UntilLevel": 488
+    "XpPerLevel": 282250,
+    "UntilLevel": 488,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "488": {
-    "XpPerLevel": 245750,
-    "UntilLevel": 489
+    "XpPerLevel": 283500,
+    "UntilLevel": 489,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "489": {
-    "XpPerLevel": 246750,
-    "UntilLevel": 490
+    "XpPerLevel": 284750,
+    "UntilLevel": 490,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "490": {
-    "XpPerLevel": 247750,
-    "UntilLevel": 491
+    "XpPerLevel": 286000,
+    "UntilLevel": 491,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "491": {
-    "XpPerLevel": 248750,
-    "UntilLevel": 492
+    "XpPerLevel": 287500,
+    "UntilLevel": 492,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "492": {
-    "XpPerLevel": 249750,
-    "UntilLevel": 493
+    "XpPerLevel": 288750,
+    "UntilLevel": 493,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "493": {
-    "XpPerLevel": 250750,
-    "UntilLevel": 494
+    "XpPerLevel": 290000,
+    "UntilLevel": 494,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "494": {
-    "XpPerLevel": 251750,
-    "UntilLevel": 495
+    "XpPerLevel": 291500,
+    "UntilLevel": 495,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "495": {
-    "XpPerLevel": 252750,
-    "UntilLevel": 496
+    "XpPerLevel": 292750,
+    "UntilLevel": 496,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "496": {
-    "XpPerLevel": 254000,
-    "UntilLevel": 497
+    "XpPerLevel": 294250,
+    "UntilLevel": 497,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "497": {
-    "XpPerLevel": 255000,
-    "UntilLevel": 498
+    "XpPerLevel": 295500,
+    "UntilLevel": 498,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "498": {
-    "XpPerLevel": 256000,
-    "UntilLevel": 499
+    "XpPerLevel": 297000,
+    "UntilLevel": 499,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "499": {
-    "XpPerLevel": 257000,
-    "UntilLevel": 500
+    "XpPerLevel": 298250,
+    "UntilLevel": 500,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "500": {
-    "XpPerLevel": 258000,
-    "UntilLevel": 501
+    "XpPerLevel": 299750,
+    "UntilLevel": 501,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "501": {
-    "XpPerLevel": 259250,
-    "UntilLevel": 502
+    "XpPerLevel": 301000,
+    "UntilLevel": 502,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "502": {
-    "XpPerLevel": 260250,
-    "UntilLevel": 503
+    "XpPerLevel": 302500,
+    "UntilLevel": 503,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "503": {
-    "XpPerLevel": 261250,
-    "UntilLevel": 504
+    "XpPerLevel": 303750,
+    "UntilLevel": 504,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "504": {
-    "XpPerLevel": 262250,
-    "UntilLevel": 505
+    "XpPerLevel": 305250,
+    "UntilLevel": 505,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "505": {
-    "XpPerLevel": 263500,
-    "UntilLevel": 506
+    "XpPerLevel": 306750,
+    "UntilLevel": 506,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "506": {
-    "XpPerLevel": 264500,
-    "UntilLevel": 507
+    "XpPerLevel": 308000,
+    "UntilLevel": 507,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "507": {
-    "XpPerLevel": 265500,
-    "UntilLevel": 508
+    "XpPerLevel": 309500,
+    "UntilLevel": 508,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "508": {
-    "XpPerLevel": 266750,
-    "UntilLevel": 509
+    "XpPerLevel": 311000,
+    "UntilLevel": 509,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "509": {
-    "XpPerLevel": 267750,
-    "UntilLevel": 510
+    "XpPerLevel": 312250,
+    "UntilLevel": 510,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "510": {
-    "XpPerLevel": 269000,
-    "UntilLevel": 511
+    "XpPerLevel": 313750,
+    "UntilLevel": 511,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "511": {
-    "XpPerLevel": 270000,
-    "UntilLevel": 512
+    "XpPerLevel": 315250,
+    "UntilLevel": 512,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "512": {
-    "XpPerLevel": 271250,
-    "UntilLevel": 513
+    "XpPerLevel": 316750,
+    "UntilLevel": 513,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "513": {
-    "XpPerLevel": 272250,
-    "UntilLevel": 514
+    "XpPerLevel": 318250,
+    "UntilLevel": 514,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "514": {
-    "XpPerLevel": 273250,
-    "UntilLevel": 515
+    "XpPerLevel": 319750,
+    "UntilLevel": 515,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "515": {
-    "XpPerLevel": 274500,
-    "UntilLevel": 516
+    "XpPerLevel": 321000,
+    "UntilLevel": 516,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "516": {
-    "XpPerLevel": 275500,
-    "UntilLevel": 517
+    "XpPerLevel": 322500,
+    "UntilLevel": 517,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "517": {
-    "XpPerLevel": 276750,
-    "UntilLevel": 518
+    "XpPerLevel": 324000,
+    "UntilLevel": 518,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "518": {
-    "XpPerLevel": 278000,
-    "UntilLevel": 519
+    "XpPerLevel": 325500,
+    "UntilLevel": 519,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "519": {
-    "XpPerLevel": 279000,
-    "UntilLevel": 520
+    "XpPerLevel": 327000,
+    "UntilLevel": 520,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "520": {
-    "XpPerLevel": 280250,
-    "UntilLevel": 521
+    "XpPerLevel": 328500,
+    "UntilLevel": 521,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "521": {
-    "XpPerLevel": 281250,
-    "UntilLevel": 522
+    "XpPerLevel": 330250,
+    "UntilLevel": 522,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "522": {
-    "XpPerLevel": 282500,
-    "UntilLevel": 523
+    "XpPerLevel": 331750,
+    "UntilLevel": 523,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "523": {
-    "XpPerLevel": 283750,
-    "UntilLevel": 524
+    "XpPerLevel": 333250,
+    "UntilLevel": 524,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "524": {
-    "XpPerLevel": 284750,
-    "UntilLevel": 525
+    "XpPerLevel": 334750,
+    "UntilLevel": 525,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "525": {
-    "XpPerLevel": 286000,
-    "UntilLevel": 526
+    "XpPerLevel": 336250,
+    "UntilLevel": 526,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "526": {
-    "XpPerLevel": 287250,
-    "UntilLevel": 527
+    "XpPerLevel": 337750,
+    "UntilLevel": 527,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "527": {
-    "XpPerLevel": 288250,
-    "UntilLevel": 528
+    "XpPerLevel": 339500,
+    "UntilLevel": 528,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "528": {
-    "XpPerLevel": 289500,
-    "UntilLevel": 529
+    "XpPerLevel": 341000,
+    "UntilLevel": 529,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "529": {
-    "XpPerLevel": 290750,
-    "UntilLevel": 530
+    "XpPerLevel": 342500,
+    "UntilLevel": 530,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "530": {
-    "XpPerLevel": 292000,
-    "UntilLevel": 531
+    "XpPerLevel": 344250,
+    "UntilLevel": 531,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "531": {
-    "XpPerLevel": 293000,
-    "UntilLevel": 532
+    "XpPerLevel": 345750,
+    "UntilLevel": 532,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "532": {
-    "XpPerLevel": 294250,
-    "UntilLevel": 533
+    "XpPerLevel": 347250,
+    "UntilLevel": 533,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "533": {
-    "XpPerLevel": 295500,
-    "UntilLevel": 534
+    "XpPerLevel": 349000,
+    "UntilLevel": 534,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "534": {
-    "XpPerLevel": 296750,
-    "UntilLevel": 535
+    "XpPerLevel": 350500,
+    "UntilLevel": 535,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "535": {
-    "XpPerLevel": 298000,
-    "UntilLevel": 536
+    "XpPerLevel": 352250,
+    "UntilLevel": 536,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "536": {
-    "XpPerLevel": 299250,
-    "UntilLevel": 537
+    "XpPerLevel": 353750,
+    "UntilLevel": 537,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "537": {
-    "XpPerLevel": 300500,
-    "UntilLevel": 538
+    "XpPerLevel": 355500,
+    "UntilLevel": 538,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "538": {
-    "XpPerLevel": 301750,
-    "UntilLevel": 539
+    "XpPerLevel": 357000,
+    "UntilLevel": 539,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "539": {
-    "XpPerLevel": 303000,
-    "UntilLevel": 540
+    "XpPerLevel": 358750,
+    "UntilLevel": 540,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "540": {
-    "XpPerLevel": 304250,
-    "UntilLevel": 541
+    "XpPerLevel": 360500,
+    "UntilLevel": 541,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "541": {
-    "XpPerLevel": 305500,
-    "UntilLevel": 542
+    "XpPerLevel": 362000,
+    "UntilLevel": 542,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "542": {
-    "XpPerLevel": 306750,
-    "UntilLevel": 543
+    "XpPerLevel": 363750,
+    "UntilLevel": 543,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "543": {
-    "XpPerLevel": 308000,
-    "UntilLevel": 544
+    "XpPerLevel": 365500,
+    "UntilLevel": 544,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "544": {
-    "XpPerLevel": 309250,
-    "UntilLevel": 545
+    "XpPerLevel": 367000,
+    "UntilLevel": 545,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "545": {
-    "XpPerLevel": 310500,
-    "UntilLevel": 546
+    "XpPerLevel": 368750,
+    "UntilLevel": 546,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "546": {
-    "XpPerLevel": 311750,
-    "UntilLevel": 547
+    "XpPerLevel": 370500,
+    "UntilLevel": 547,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "547": {
-    "XpPerLevel": 313000,
-    "UntilLevel": 548
+    "XpPerLevel": 372250,
+    "UntilLevel": 548,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "548": {
-    "XpPerLevel": 314250,
-    "UntilLevel": 549
+    "XpPerLevel": 374000,
+    "UntilLevel": 549,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "549": {
-    "XpPerLevel": 315500,
-    "UntilLevel": 550
+    "XpPerLevel": 375750,
+    "UntilLevel": 550,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "550": {
-    "XpPerLevel": 317000,
-    "UntilLevel": 551
+    "XpPerLevel": 377500,
+    "UntilLevel": 551,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "551": {
-    "XpPerLevel": 318250,
-    "UntilLevel": 552
+    "XpPerLevel": 379250,
+    "UntilLevel": 552,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "552": {
-    "XpPerLevel": 319500,
-    "UntilLevel": 553
+    "XpPerLevel": 381000,
+    "UntilLevel": 553,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "553": {
-    "XpPerLevel": 320750,
-    "UntilLevel": 554
+    "XpPerLevel": 382750,
+    "UntilLevel": 554,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "554": {
-    "XpPerLevel": 322000,
-    "UntilLevel": 555
+    "XpPerLevel": 384500,
+    "UntilLevel": 555,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "555": {
-    "XpPerLevel": 323500,
-    "UntilLevel": 556
+    "XpPerLevel": 386250,
+    "UntilLevel": 556,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "556": {
-    "XpPerLevel": 324750,
-    "UntilLevel": 557
+    "XpPerLevel": 388000,
+    "UntilLevel": 557,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "557": {
-    "XpPerLevel": 326000,
-    "UntilLevel": 558
+    "XpPerLevel": 389750,
+    "UntilLevel": 558,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "558": {
-    "XpPerLevel": 327500,
-    "UntilLevel": 559
+    "XpPerLevel": 391750,
+    "UntilLevel": 559,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "559": {
-    "XpPerLevel": 328750,
-    "UntilLevel": 560
+    "XpPerLevel": 393500,
+    "UntilLevel": 560,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "560": {
-    "XpPerLevel": 330250,
-    "UntilLevel": 561
+    "XpPerLevel": 395250,
+    "UntilLevel": 561,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "561": {
-    "XpPerLevel": 331500,
-    "UntilLevel": 562
+    "XpPerLevel": 397000,
+    "UntilLevel": 562,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "562": {
-    "XpPerLevel": 332750,
-    "UntilLevel": 563
+    "XpPerLevel": 399000,
+    "UntilLevel": 563,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "563": {
-    "XpPerLevel": 334250,
-    "UntilLevel": 564
+    "XpPerLevel": 400750,
+    "UntilLevel": 564,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "564": {
-    "XpPerLevel": 335500,
-    "UntilLevel": 565
+    "XpPerLevel": 402750,
+    "UntilLevel": 565,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "565": {
-    "XpPerLevel": 337000,
-    "UntilLevel": 566
+    "XpPerLevel": 404500,
+    "UntilLevel": 566,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "566": {
-    "XpPerLevel": 338500,
-    "UntilLevel": 567
+    "XpPerLevel": 406250,
+    "UntilLevel": 567,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "567": {
-    "XpPerLevel": 339750,
-    "UntilLevel": 568
+    "XpPerLevel": 408250,
+    "UntilLevel": 568,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "568": {
-    "XpPerLevel": 341250,
-    "UntilLevel": 569
+    "XpPerLevel": 410250,
+    "UntilLevel": 569,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "569": {
-    "XpPerLevel": 342500,
-    "UntilLevel": 570
+    "XpPerLevel": 412000,
+    "UntilLevel": 570,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "570": {
-    "XpPerLevel": 344000,
-    "UntilLevel": 571
+    "XpPerLevel": 414000,
+    "UntilLevel": 571,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "571": {
-    "XpPerLevel": 345500,
-    "UntilLevel": 572
+    "XpPerLevel": 415750,
+    "UntilLevel": 572,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "572": {
-    "XpPerLevel": 346750,
-    "UntilLevel": 573
+    "XpPerLevel": 417750,
+    "UntilLevel": 573,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "573": {
-    "XpPerLevel": 348250,
-    "UntilLevel": 574
+    "XpPerLevel": 419750,
+    "UntilLevel": 574,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "574": {
-    "XpPerLevel": 349750,
-    "UntilLevel": 575
+    "XpPerLevel": 421750,
+    "UntilLevel": 575,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "575": {
-    "XpPerLevel": 351000,
-    "UntilLevel": 576
+    "XpPerLevel": 423500,
+    "UntilLevel": 576,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "576": {
-    "XpPerLevel": 352500,
-    "UntilLevel": 577
+    "XpPerLevel": 425500,
+    "UntilLevel": 577,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "577": {
-    "XpPerLevel": 354000,
-    "UntilLevel": 578
+    "XpPerLevel": 427500,
+    "UntilLevel": 578,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "578": {
-    "XpPerLevel": 355500,
-    "UntilLevel": 579
+    "XpPerLevel": 429500,
+    "UntilLevel": 579,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "579": {
-    "XpPerLevel": 357000,
-    "UntilLevel": 580
+    "XpPerLevel": 431500,
+    "UntilLevel": 580,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "580": {
-    "XpPerLevel": 358500,
-    "UntilLevel": 581
+    "XpPerLevel": 433500,
+    "UntilLevel": 581,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "581": {
-    "XpPerLevel": 359750,
-    "UntilLevel": 582
+    "XpPerLevel": 435500,
+    "UntilLevel": 582,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "582": {
-    "XpPerLevel": 361250,
-    "UntilLevel": 583
+    "XpPerLevel": 437500,
+    "UntilLevel": 583,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "583": {
-    "XpPerLevel": 362750,
-    "UntilLevel": 584
+    "XpPerLevel": 439500,
+    "UntilLevel": 584,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "584": {
-    "XpPerLevel": 364250,
-    "UntilLevel": 585
+    "XpPerLevel": 441500,
+    "UntilLevel": 585,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "585": {
-    "XpPerLevel": 365750,
-    "UntilLevel": 586
+    "XpPerLevel": 443750,
+    "UntilLevel": 586,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "586": {
-    "XpPerLevel": 367250,
-    "UntilLevel": 587
+    "XpPerLevel": 445750,
+    "UntilLevel": 587,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "587": {
-    "XpPerLevel": 368750,
-    "UntilLevel": 588
+    "XpPerLevel": 447750,
+    "UntilLevel": 588,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "588": {
-    "XpPerLevel": 370250,
-    "UntilLevel": 589
+    "XpPerLevel": 449750,
+    "UntilLevel": 589,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "589": {
-    "XpPerLevel": 371750,
-    "UntilLevel": 590
+    "XpPerLevel": 452000,
+    "UntilLevel": 590,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "590": {
-    "XpPerLevel": 373500,
-    "UntilLevel": 591
+    "XpPerLevel": 454000,
+    "UntilLevel": 591,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "591": {
-    "XpPerLevel": 375000,
-    "UntilLevel": 592
+    "XpPerLevel": 456000,
+    "UntilLevel": 592,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "592": {
-    "XpPerLevel": 376500,
-    "UntilLevel": 593
+    "XpPerLevel": 458250,
+    "UntilLevel": 593,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "593": {
-    "XpPerLevel": 378000,
-    "UntilLevel": 594
+    "XpPerLevel": 460250,
+    "UntilLevel": 594,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "594": {
-    "XpPerLevel": 379500,
-    "UntilLevel": 595
+    "XpPerLevel": 462500,
+    "UntilLevel": 595,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "595": {
-    "XpPerLevel": 381250,
-    "UntilLevel": 596
+    "XpPerLevel": 464500,
+    "UntilLevel": 596,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "596": {
-    "XpPerLevel": 382750,
-    "UntilLevel": 597
+    "XpPerLevel": 466750,
+    "UntilLevel": 597,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "597": {
-    "XpPerLevel": 384250,
-    "UntilLevel": 598
+    "XpPerLevel": 469000,
+    "UntilLevel": 598,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "598": {
-    "XpPerLevel": 385750,
-    "UntilLevel": 599
+    "XpPerLevel": 471000,
+    "UntilLevel": 599,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "599": {
-    "XpPerLevel": 387500,
-    "UntilLevel": 600
+    "XpPerLevel": 473250,
+    "UntilLevel": 600,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "600": {
-    "XpPerLevel": 389000,
-    "UntilLevel": 601
+    "XpPerLevel": 475500,
+    "UntilLevel": 601,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "601": {
-    "XpPerLevel": 390750,
-    "UntilLevel": 602
+    "XpPerLevel": 477750,
+    "UntilLevel": 602,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "602": {
-    "XpPerLevel": 392250,
-    "UntilLevel": 603
+    "XpPerLevel": 479750,
+    "UntilLevel": 603,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "603": {
-    "XpPerLevel": 393750,
-    "UntilLevel": 604
+    "XpPerLevel": 482000,
+    "UntilLevel": 604,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "604": {
-    "XpPerLevel": 395500,
-    "UntilLevel": 605
+    "XpPerLevel": 484250,
+    "UntilLevel": 605,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "605": {
-    "XpPerLevel": 397000,
-    "UntilLevel": 606
+    "XpPerLevel": 486500,
+    "UntilLevel": 606,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "606": {
-    "XpPerLevel": 398750,
-    "UntilLevel": 607
+    "XpPerLevel": 488750,
+    "UntilLevel": 607,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "607": {
-    "XpPerLevel": 400500,
-    "UntilLevel": 608
+    "XpPerLevel": 491000,
+    "UntilLevel": 608,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "608": {
-    "XpPerLevel": 402000,
-    "UntilLevel": 609
+    "XpPerLevel": 493250,
+    "UntilLevel": 609,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "609": {
-    "XpPerLevel": 403750,
-    "UntilLevel": 610
+    "XpPerLevel": 495500,
+    "UntilLevel": 610,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "610": {
-    "XpPerLevel": 405250,
-    "UntilLevel": 611
+    "XpPerLevel": 498000,
+    "UntilLevel": 611,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "611": {
-    "XpPerLevel": 407000,
-    "UntilLevel": 612
+    "XpPerLevel": 500250,
+    "UntilLevel": 612,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "612": {
-    "XpPerLevel": 408750,
-    "UntilLevel": 613
+    "XpPerLevel": 502500,
+    "UntilLevel": 613,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "613": {
-    "XpPerLevel": 410250,
-    "UntilLevel": 614
+    "XpPerLevel": 504750,
+    "UntilLevel": 614,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "614": {
-    "XpPerLevel": 412000,
-    "UntilLevel": 615
+    "XpPerLevel": 507250,
+    "UntilLevel": 615,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "615": {
-    "XpPerLevel": 413750,
-    "UntilLevel": 616
+    "XpPerLevel": 509500,
+    "UntilLevel": 616,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "616": {
-    "XpPerLevel": 415500,
-    "UntilLevel": 617
+    "XpPerLevel": 512000,
+    "UntilLevel": 617,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "617": {
-    "XpPerLevel": 417250,
-    "UntilLevel": 618
+    "XpPerLevel": 514250,
+    "UntilLevel": 618,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "618": {
-    "XpPerLevel": 418750,
-    "UntilLevel": 619
+    "XpPerLevel": 516750,
+    "UntilLevel": 619,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "619": {
-    "XpPerLevel": 420500,
-    "UntilLevel": 620
+    "XpPerLevel": 519000,
+    "UntilLevel": 620,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "620": {
-    "XpPerLevel": 422250,
-    "UntilLevel": 621
+    "XpPerLevel": 521500,
+    "UntilLevel": 621,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "621": {
-    "XpPerLevel": 424000,
-    "UntilLevel": 622
+    "XpPerLevel": 523750,
+    "UntilLevel": 622,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "622": {
-    "XpPerLevel": 425750,
-    "UntilLevel": 623
+    "XpPerLevel": 526250,
+    "UntilLevel": 623,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "623": {
-    "XpPerLevel": 427500,
-    "UntilLevel": 624
+    "XpPerLevel": 528750,
+    "UntilLevel": 624,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "624": {
-    "XpPerLevel": 429250,
-    "UntilLevel": 625
+    "XpPerLevel": 531250,
+    "UntilLevel": 625,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "625": {
-    "XpPerLevel": 431000,
-    "UntilLevel": 626
+    "XpPerLevel": 533500,
+    "UntilLevel": 626,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "626": {
-    "XpPerLevel": 432750,
-    "UntilLevel": 627
+    "XpPerLevel": 536000,
+    "UntilLevel": 627,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "627": {
-    "XpPerLevel": 434500,
-    "UntilLevel": 628
+    "XpPerLevel": 538500,
+    "UntilLevel": 628,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "628": {
-    "XpPerLevel": 436500,
-    "UntilLevel": 629
+    "XpPerLevel": 541000,
+    "UntilLevel": 629,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "629": {
-    "XpPerLevel": 438250,
-    "UntilLevel": 630
+    "XpPerLevel": 543500,
+    "UntilLevel": 630,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "630": {
-    "XpPerLevel": 440000,
-    "UntilLevel": 631
+    "XpPerLevel": 546000,
+    "UntilLevel": 631,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "631": {
-    "XpPerLevel": 441750,
-    "UntilLevel": 632
+    "XpPerLevel": 548500,
+    "UntilLevel": 632,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "632": {
-    "XpPerLevel": 443750,
-    "UntilLevel": 633
+    "XpPerLevel": 551250,
+    "UntilLevel": 633,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "633": {
-    "XpPerLevel": 445500,
-    "UntilLevel": 634
+    "XpPerLevel": 553750,
+    "UntilLevel": 634,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "634": {
-    "XpPerLevel": 447250,
-    "UntilLevel": 635
+    "XpPerLevel": 556250,
+    "UntilLevel": 635,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "635": {
-    "XpPerLevel": 449000,
-    "UntilLevel": 636
+    "XpPerLevel": 558750,
+    "UntilLevel": 636,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "636": {
-    "XpPerLevel": 451000,
-    "UntilLevel": 637
+    "XpPerLevel": 561500,
+    "UntilLevel": 637,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "637": {
-    "XpPerLevel": 452750,
-    "UntilLevel": 638
+    "XpPerLevel": 564000,
+    "UntilLevel": 638,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "638": {
-    "XpPerLevel": 454750,
-    "UntilLevel": 639
+    "XpPerLevel": 566500,
+    "UntilLevel": 639,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "639": {
-    "XpPerLevel": 456500,
-    "UntilLevel": 640
+    "XpPerLevel": 569250,
+    "UntilLevel": 640,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "640": {
-    "XpPerLevel": 458500,
-    "UntilLevel": 641
+    "XpPerLevel": 571750,
+    "UntilLevel": 641,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "641": {
-    "XpPerLevel": 460250,
-    "UntilLevel": 642
+    "XpPerLevel": 574500,
+    "UntilLevel": 642,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "642": {
-    "XpPerLevel": 462250,
-    "UntilLevel": 643
+    "XpPerLevel": 577250,
+    "UntilLevel": 643,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "643": {
-    "XpPerLevel": 464000,
-    "UntilLevel": 644
+    "XpPerLevel": 579750,
+    "UntilLevel": 644,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "644": {
-    "XpPerLevel": 466000,
-    "UntilLevel": 645
+    "XpPerLevel": 582500,
+    "UntilLevel": 645,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "645": {
-    "XpPerLevel": 468000,
-    "UntilLevel": 646
+    "XpPerLevel": 585250,
+    "UntilLevel": 646,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "646": {
-    "XpPerLevel": 469750,
-    "UntilLevel": 647
+    "XpPerLevel": 588000,
+    "UntilLevel": 647,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "647": {
-    "XpPerLevel": 471750,
-    "UntilLevel": 648
+    "XpPerLevel": 590750,
+    "UntilLevel": 648,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "648": {
-    "XpPerLevel": 473750,
-    "UntilLevel": 649
+    "XpPerLevel": 593500,
+    "UntilLevel": 649,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "649": {
-    "XpPerLevel": 475750,
-    "UntilLevel": 650
+    "XpPerLevel": 596250,
+    "UntilLevel": 650,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "650": {
-    "XpPerLevel": 477750,
-    "UntilLevel": 651
+    "XpPerLevel": 599000,
+    "UntilLevel": 651,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "651": {
-    "XpPerLevel": 479500,
-    "UntilLevel": 652
+    "XpPerLevel": 601750,
+    "UntilLevel": 652,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "652": {
-    "XpPerLevel": 481500,
-    "UntilLevel": 653
+    "XpPerLevel": 604500,
+    "UntilLevel": 653,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "653": {
-    "XpPerLevel": 483500,
-    "UntilLevel": 654
+    "XpPerLevel": 607250,
+    "UntilLevel": 654,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "654": {
-    "XpPerLevel": 485500,
-    "UntilLevel": 655
+    "XpPerLevel": 610000,
+    "UntilLevel": 655,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "655": {
-    "XpPerLevel": 487500,
-    "UntilLevel": 656
+    "XpPerLevel": 613000,
+    "UntilLevel": 656,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "656": {
-    "XpPerLevel": 489500,
-    "UntilLevel": 657
+    "XpPerLevel": 615750,
+    "UntilLevel": 657,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "657": {
-    "XpPerLevel": 491500,
-    "UntilLevel": 658
+    "XpPerLevel": 618500,
+    "UntilLevel": 658,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "658": {
-    "XpPerLevel": 493500,
-    "UntilLevel": 659
+    "XpPerLevel": 621500,
+    "UntilLevel": 659,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "659": {
-    "XpPerLevel": 495500,
-    "UntilLevel": 660
+    "XpPerLevel": 624250,
+    "UntilLevel": 660,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "660": {
-    "XpPerLevel": 497750,
-    "UntilLevel": 661
+    "XpPerLevel": 627250,
+    "UntilLevel": 661,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "661": {
-    "XpPerLevel": 499750,
-    "UntilLevel": 662
+    "XpPerLevel": 630000,
+    "UntilLevel": 662,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "662": {
-    "XpPerLevel": 501750,
-    "UntilLevel": 663
+    "XpPerLevel": 633000,
+    "UntilLevel": 663,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "663": {
-    "XpPerLevel": 503750,
-    "UntilLevel": 664
+    "XpPerLevel": 636000,
+    "UntilLevel": 664,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "664": {
-    "XpPerLevel": 506000,
-    "UntilLevel": 665
+    "XpPerLevel": 639000,
+    "UntilLevel": 665,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "665": {
-    "XpPerLevel": 508000,
-    "UntilLevel": 666
+    "XpPerLevel": 641750,
+    "UntilLevel": 666,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "666": {
-    "XpPerLevel": 510000,
-    "UntilLevel": 667
+    "XpPerLevel": 644750,
+    "UntilLevel": 667,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "667": {
-    "XpPerLevel": 512250,
-    "UntilLevel": 668
+    "XpPerLevel": 647750,
+    "UntilLevel": 668,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "668": {
-    "XpPerLevel": 514250,
-    "UntilLevel": 669
+    "XpPerLevel": 650750,
+    "UntilLevel": 669,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "669": {
-    "XpPerLevel": 516250,
-    "UntilLevel": 670
+    "XpPerLevel": 653750,
+    "UntilLevel": 670,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "670": {
-    "XpPerLevel": 518500,
-    "UntilLevel": 671
+    "XpPerLevel": 656750,
+    "UntilLevel": 671,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "671": {
-    "XpPerLevel": 520500,
-    "UntilLevel": 672
+    "XpPerLevel": 659750,
+    "UntilLevel": 672,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "672": {
-    "XpPerLevel": 522750,
-    "UntilLevel": 673
+    "XpPerLevel": 663000,
+    "UntilLevel": 673,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "673": {
-    "XpPerLevel": 525000,
-    "UntilLevel": 674
+    "XpPerLevel": 666000,
+    "UntilLevel": 674,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "674": {
-    "XpPerLevel": 527000,
-    "UntilLevel": 675
+    "XpPerLevel": 669000,
+    "UntilLevel": 675,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "675": {
-    "XpPerLevel": 529250,
-    "UntilLevel": 676
+    "XpPerLevel": 672250,
+    "UntilLevel": 676,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "676": {
-    "XpPerLevel": 531500,
-    "UntilLevel": 677
+    "XpPerLevel": 675250,
+    "UntilLevel": 677,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "677": {
-    "XpPerLevel": 533500,
-    "UntilLevel": 678
+    "XpPerLevel": 678500,
+    "UntilLevel": 678,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "678": {
-    "XpPerLevel": 535750,
-    "UntilLevel": 679
+    "XpPerLevel": 681500,
+    "UntilLevel": 679,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "679": {
-    "XpPerLevel": 538000,
-    "UntilLevel": 680
+    "XpPerLevel": 684750,
+    "UntilLevel": 680,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "680": {
-    "XpPerLevel": 540250,
-    "UntilLevel": 681
+    "XpPerLevel": 687750,
+    "UntilLevel": 681,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "681": {
-    "XpPerLevel": 542500,
-    "UntilLevel": 682
+    "XpPerLevel": 691000,
+    "UntilLevel": 682,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "682": {
-    "XpPerLevel": 544750,
-    "UntilLevel": 683
+    "XpPerLevel": 694250,
+    "UntilLevel": 683,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "683": {
-    "XpPerLevel": 547000,
-    "UntilLevel": 684
+    "XpPerLevel": 697500,
+    "UntilLevel": 684,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "684": {
-    "XpPerLevel": 549250,
-    "UntilLevel": 685
+    "XpPerLevel": 700750,
+    "UntilLevel": 685,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "685": {
-    "XpPerLevel": 551500,
-    "UntilLevel": 686
+    "XpPerLevel": 704000,
+    "UntilLevel": 686,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "686": {
-    "XpPerLevel": 553750,
-    "UntilLevel": 687
+    "XpPerLevel": 707250,
+    "UntilLevel": 687,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "687": {
-    "XpPerLevel": 556000,
-    "UntilLevel": 688
+    "XpPerLevel": 710500,
+    "UntilLevel": 688,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "688": {
-    "XpPerLevel": 558250,
-    "UntilLevel": 689
+    "XpPerLevel": 713750,
+    "UntilLevel": 689,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "689": {
-    "XpPerLevel": 560500,
-    "UntilLevel": 690
+    "XpPerLevel": 717000,
+    "UntilLevel": 690,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "690": {
-    "XpPerLevel": 562750,
-    "UntilLevel": 691
+    "XpPerLevel": 720250,
+    "UntilLevel": 691,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "691": {
-    "XpPerLevel": 565250,
-    "UntilLevel": 692
+    "XpPerLevel": 723750,
+    "UntilLevel": 692,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "692": {
-    "XpPerLevel": 567500,
-    "UntilLevel": 693
+    "XpPerLevel": 727000,
+    "UntilLevel": 693,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "693": {
-    "XpPerLevel": 569750,
-    "UntilLevel": 694
+    "XpPerLevel": 730500,
+    "UntilLevel": 694,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "694": {
-    "XpPerLevel": 572250,
-    "UntilLevel": 695
+    "XpPerLevel": 733750,
+    "UntilLevel": 695,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "695": {
-    "XpPerLevel": 574500,
-    "UntilLevel": 696
+    "XpPerLevel": 737250,
+    "UntilLevel": 696,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "696": {
-    "XpPerLevel": 576750,
-    "UntilLevel": 697
+    "XpPerLevel": 740500,
+    "UntilLevel": 697,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "697": {
-    "XpPerLevel": 579250,
-    "UntilLevel": 698
+    "XpPerLevel": 744000,
+    "UntilLevel": 698,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "698": {
-    "XpPerLevel": 581500,
-    "UntilLevel": 699
+    "XpPerLevel": 747500,
+    "UntilLevel": 699,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "699": {
-    "XpPerLevel": 584000,
-    "UntilLevel": 700
+    "XpPerLevel": 751000,
+    "UntilLevel": 700,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "700": {
-    "XpPerLevel": 586500,
-    "UntilLevel": 701
+    "XpPerLevel": 754500,
+    "UntilLevel": 701,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "701": {
-    "XpPerLevel": 588750,
-    "UntilLevel": 702
+    "XpPerLevel": 758000,
+    "UntilLevel": 702,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "702": {
-    "XpPerLevel": 591250,
-    "UntilLevel": 703
+    "XpPerLevel": 761500,
+    "UntilLevel": 703,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "703": {
-    "XpPerLevel": 593750,
-    "UntilLevel": 704
+    "XpPerLevel": 765000,
+    "UntilLevel": 704,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "704": {
-    "XpPerLevel": 596000,
-    "UntilLevel": 705
+    "XpPerLevel": 768500,
+    "UntilLevel": 705,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "705": {
-    "XpPerLevel": 598500,
-    "UntilLevel": 706
+    "XpPerLevel": 772000,
+    "UntilLevel": 706,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "706": {
-    "XpPerLevel": 601000,
-    "UntilLevel": 707
+    "XpPerLevel": 775500,
+    "UntilLevel": 707,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "707": {
-    "XpPerLevel": 603500,
-    "UntilLevel": 708
+    "XpPerLevel": 779250,
+    "UntilLevel": 708,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "708": {
-    "XpPerLevel": 606000,
-    "UntilLevel": 709
+    "XpPerLevel": 782750,
+    "UntilLevel": 709,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "709": {
-    "XpPerLevel": 608500,
-    "UntilLevel": 710
+    "XpPerLevel": 786500,
+    "UntilLevel": 710,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "710": {
-    "XpPerLevel": 611000,
-    "UntilLevel": 711
+    "XpPerLevel": 790000,
+    "UntilLevel": 711,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "711": {
-    "XpPerLevel": 613500,
-    "UntilLevel": 712
+    "XpPerLevel": 793750,
+    "UntilLevel": 712,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "712": {
-    "XpPerLevel": 616000,
-    "UntilLevel": 713
+    "XpPerLevel": 797500,
+    "UntilLevel": 713,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "713": {
-    "XpPerLevel": 618500,
-    "UntilLevel": 714
+    "XpPerLevel": 801000,
+    "UntilLevel": 714,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "714": {
-    "XpPerLevel": 621000,
-    "UntilLevel": 715
+    "XpPerLevel": 804750,
+    "UntilLevel": 715,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "715": {
-    "XpPerLevel": 623750,
-    "UntilLevel": 716
+    "XpPerLevel": 808500,
+    "UntilLevel": 716,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "716": {
-    "XpPerLevel": 626250,
-    "UntilLevel": 717
+    "XpPerLevel": 812250,
+    "UntilLevel": 717,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "717": {
-    "XpPerLevel": 628750,
-    "UntilLevel": 718
+    "XpPerLevel": 816000,
+    "UntilLevel": 718,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "718": {
-    "XpPerLevel": 631250,
-    "UntilLevel": 719
+    "XpPerLevel": 819750,
+    "UntilLevel": 719,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "719": {
-    "XpPerLevel": 634000,
-    "UntilLevel": 720
+    "XpPerLevel": 823500,
+    "UntilLevel": 720,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "720": {
-    "XpPerLevel": 636500,
-    "UntilLevel": 721
+    "XpPerLevel": 827500,
+    "UntilLevel": 721,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "721": {
-    "XpPerLevel": 639250,
-    "UntilLevel": 722
+    "XpPerLevel": 831250,
+    "UntilLevel": 722,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "722": {
-    "XpPerLevel": 641750,
-    "UntilLevel": 723
+    "XpPerLevel": 835000,
+    "UntilLevel": 723,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "723": {
-    "XpPerLevel": 644500,
-    "UntilLevel": 724
+    "XpPerLevel": 839000,
+    "UntilLevel": 724,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "724": {
-    "XpPerLevel": 647000,
-    "UntilLevel": 725
+    "XpPerLevel": 842750,
+    "UntilLevel": 725,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "725": {
-    "XpPerLevel": 649750,
-    "UntilLevel": 726
+    "XpPerLevel": 846750,
+    "UntilLevel": 726,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "726": {
-    "XpPerLevel": 652500,
-    "UntilLevel": 727
+    "XpPerLevel": 850500,
+    "UntilLevel": 727,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "727": {
-    "XpPerLevel": 655000,
-    "UntilLevel": 728
+    "XpPerLevel": 854500,
+    "UntilLevel": 728,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "728": {
-    "XpPerLevel": 657750,
-    "UntilLevel": 729
+    "XpPerLevel": 858500,
+    "UntilLevel": 729,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "729": {
-    "XpPerLevel": 660500,
-    "UntilLevel": 730
+    "XpPerLevel": 862500,
+    "UntilLevel": 730,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "730": {
-    "XpPerLevel": 663250,
-    "UntilLevel": 731
+    "XpPerLevel": 866500,
+    "UntilLevel": 731,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "731": {
-    "XpPerLevel": 666000,
-    "UntilLevel": 732
+    "XpPerLevel": 870500,
+    "UntilLevel": 732,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "732": {
-    "XpPerLevel": 668750,
-    "UntilLevel": 733
+    "XpPerLevel": 874500,
+    "UntilLevel": 733,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "733": {
-    "XpPerLevel": 671500,
-    "UntilLevel": 734
+    "XpPerLevel": 878500,
+    "UntilLevel": 734,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "734": {
-    "XpPerLevel": 674250,
-    "UntilLevel": 735
+    "XpPerLevel": 882500,
+    "UntilLevel": 735,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "735": {
-    "XpPerLevel": 677000,
-    "UntilLevel": 736
+    "XpPerLevel": 886750,
+    "UntilLevel": 736,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "736": {
-    "XpPerLevel": 679750,
-    "UntilLevel": 737
+    "XpPerLevel": 890750,
+    "UntilLevel": 737,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "737": {
-    "XpPerLevel": 682500,
-    "UntilLevel": 738
+    "XpPerLevel": 895000,
+    "UntilLevel": 738,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "738": {
-    "XpPerLevel": 685250,
-    "UntilLevel": 739
+    "XpPerLevel": 899000,
+    "UntilLevel": 739,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "739": {
-    "XpPerLevel": 688250,
-    "UntilLevel": 740
+    "XpPerLevel": 903250,
+    "UntilLevel": 740,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "740": {
-    "XpPerLevel": 691000,
-    "UntilLevel": 741
+    "XpPerLevel": 907500,
+    "UntilLevel": 741,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "741": {
-    "XpPerLevel": 693750,
-    "UntilLevel": 742
+    "XpPerLevel": 911500,
+    "UntilLevel": 742,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "742": {
-    "XpPerLevel": 696750,
-    "UntilLevel": 743
+    "XpPerLevel": 915750,
+    "UntilLevel": 743,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "743": {
-    "XpPerLevel": 699500,
-    "UntilLevel": 744
+    "XpPerLevel": 920000,
+    "UntilLevel": 744,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "744": {
-    "XpPerLevel": 702500,
-    "UntilLevel": 745
+    "XpPerLevel": 924250,
+    "UntilLevel": 745,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "745": {
-    "XpPerLevel": 705250,
-    "UntilLevel": 746
+    "XpPerLevel": 928500,
+    "UntilLevel": 746,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "746": {
-    "XpPerLevel": 708250,
-    "UntilLevel": 747
+    "XpPerLevel": 933000,
+    "UntilLevel": 747,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "747": {
-    "XpPerLevel": 711250,
-    "UntilLevel": 748
+    "XpPerLevel": 937250,
+    "UntilLevel": 748,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "748": {
-    "XpPerLevel": 714000,
-    "UntilLevel": 749
+    "XpPerLevel": 941500,
+    "UntilLevel": 749,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "749": {
-    "XpPerLevel": 717000,
-    "UntilLevel": 750
+    "XpPerLevel": 946000,
+    "UntilLevel": 750,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "750": {
-    "XpPerLevel": 720000,
-    "UntilLevel": 751
+    "XpPerLevel": 950250,
+    "UntilLevel": 751,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "751": {
-    "XpPerLevel": 723000,
-    "UntilLevel": 752
+    "XpPerLevel": 954750,
+    "UntilLevel": 752,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "752": {
-    "XpPerLevel": 726000,
-    "UntilLevel": 753
+    "XpPerLevel": 959000,
+    "UntilLevel": 753,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "753": {
-    "XpPerLevel": 728750,
-    "UntilLevel": 754
+    "XpPerLevel": 963500,
+    "UntilLevel": 754,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "754": {
-    "XpPerLevel": 731750,
-    "UntilLevel": 755
+    "XpPerLevel": 968000,
+    "UntilLevel": 755,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "755": {
-    "XpPerLevel": 734750,
-    "UntilLevel": 756
+    "XpPerLevel": 972500,
+    "UntilLevel": 756,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "756": {
-    "XpPerLevel": 738000,
-    "UntilLevel": 757
+    "XpPerLevel": 977000,
+    "UntilLevel": 757,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "757": {
-    "XpPerLevel": 741000,
-    "UntilLevel": 758
+    "XpPerLevel": 981500,
+    "UntilLevel": 758,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "758": {
-    "XpPerLevel": 744000,
-    "UntilLevel": 759
+    "XpPerLevel": 986000,
+    "UntilLevel": 759,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "759": {
-    "XpPerLevel": 747000,
-    "UntilLevel": 760
+    "XpPerLevel": 990500,
+    "UntilLevel": 760,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "760": {
-    "XpPerLevel": 750000,
-    "UntilLevel": 761
+    "XpPerLevel": 995250,
+    "UntilLevel": 761,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "761": {
-    "XpPerLevel": 753250,
-    "UntilLevel": 762
+    "XpPerLevel": 999750,
+    "UntilLevel": 762,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "762": {
-    "XpPerLevel": 756250,
-    "UntilLevel": 763
+    "XpPerLevel": 1004500,
+    "UntilLevel": 763,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "763": {
-    "XpPerLevel": 759500,
-    "UntilLevel": 764
+    "XpPerLevel": 1009000,
+    "UntilLevel": 764,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "764": {
-    "XpPerLevel": 762500,
-    "UntilLevel": 765
+    "XpPerLevel": 1013750,
+    "UntilLevel": 765,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "765": {
-    "XpPerLevel": 765750,
-    "UntilLevel": 766
+    "XpPerLevel": 1018500,
+    "UntilLevel": 766,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "766": {
-    "XpPerLevel": 768750,
-    "UntilLevel": 767
+    "XpPerLevel": 1023250,
+    "UntilLevel": 767,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "767": {
-    "XpPerLevel": 772000,
-    "UntilLevel": 768
+    "XpPerLevel": 1028000,
+    "UntilLevel": 768,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "768": {
-    "XpPerLevel": 775250,
-    "UntilLevel": 769
+    "XpPerLevel": 1032750,
+    "UntilLevel": 769,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "769": {
-    "XpPerLevel": 778250,
-    "UntilLevel": 770
+    "XpPerLevel": 1037500,
+    "UntilLevel": 770,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "770": {
-    "XpPerLevel": 781500,
-    "UntilLevel": 771
+    "XpPerLevel": 1042250,
+    "UntilLevel": 771,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "771": {
-    "XpPerLevel": 784750,
-    "UntilLevel": 772
+    "XpPerLevel": 1047000,
+    "UntilLevel": 772,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "772": {
-    "XpPerLevel": 788000,
-    "UntilLevel": 773
+    "XpPerLevel": 1052000,
+    "UntilLevel": 773,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "773": {
-    "XpPerLevel": 791250,
-    "UntilLevel": 774
+    "XpPerLevel": 1056750,
+    "UntilLevel": 774,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "774": {
-    "XpPerLevel": 794500,
-    "UntilLevel": 775
+    "XpPerLevel": 1061750,
+    "UntilLevel": 775,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "775": {
-    "XpPerLevel": 797750,
-    "UntilLevel": 776
+    "XpPerLevel": 1066500,
+    "UntilLevel": 776,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "776": {
-    "XpPerLevel": 801000,
-    "UntilLevel": 777
+    "XpPerLevel": 1071500,
+    "UntilLevel": 777,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "777": {
-    "XpPerLevel": 804250,
-    "UntilLevel": 778
+    "XpPerLevel": 1076500,
+    "UntilLevel": 778,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "778": {
-    "XpPerLevel": 807500,
-    "UntilLevel": 779
+    "XpPerLevel": 1081500,
+    "UntilLevel": 779,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "779": {
-    "XpPerLevel": 811000,
-    "UntilLevel": 780
+    "XpPerLevel": 1086500,
+    "UntilLevel": 780,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "780": {
-    "XpPerLevel": 814250,
-    "UntilLevel": 781
+    "XpPerLevel": 1091500,
+    "UntilLevel": 781,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "781": {
-    "XpPerLevel": 817500,
-    "UntilLevel": 782
+    "XpPerLevel": 1096500,
+    "UntilLevel": 782,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "782": {
-    "XpPerLevel": 821000,
-    "UntilLevel": 783
+    "XpPerLevel": 1101500,
+    "UntilLevel": 783,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "783": {
-    "XpPerLevel": 824250,
-    "UntilLevel": 784
+    "XpPerLevel": 1106750,
+    "UntilLevel": 784,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "784": {
-    "XpPerLevel": 827750,
-    "UntilLevel": 785
+    "XpPerLevel": 1111750,
+    "UntilLevel": 785,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "785": {
-    "XpPerLevel": 831250,
-    "UntilLevel": 786
+    "XpPerLevel": 1117000,
+    "UntilLevel": 786,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "786": {
-    "XpPerLevel": 834500,
-    "UntilLevel": 787
+    "XpPerLevel": 1122000,
+    "UntilLevel": 787,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "787": {
-    "XpPerLevel": 838000,
-    "UntilLevel": 788
+    "XpPerLevel": 1127250,
+    "UntilLevel": 788,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "788": {
-    "XpPerLevel": 841500,
-    "UntilLevel": 789
+    "XpPerLevel": 1132500,
+    "UntilLevel": 789,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "789": {
-    "XpPerLevel": 845000,
-    "UntilLevel": 790
+    "XpPerLevel": 1137750,
+    "UntilLevel": 790,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "790": {
-    "XpPerLevel": 848250,
-    "UntilLevel": 791
+    "XpPerLevel": 1143000,
+    "UntilLevel": 791,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "791": {
-    "XpPerLevel": 851750,
-    "UntilLevel": 792
+    "XpPerLevel": 1148250,
+    "UntilLevel": 792,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "792": {
-    "XpPerLevel": 855250,
-    "UntilLevel": 793
+    "XpPerLevel": 1153750,
+    "UntilLevel": 793,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "793": {
-    "XpPerLevel": 858750,
-    "UntilLevel": 794
+    "XpPerLevel": 1159000,
+    "UntilLevel": 794,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "794": {
-    "XpPerLevel": 862500,
-    "UntilLevel": 795
+    "XpPerLevel": 1164250,
+    "UntilLevel": 795,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "795": {
-    "XpPerLevel": 866000,
-    "UntilLevel": 796
+    "XpPerLevel": 1169750,
+    "UntilLevel": 796,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "796": {
-    "XpPerLevel": 869500,
-    "UntilLevel": 797
+    "XpPerLevel": 1175250,
+    "UntilLevel": 797,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "797": {
-    "XpPerLevel": 873000,
-    "UntilLevel": 798
+    "XpPerLevel": 1180500,
+    "UntilLevel": 798,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "798": {
-    "XpPerLevel": 876750,
-    "UntilLevel": 799
+    "XpPerLevel": 1186000,
+    "UntilLevel": 799,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "799": {
-    "XpPerLevel": 880250,
-    "UntilLevel": 800
+    "XpPerLevel": 1191500,
+    "UntilLevel": 800,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "800": {
-    "XpPerLevel": 884000,
-    "UntilLevel": 801
+    "XpPerLevel": 1197000,
+    "UntilLevel": 801,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "801": {
-    "XpPerLevel": 887500,
-    "UntilLevel": 802
+    "XpPerLevel": 1202500,
+    "UntilLevel": 802,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "802": {
-    "XpPerLevel": 891250,
-    "UntilLevel": 803
+    "XpPerLevel": 1208250,
+    "UntilLevel": 803,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "803": {
-    "XpPerLevel": 894750,
-    "UntilLevel": 804
+    "XpPerLevel": 1213750,
+    "UntilLevel": 804,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "804": {
-    "XpPerLevel": 898500,
-    "UntilLevel": 805
+    "XpPerLevel": 1219250,
+    "UntilLevel": 805,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "805": {
-    "XpPerLevel": 902250,
-    "UntilLevel": 806
+    "XpPerLevel": 1225000,
+    "UntilLevel": 806,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "806": {
-    "XpPerLevel": 906000,
-    "UntilLevel": 807
+    "XpPerLevel": 1230750,
+    "UntilLevel": 807,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "807": {
-    "XpPerLevel": 909750,
-    "UntilLevel": 808
+    "XpPerLevel": 1236250,
+    "UntilLevel": 808,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "808": {
-    "XpPerLevel": 913500,
-    "UntilLevel": 809
+    "XpPerLevel": 1242000,
+    "UntilLevel": 809,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "809": {
-    "XpPerLevel": 917250,
-    "UntilLevel": 810
+    "XpPerLevel": 1247750,
+    "UntilLevel": 810,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "810": {
-    "XpPerLevel": 921000,
-    "UntilLevel": 811
+    "XpPerLevel": 1253500,
+    "UntilLevel": 811,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "811": {
-    "XpPerLevel": 924750,
-    "UntilLevel": 812
+    "XpPerLevel": 1259500,
+    "UntilLevel": 812,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "812": {
-    "XpPerLevel": 928500,
-    "UntilLevel": 813
+    "XpPerLevel": 1265250,
+    "UntilLevel": 813,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "813": {
-    "XpPerLevel": 932250,
-    "UntilLevel": 814
+    "XpPerLevel": 1271000,
+    "UntilLevel": 814,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "814": {
-    "XpPerLevel": 936250,
-    "UntilLevel": 815
+    "XpPerLevel": 1277000,
+    "UntilLevel": 815,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "815": {
-    "XpPerLevel": 940000,
-    "UntilLevel": 816
+    "XpPerLevel": 1283000,
+    "UntilLevel": 816,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "816": {
-    "XpPerLevel": 944000,
-    "UntilLevel": 817
+    "XpPerLevel": 1288750,
+    "UntilLevel": 817,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "817": {
-    "XpPerLevel": 947750,
-    "UntilLevel": 818
+    "XpPerLevel": 1294750,
+    "UntilLevel": 818,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "818": {
-    "XpPerLevel": 951750,
-    "UntilLevel": 819
+    "XpPerLevel": 1300750,
+    "UntilLevel": 819,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "819": {
-    "XpPerLevel": 955500,
-    "UntilLevel": 820
+    "XpPerLevel": 1306750,
+    "UntilLevel": 820,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "820": {
-    "XpPerLevel": 959500,
-    "UntilLevel": 821
+    "XpPerLevel": 1312750,
+    "UntilLevel": 821,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "821": {
-    "XpPerLevel": 963500,
-    "UntilLevel": 822
+    "XpPerLevel": 1319000,
+    "UntilLevel": 822,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "822": {
-    "XpPerLevel": 967500,
-    "UntilLevel": 823
+    "XpPerLevel": 1325000,
+    "UntilLevel": 823,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "823": {
-    "XpPerLevel": 971500,
-    "UntilLevel": 824
+    "XpPerLevel": 1331250,
+    "UntilLevel": 824,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "824": {
-    "XpPerLevel": 975500,
-    "UntilLevel": 825
+    "XpPerLevel": 1337250,
+    "UntilLevel": 825,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "825": {
-    "XpPerLevel": 979500,
-    "UntilLevel": 826
+    "XpPerLevel": 1343500,
+    "UntilLevel": 826,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "826": {
-    "XpPerLevel": 983500,
-    "UntilLevel": 827
+    "XpPerLevel": 1349750,
+    "UntilLevel": 827,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "827": {
-    "XpPerLevel": 987500,
-    "UntilLevel": 828
+    "XpPerLevel": 1356000,
+    "UntilLevel": 828,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "828": {
-    "XpPerLevel": 991500,
-    "UntilLevel": 829
+    "XpPerLevel": 1362250,
+    "UntilLevel": 829,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "829": {
-    "XpPerLevel": 995500,
-    "UntilLevel": 830
+    "XpPerLevel": 1368500,
+    "UntilLevel": 830,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "830": {
-    "XpPerLevel": 999750,
-    "UntilLevel": 831
+    "XpPerLevel": 1374750,
+    "UntilLevel": 831,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "831": {
-    "XpPerLevel": 1003750,
-    "UntilLevel": 832
+    "XpPerLevel": 1381250,
+    "UntilLevel": 832,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "832": {
-    "XpPerLevel": 1008000,
-    "UntilLevel": 833
+    "XpPerLevel": 1387750,
+    "UntilLevel": 833,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "833": {
-    "XpPerLevel": 1012000,
-    "UntilLevel": 834
+    "XpPerLevel": 1394000,
+    "UntilLevel": 834,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "834": {
-    "XpPerLevel": 1016250,
-    "UntilLevel": 835
+    "XpPerLevel": 1400500,
+    "UntilLevel": 835,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "835": {
-    "XpPerLevel": 1020500,
-    "UntilLevel": 836
+    "XpPerLevel": 1407000,
+    "UntilLevel": 836,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "836": {
-    "XpPerLevel": 1024500,
-    "UntilLevel": 837
+    "XpPerLevel": 1413500,
+    "UntilLevel": 837,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "837": {
-    "XpPerLevel": 1028750,
-    "UntilLevel": 838
+    "XpPerLevel": 1420000,
+    "UntilLevel": 838,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "838": {
-    "XpPerLevel": 1033000,
-    "UntilLevel": 839
+    "XpPerLevel": 1426500,
+    "UntilLevel": 839,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "839": {
-    "XpPerLevel": 1037250,
-    "UntilLevel": 840
+    "XpPerLevel": 1433250,
+    "UntilLevel": 840,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "840": {
-    "XpPerLevel": 1041500,
-    "UntilLevel": 841
+    "XpPerLevel": 1439750,
+    "UntilLevel": 841,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "841": {
-    "XpPerLevel": 1045750,
-    "UntilLevel": 842
+    "XpPerLevel": 1446500,
+    "UntilLevel": 842,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "842": {
-    "XpPerLevel": 1050250,
-    "UntilLevel": 843
+    "XpPerLevel": 1453250,
+    "UntilLevel": 843,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "843": {
-    "XpPerLevel": 1054500,
-    "UntilLevel": 844
+    "XpPerLevel": 1460000,
+    "UntilLevel": 844,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "844": {
-    "XpPerLevel": 1058750,
-    "UntilLevel": 845
+    "XpPerLevel": 1466750,
+    "UntilLevel": 845,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "845": {
-    "XpPerLevel": 1063250,
-    "UntilLevel": 846
+    "XpPerLevel": 1473500,
+    "UntilLevel": 846,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "846": {
-    "XpPerLevel": 1067500,
-    "UntilLevel": 847
+    "XpPerLevel": 1480250,
+    "UntilLevel": 847,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "847": {
-    "XpPerLevel": 1072000,
-    "UntilLevel": 848
+    "XpPerLevel": 1487250,
+    "UntilLevel": 848,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "848": {
-    "XpPerLevel": 1076250,
-    "UntilLevel": 849
+    "XpPerLevel": 1494000,
+    "UntilLevel": 849,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "849": {
-    "XpPerLevel": 1080750,
-    "UntilLevel": 850
+    "XpPerLevel": 1501000,
+    "UntilLevel": 850,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "850": {
-    "XpPerLevel": 1085250,
-    "UntilLevel": 851
+    "XpPerLevel": 1507750,
+    "UntilLevel": 851,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "851": {
-    "XpPerLevel": 1089750,
-    "UntilLevel": 852
+    "XpPerLevel": 1514750,
+    "UntilLevel": 852,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "852": {
-    "XpPerLevel": 1094250,
-    "UntilLevel": 853
+    "XpPerLevel": 1521750,
+    "UntilLevel": 853,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "853": {
-    "XpPerLevel": 1098750,
-    "UntilLevel": 854
+    "XpPerLevel": 1529000,
+    "UntilLevel": 854,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "854": {
-    "XpPerLevel": 1103250,
-    "UntilLevel": 855
+    "XpPerLevel": 1536000,
+    "UntilLevel": 855,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "855": {
-    "XpPerLevel": 1107750,
-    "UntilLevel": 856
+    "XpPerLevel": 1543000,
+    "UntilLevel": 856,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "856": {
-    "XpPerLevel": 1112250,
-    "UntilLevel": 857
+    "XpPerLevel": 1550250,
+    "UntilLevel": 857,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "857": {
-    "XpPerLevel": 1116750,
-    "UntilLevel": 858
+    "XpPerLevel": 1557500,
+    "UntilLevel": 858,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "858": {
-    "XpPerLevel": 1121500,
-    "UntilLevel": 859
+    "XpPerLevel": 1564500,
+    "UntilLevel": 859,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "859": {
-    "XpPerLevel": 1126000,
-    "UntilLevel": 860
+    "XpPerLevel": 1571750,
+    "UntilLevel": 860,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "860": {
-    "XpPerLevel": 1130750,
-    "UntilLevel": 861
+    "XpPerLevel": 1579000,
+    "UntilLevel": 861,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "861": {
-    "XpPerLevel": 1135250,
-    "UntilLevel": 862
+    "XpPerLevel": 1586500,
+    "UntilLevel": 862,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "862": {
-    "XpPerLevel": 1140000,
-    "UntilLevel": 863
+    "XpPerLevel": 1593750,
+    "UntilLevel": 863,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "863": {
-    "XpPerLevel": 1144750,
-    "UntilLevel": 864
+    "XpPerLevel": 1601250,
+    "UntilLevel": 864,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "864": {
-    "XpPerLevel": 1149250,
-    "UntilLevel": 865
+    "XpPerLevel": 1608500,
+    "UntilLevel": 865,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "865": {
-    "XpPerLevel": 1154000,
-    "UntilLevel": 866
+    "XpPerLevel": 1616000,
+    "UntilLevel": 866,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "866": {
-    "XpPerLevel": 1158750,
-    "UntilLevel": 867
+    "XpPerLevel": 1623500,
+    "UntilLevel": 867,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "867": {
-    "XpPerLevel": 1163500,
-    "UntilLevel": 868
+    "XpPerLevel": 1631000,
+    "UntilLevel": 868,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "868": {
-    "XpPerLevel": 1168250,
-    "UntilLevel": 869
+    "XpPerLevel": 1638500,
+    "UntilLevel": 869,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "869": {
-    "XpPerLevel": 1173250,
-    "UntilLevel": 870
+    "XpPerLevel": 1646000,
+    "UntilLevel": 870,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "870": {
-    "XpPerLevel": 1178000,
-    "UntilLevel": 871
+    "XpPerLevel": 1653750,
+    "UntilLevel": 871,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "871": {
-    "XpPerLevel": 1182750,
-    "UntilLevel": 872
+    "XpPerLevel": 1661500,
+    "UntilLevel": 872,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "872": {
-    "XpPerLevel": 1187750,
-    "UntilLevel": 873
+    "XpPerLevel": 1669000,
+    "UntilLevel": 873,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "873": {
-    "XpPerLevel": 1192500,
-    "UntilLevel": 874
+    "XpPerLevel": 1676750,
+    "UntilLevel": 874,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "874": {
-    "XpPerLevel": 1197500,
-    "UntilLevel": 875
+    "XpPerLevel": 1684500,
+    "UntilLevel": 875,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "875": {
-    "XpPerLevel": 1202500,
-    "UntilLevel": 876
+    "XpPerLevel": 1692250,
+    "UntilLevel": 876,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "876": {
-    "XpPerLevel": 1207250,
-    "UntilLevel": 877
+    "XpPerLevel": 1700250,
+    "UntilLevel": 877,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "877": {
-    "XpPerLevel": 1212250,
-    "UntilLevel": 878
+    "XpPerLevel": 1708000,
+    "UntilLevel": 878,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "878": {
-    "XpPerLevel": 1217250,
-    "UntilLevel": 879
+    "XpPerLevel": 1716000,
+    "UntilLevel": 879,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "879": {
-    "XpPerLevel": 1222250,
-    "UntilLevel": 880
+    "XpPerLevel": 1724000,
+    "UntilLevel": 880,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "880": {
-    "XpPerLevel": 1227250,
-    "UntilLevel": 881
+    "XpPerLevel": 1732000,
+    "UntilLevel": 881,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "881": {
-    "XpPerLevel": 1232500,
-    "UntilLevel": 882
+    "XpPerLevel": 1740000,
+    "UntilLevel": 882,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "882": {
-    "XpPerLevel": 1237500,
-    "UntilLevel": 883
+    "XpPerLevel": 1748000,
+    "UntilLevel": 883,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "883": {
-    "XpPerLevel": 1242500,
-    "UntilLevel": 884
+    "XpPerLevel": 1756000,
+    "UntilLevel": 884,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "884": {
-    "XpPerLevel": 1247750,
-    "UntilLevel": 885
+    "XpPerLevel": 1764250,
+    "UntilLevel": 885,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "885": {
-    "XpPerLevel": 1252750,
-    "UntilLevel": 886
+    "XpPerLevel": 1772250,
+    "UntilLevel": 886,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "886": {
-    "XpPerLevel": 1258000,
-    "UntilLevel": 887
+    "XpPerLevel": 1780500,
+    "UntilLevel": 887,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "887": {
-    "XpPerLevel": 1263000,
-    "UntilLevel": 888
+    "XpPerLevel": 1788750,
+    "UntilLevel": 888,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "888": {
-    "XpPerLevel": 1268250,
-    "UntilLevel": 889
+    "XpPerLevel": 1797000,
+    "UntilLevel": 889,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "889": {
-    "XpPerLevel": 1273500,
-    "UntilLevel": 890
+    "XpPerLevel": 1805250,
+    "UntilLevel": 890,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "890": {
-    "XpPerLevel": 1278750,
-    "UntilLevel": 891
+    "XpPerLevel": 1813750,
+    "UntilLevel": 891,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "891": {
-    "XpPerLevel": 1284000,
-    "UntilLevel": 892
+    "XpPerLevel": 1822000,
+    "UntilLevel": 892,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "892": {
-    "XpPerLevel": 1289250,
-    "UntilLevel": 893
+    "XpPerLevel": 1830500,
+    "UntilLevel": 893,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "893": {
-    "XpPerLevel": 1294500,
-    "UntilLevel": 894
+    "XpPerLevel": 1839000,
+    "UntilLevel": 894,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "894": {
-    "XpPerLevel": 1300000,
-    "UntilLevel": 895
+    "XpPerLevel": 1847500,
+    "UntilLevel": 895,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "895": {
-    "XpPerLevel": 1305250,
-    "UntilLevel": 896
+    "XpPerLevel": 1856000,
+    "UntilLevel": 896,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "896": {
-    "XpPerLevel": 1310750,
-    "UntilLevel": 897
+    "XpPerLevel": 1864750,
+    "UntilLevel": 897,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "897": {
-    "XpPerLevel": 1316000,
-    "UntilLevel": 898
+    "XpPerLevel": 1873250,
+    "UntilLevel": 898,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "898": {
-    "XpPerLevel": 1321500,
-    "UntilLevel": 899
+    "XpPerLevel": 1882000,
+    "UntilLevel": 899,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "899": {
-    "XpPerLevel": 1326750,
-    "UntilLevel": 900
+    "XpPerLevel": 1890750,
+    "UntilLevel": 900,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "900": {
-    "XpPerLevel": 1332250,
-    "UntilLevel": 901
+    "XpPerLevel": 1899500,
+    "UntilLevel": 901,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "901": {
-    "XpPerLevel": 1337750,
-    "UntilLevel": 902
+    "XpPerLevel": 1908250,
+    "UntilLevel": 902,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "902": {
-    "XpPerLevel": 1343250,
-    "UntilLevel": 903
+    "XpPerLevel": 1917000,
+    "UntilLevel": 903,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "903": {
-    "XpPerLevel": 1348750,
-    "UntilLevel": 904
+    "XpPerLevel": 1926000,
+    "UntilLevel": 904,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "904": {
-    "XpPerLevel": 1354250,
-    "UntilLevel": 905
+    "XpPerLevel": 1934750,
+    "UntilLevel": 905,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "905": {
-    "XpPerLevel": 1360000,
-    "UntilLevel": 906
+    "XpPerLevel": 1943750,
+    "UntilLevel": 906,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "906": {
-    "XpPerLevel": 1365500,
-    "UntilLevel": 907
+    "XpPerLevel": 1952750,
+    "UntilLevel": 907,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "907": {
-    "XpPerLevel": 1371250,
-    "UntilLevel": 908
+    "XpPerLevel": 1961750,
+    "UntilLevel": 908,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "908": {
-    "XpPerLevel": 1376750,
-    "UntilLevel": 909
+    "XpPerLevel": 1970750,
+    "UntilLevel": 909,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "909": {
-    "XpPerLevel": 1382500,
-    "UntilLevel": 910
+    "XpPerLevel": 1980000,
+    "UntilLevel": 910,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "910": {
-    "XpPerLevel": 1388000,
-    "UntilLevel": 911
+    "XpPerLevel": 1989250,
+    "UntilLevel": 911,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "911": {
-    "XpPerLevel": 1393750,
-    "UntilLevel": 912
+    "XpPerLevel": 1998250,
+    "UntilLevel": 912,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "912": {
-    "XpPerLevel": 1399500,
-    "UntilLevel": 913
+    "XpPerLevel": 2007500,
+    "UntilLevel": 913,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "913": {
-    "XpPerLevel": 1405250,
-    "UntilLevel": 914
+    "XpPerLevel": 2017000,
+    "UntilLevel": 914,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "914": {
-    "XpPerLevel": 1411000,
-    "UntilLevel": 915
+    "XpPerLevel": 2026250,
+    "UntilLevel": 915,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "915": {
-    "XpPerLevel": 1417000,
-    "UntilLevel": 916
+    "XpPerLevel": 2035500,
+    "UntilLevel": 916,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "916": {
-    "XpPerLevel": 1422750,
-    "UntilLevel": 917
+    "XpPerLevel": 2045000,
+    "UntilLevel": 917,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "917": {
-    "XpPerLevel": 1428500,
-    "UntilLevel": 918
+    "XpPerLevel": 2054500,
+    "UntilLevel": 918,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "918": {
-    "XpPerLevel": 1434500,
-    "UntilLevel": 919
+    "XpPerLevel": 2064000,
+    "UntilLevel": 919,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "919": {
-    "XpPerLevel": 1440250,
-    "UntilLevel": 920
+    "XpPerLevel": 2073500,
+    "UntilLevel": 920,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "920": {
-    "XpPerLevel": 1446250,
-    "UntilLevel": 921
+    "XpPerLevel": 2083250,
+    "UntilLevel": 921,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "921": {
-    "XpPerLevel": 1452250,
-    "UntilLevel": 922
+    "XpPerLevel": 2092750,
+    "UntilLevel": 922,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "922": {
-    "XpPerLevel": 1458250,
-    "UntilLevel": 923
+    "XpPerLevel": 2102500,
+    "UntilLevel": 923,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "923": {
-    "XpPerLevel": 1464250,
-    "UntilLevel": 924
+    "XpPerLevel": 2112250,
+    "UntilLevel": 924,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "924": {
-    "XpPerLevel": 1470250,
-    "UntilLevel": 925
+    "XpPerLevel": 2122000,
+    "UntilLevel": 925,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "925": {
-    "XpPerLevel": 1476250,
-    "UntilLevel": 926
+    "XpPerLevel": 2131750,
+    "UntilLevel": 926,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "926": {
-    "XpPerLevel": 1482250,
-    "UntilLevel": 927
+    "XpPerLevel": 2141750,
+    "UntilLevel": 927,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "927": {
-    "XpPerLevel": 1488500,
-    "UntilLevel": 928
+    "XpPerLevel": 2151500,
+    "UntilLevel": 928,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "928": {
-    "XpPerLevel": 1494500,
-    "UntilLevel": 929
+    "XpPerLevel": 2161500,
+    "UntilLevel": 929,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "929": {
-    "XpPerLevel": 1500750,
-    "UntilLevel": 930
+    "XpPerLevel": 2171500,
+    "UntilLevel": 930,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "930": {
-    "XpPerLevel": 1506750,
-    "UntilLevel": 931
+    "XpPerLevel": 2181500,
+    "UntilLevel": 931,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "931": {
-    "XpPerLevel": 1513000,
-    "UntilLevel": 932
+    "XpPerLevel": 2191750,
+    "UntilLevel": 932,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "932": {
-    "XpPerLevel": 1519250,
-    "UntilLevel": 933
+    "XpPerLevel": 2201750,
+    "UntilLevel": 933,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "933": {
-    "XpPerLevel": 1525500,
-    "UntilLevel": 934
+    "XpPerLevel": 2212000,
+    "UntilLevel": 934,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "934": {
-    "XpPerLevel": 1531750,
-    "UntilLevel": 935
+    "XpPerLevel": 2222250,
+    "UntilLevel": 935,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "935": {
-    "XpPerLevel": 1538000,
-    "UntilLevel": 936
+    "XpPerLevel": 2232500,
+    "UntilLevel": 936,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "936": {
-    "XpPerLevel": 1544500,
-    "UntilLevel": 937
+    "XpPerLevel": 2242750,
+    "UntilLevel": 937,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "937": {
-    "XpPerLevel": 1550750,
-    "UntilLevel": 938
+    "XpPerLevel": 2253250,
+    "UntilLevel": 938,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "938": {
-    "XpPerLevel": 1557250,
-    "UntilLevel": 939
+    "XpPerLevel": 2263750,
+    "UntilLevel": 939,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "939": {
-    "XpPerLevel": 1563500,
-    "UntilLevel": 940
+    "XpPerLevel": 2274250,
+    "UntilLevel": 940,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "940": {
-    "XpPerLevel": 1570000,
-    "UntilLevel": 941
+    "XpPerLevel": 2284750,
+    "UntilLevel": 941,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "941": {
-    "XpPerLevel": 1576500,
-    "UntilLevel": 942
+    "XpPerLevel": 2295250,
+    "UntilLevel": 942,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "942": {
-    "XpPerLevel": 1583000,
-    "UntilLevel": 943
+    "XpPerLevel": 2305750,
+    "UntilLevel": 943,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "943": {
-    "XpPerLevel": 1589500,
-    "UntilLevel": 944
+    "XpPerLevel": 2316500,
+    "UntilLevel": 944,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "944": {
-    "XpPerLevel": 1596000,
-    "UntilLevel": 945
+    "XpPerLevel": 2327250,
+    "UntilLevel": 945,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "945": {
-    "XpPerLevel": 1602500,
-    "UntilLevel": 946
+    "XpPerLevel": 2338000,
+    "UntilLevel": 946,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "946": {
-    "XpPerLevel": 1609000,
-    "UntilLevel": 947
+    "XpPerLevel": 2348750,
+    "UntilLevel": 947,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "947": {
-    "XpPerLevel": 1615750,
-    "UntilLevel": 948
+    "XpPerLevel": 2359750,
+    "UntilLevel": 948,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "948": {
-    "XpPerLevel": 1622250,
-    "UntilLevel": 949
+    "XpPerLevel": 2370500,
+    "UntilLevel": 949,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "949": {
-    "XpPerLevel": 1629000,
-    "UntilLevel": 950
+    "XpPerLevel": 2381500,
+    "UntilLevel": 950,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "950": {
-    "XpPerLevel": 1635750,
-    "UntilLevel": 951
+    "XpPerLevel": 2392500,
+    "UntilLevel": 951,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "951": {
-    "XpPerLevel": 1642500,
-    "UntilLevel": 952
+    "XpPerLevel": 2403750,
+    "UntilLevel": 952,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "952": {
-    "XpPerLevel": 1649250,
-    "UntilLevel": 953
+    "XpPerLevel": 2414750,
+    "UntilLevel": 953,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "953": {
-    "XpPerLevel": 1656000,
-    "UntilLevel": 954
+    "XpPerLevel": 2426000,
+    "UntilLevel": 954,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "954": {
-    "XpPerLevel": 1662750,
-    "UntilLevel": 955
+    "XpPerLevel": 2437250,
+    "UntilLevel": 955,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "955": {
-    "XpPerLevel": 1669750,
-    "UntilLevel": 956
+    "XpPerLevel": 2448500,
+    "UntilLevel": 956,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "956": {
-    "XpPerLevel": 1676500,
-    "UntilLevel": 957
+    "XpPerLevel": 2459750,
+    "UntilLevel": 957,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "957": {
-    "XpPerLevel": 1683500,
-    "UntilLevel": 958
+    "XpPerLevel": 2471250,
+    "UntilLevel": 958,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "958": {
-    "XpPerLevel": 1690250,
-    "UntilLevel": 959
+    "XpPerLevel": 2482750,
+    "UntilLevel": 959,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "959": {
-    "XpPerLevel": 1697250,
-    "UntilLevel": 960
+    "XpPerLevel": 2494000,
+    "UntilLevel": 960,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "960": {
-    "XpPerLevel": 1704250,
-    "UntilLevel": 961
+    "XpPerLevel": 2505750,
+    "UntilLevel": 961,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "961": {
-    "XpPerLevel": 1711250,
-    "UntilLevel": 962
+    "XpPerLevel": 2517250,
+    "UntilLevel": 962,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "962": {
-    "XpPerLevel": 1718250,
-    "UntilLevel": 963
+    "XpPerLevel": 2529000,
+    "UntilLevel": 963,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "963": {
-    "XpPerLevel": 1725250,
-    "UntilLevel": 964
+    "XpPerLevel": 2540500,
+    "UntilLevel": 964,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "964": {
-    "XpPerLevel": 1732500,
-    "UntilLevel": 965
+    "XpPerLevel": 2552250,
+    "UntilLevel": 965,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "965": {
-    "XpPerLevel": 1739500,
-    "UntilLevel": 966
+    "XpPerLevel": 2564250,
+    "UntilLevel": 966,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "966": {
-    "XpPerLevel": 1746750,
-    "UntilLevel": 967
+    "XpPerLevel": 2576000,
+    "UntilLevel": 967,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "967": {
-    "XpPerLevel": 1754000,
-    "UntilLevel": 968
+    "XpPerLevel": 2588000,
+    "UntilLevel": 968,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "968": {
-    "XpPerLevel": 1761000,
-    "UntilLevel": 969
+    "XpPerLevel": 2600000,
+    "UntilLevel": 969,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "969": {
-    "XpPerLevel": 1768250,
-    "UntilLevel": 970
+    "XpPerLevel": 2612000,
+    "UntilLevel": 970,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "970": {
-    "XpPerLevel": 1775500,
-    "UntilLevel": 971
+    "XpPerLevel": 2624000,
+    "UntilLevel": 971,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "971": {
-    "XpPerLevel": 1783000,
-    "UntilLevel": 972
+    "XpPerLevel": 2636250,
+    "UntilLevel": 972,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "972": {
-    "XpPerLevel": 1790250,
-    "UntilLevel": 973
+    "XpPerLevel": 2648500,
+    "UntilLevel": 973,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "973": {
-    "XpPerLevel": 1797500,
-    "UntilLevel": 974
+    "XpPerLevel": 2660750,
+    "UntilLevel": 974,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "974": {
-    "XpPerLevel": 1805000,
-    "UntilLevel": 975
+    "XpPerLevel": 2673000,
+    "UntilLevel": 975,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "975": {
-    "XpPerLevel": 1812500,
-    "UntilLevel": 976
+    "XpPerLevel": 2685250,
+    "UntilLevel": 976,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "976": {
-    "XpPerLevel": 1820000,
-    "UntilLevel": 977
+    "XpPerLevel": 2697750,
+    "UntilLevel": 977,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "977": {
-    "XpPerLevel": 1827250,
-    "UntilLevel": 978
+    "XpPerLevel": 2710250,
+    "UntilLevel": 978,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "978": {
-    "XpPerLevel": 1835000,
-    "UntilLevel": 979
+    "XpPerLevel": 2722750,
+    "UntilLevel": 979,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "979": {
-    "XpPerLevel": 1842500,
-    "UntilLevel": 980
+    "XpPerLevel": 2735500,
+    "UntilLevel": 980,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "980": {
-    "XpPerLevel": 1850000,
-    "UntilLevel": 981
+    "XpPerLevel": 2748000,
+    "UntilLevel": 981,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "981": {
-    "XpPerLevel": 1857500,
-    "UntilLevel": 982
+    "XpPerLevel": 2760750,
+    "UntilLevel": 982,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "982": {
-    "XpPerLevel": 1865250,
-    "UntilLevel": 983
+    "XpPerLevel": 2773500,
+    "UntilLevel": 983,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "983": {
-    "XpPerLevel": 1873000,
-    "UntilLevel": 984
+    "XpPerLevel": 2786500,
+    "UntilLevel": 984,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "984": {
-    "XpPerLevel": 1880500,
-    "UntilLevel": 985
+    "XpPerLevel": 2799250,
+    "UntilLevel": 985,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "985": {
-    "XpPerLevel": 1888250,
-    "UntilLevel": 986
+    "XpPerLevel": 2812250,
+    "UntilLevel": 986,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "986": {
-    "XpPerLevel": 1896000,
-    "UntilLevel": 987
+    "XpPerLevel": 2825250,
+    "UntilLevel": 987,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "987": {
-    "XpPerLevel": 1904000,
-    "UntilLevel": 988
+    "XpPerLevel": 2838250,
+    "UntilLevel": 988,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "988": {
-    "XpPerLevel": 1911750,
-    "UntilLevel": 989
+    "XpPerLevel": 2851500,
+    "UntilLevel": 989,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "989": {
-    "XpPerLevel": 1919500,
-    "UntilLevel": 990
+    "XpPerLevel": 2864750,
+    "UntilLevel": 990,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "990": {
-    "XpPerLevel": 1927500,
-    "UntilLevel": 991
+    "XpPerLevel": 2878000,
+    "UntilLevel": 991,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "991": {
-    "XpPerLevel": 1935500,
-    "UntilLevel": 992
+    "XpPerLevel": 2891250,
+    "UntilLevel": 992,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "992": {
-    "XpPerLevel": 1943250,
-    "UntilLevel": 993
+    "XpPerLevel": 2904500,
+    "UntilLevel": 993,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "993": {
-    "XpPerLevel": 1951250,
-    "UntilLevel": 994
+    "XpPerLevel": 2918000,
+    "UntilLevel": 994,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "994": {
-    "XpPerLevel": 1959500,
-    "UntilLevel": 995
+    "XpPerLevel": 2931500,
+    "UntilLevel": 995,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "995": {
-    "XpPerLevel": 1967500,
-    "UntilLevel": 996
+    "XpPerLevel": 2945000,
+    "UntilLevel": 996,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "996": {
-    "XpPerLevel": 1975500,
-    "UntilLevel": 997
+    "XpPerLevel": 2958750,
+    "UntilLevel": 997,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "997": {
-    "XpPerLevel": 1983750,
-    "UntilLevel": 998
+    "XpPerLevel": 2972500,
+    "UntilLevel": 998,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "998": {
-    "XpPerLevel": 1991750,
-    "UntilLevel": 999
+    "XpPerLevel": 2986250,
+    "UntilLevel": 999,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   },
   "999": {
-    "XpPerLevel": 2000000,
-    "UntilLevel": 1000
+    "XpPerLevel": 3000000,
+    "UntilLevel": 1000,
+    "RewardItemAssetPerLevel": {
+      "AssetPathName": "None",
+      "SubPathString": ""
+    },
+    "RewardItemCountPerLevel": 0
   }
 }

--- a/TestFiles/index.js
+++ b/TestFiles/index.js
@@ -186,7 +186,7 @@ for (var index in datafile) {
     if (e.TemplateId != "") {
       templatePush = e.TemplateId;
     } else {
-      if (e.ItemDefinition.AssetPathName) {
+      if (e.ItemDefinition.AssetPathName && e.ItemDefinition.AssetPathName.includes(".")) {
         var test = e.ItemDefinition.AssetPathName.split(".")[1].toLowerCase();
         console.log(e.ItemDefinition.AssetPathName);
         //console.log(test);
@@ -204,6 +204,8 @@ for (var index in datafile) {
           templatePush = `AthenaDance:${test}`;
         } else if (test.includes("vtid")) {
           templatePush = `CosmeticVariantToken:${test}`;
+        } else if (test.includes("athenabattlestar")) {
+          templatePush = `FortPersistentResourceItem:AthenaBattleStar`;
         } else if (test.includes("mtxgiveaway")) {
           templatePush = `Currency:${test}`;
         } else if (test.includes("athenaseasonalxp")) {
@@ -232,7 +234,7 @@ for (var index in datafile) {
           templatePush = `AthenaBackpack:${test}`;
         } else if (e.ItemDefinition.AssetPathName.includes("BannerIcons")) {
           templatePush = `HomebaseBannerIcon:${test}`;
-        }else if (e.ItemDefinition.AssetPathName.includes("QuestSchedules")) {
+        } else if (e.ItemDefinition.AssetPathName.includes("QuestSchedules")) {
           templatePush = `ChallengeBundleSchedule:${test}`;
         }
 


### PR DESCRIPTION
Backend Updates
P1
Less Logging, logs are now optional to be shown (log levels shown in config)
    - these logs will still be shown in the logs file just no in terminal
    - the loglevel is also changeable on dashboard!!
Levels:
  Low: 0
  Medium: 1
  High: 2
  Medium~High: 3 (plain logs won't display but asp logs will)
Favorite Items
SpyGames
Disabled "TCP" xmpp not like it worked anyways

P2
- Added Presets
- Able to change banner
- Linux should be able to read "Config.json"
- Feeling a little festive (shops will generate christmas items from the 14th dec)
- 'season' is now a float... if you are hosting '12.41' don't put '12'
~ this feature is currently used with festive shops (christmas but this will slowly be pushed to everything <3)
- Shop Bundles can give you styles now (if added)
- Fixed Level and tiers on chapter 2 (only breaks with buying the battle bundle)
- Added season 19 bp (no quests though, and technically i only added the stuff till the 19.10 update)
- Improved certain files code
- Backend loads less stuff with force season (eg. bp)
- Fixed locker random backbling
- Fixed Temp bans not popping up insta (and 0 will actually remove the message live)

Launcher Updates
- Improved settings